### PR TITLE
feat(proposal): implement canCreateProposal queue handling and related logic

### DIFF
--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -567,6 +567,19 @@ const Web3Helper = {
 
     return token
   },
+  async isMember(pluginAddress: HexAddress, memberAddress: HexAddress, network: NetworksEnum) {
+    try {
+      const provider = ProviderModule.getAnyRpcProvider(network)
+      const pluginInstance = new Contract(pluginAddress, Multisig.abi, provider)
+      const isListed = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => pluginInstance.isListed(memberAddress)),
+      )
+      return Boolean(isListed)
+    } catch (error) {
+      logger.error('Error isMember', llo({ pluginAddress, memberAddress, network, error }))
+      return false
+    }
+  },
 }
 
 export default Web3Helper

--- a/src/services/aragon-api/controllers/proposal.ts
+++ b/src/services/aragon-api/controllers/proposal.ts
@@ -55,47 +55,20 @@ const ProposalController = {
 
   canCreateProposal: async (params: ICanCreateProposal) => {
     try {
-      const [member, plugin] = await Promise.all([
-        Models.Member.findByAddress(params.memberAddress),
-        Models.Plugin.findByAddress(params.pluginAddress, params.network),
-      ])
-
-      assertExposable(member && plugin, ErrorKeyEnum.notFound)
-
-      const [daoMappings, activeSettings] = await Promise.all([
-        Models.DaoMemberMapping.findMapping({
-          memberAddress: member.address,
-          daoAddress: plugin.daoAddress,
-          pluginAddress: plugin.address,
-          network: plugin.network,
-        }),
-        Models.Setting.findActive({
-          daoAddress: plugin.daoAddress,
-          pluginAddress: plugin.address,
-          network: plugin.network,
-        }),
-      ])
-
-      assertExposable(activeSettings, ErrorKeyEnum.notFound)
-
-      if (!plugin.tokenAddress) {
-        if (!activeSettings.onlyListed) {
-          return true
-        }
-
-        return !!daoMappings
-      }
-
-      if (plugin.tokenAddress) {
-        const userVotingPower = await Models.MemberBalance.findByAddressAndToken({
-          address: member.address,
-          tokenAddress: plugin.tokenAddress,
-          network: plugin.network,
-        })
-
-        return !!daoMappings && Number(userVotingPower.votingPower) > Number(activeSettings.minProposerVotingPower)
-      }
-    } catch (e) {
+      return await RabbitMQHelper.sendMessage(
+        EnumQueueName.canCreateProposal,
+        {
+          id: `canCreateProposal-${params.pluginAddress}-${params.memberAddress}-${params.network}`,
+          params: {
+            pluginAddress: params.pluginAddress,
+            memberAddress: params.memberAddress,
+            network: params.network,
+          },
+        },
+        { waitResponse: true, timeout: config.RABBITMQ.TIMEOUT },
+      )
+    } catch (error) {
+      logger.warn('Error while checking if user can create proposal', llo({ error, ...params }))
       return false
     }
   },

--- a/src/services/aragon-dao/index.ts
+++ b/src/services/aragon-dao/index.ts
@@ -4,6 +4,7 @@ import {
   EnumQueueName,
   type IProposalInfo,
   type IQueueAllMetrics,
+  type IQueueCanCreateProposal,
   type IQueueContractInfo,
   type IQueueDao,
   type IQueueMemberBalanceInfo,
@@ -89,6 +90,11 @@ const AragonDaoService: IService = {
     await RabbitMQHelper.process(EnumQueueName.proposalActions, async (job: any) => {
       const { id } = job.params as IProposalInfo
       return await ActionDecoder.proposalActionDecoder(id)
+    })
+
+    await RabbitMQHelper.process(EnumQueueName.canCreateProposal, async (job: any) => {
+      const { pluginAddress, memberAddress, network } = job.params as IQueueCanCreateProposal
+      return await MemberInfo.canCreateProposal(pluginAddress, memberAddress, network)
     })
 
     const tasks = [[{ fetchRates: TokenFetcher }]]

--- a/src/services/aragon-dao/memberInfo.ts
+++ b/src/services/aragon-dao/memberInfo.ts
@@ -1,8 +1,10 @@
 import Web3Helper from '@helpers/web3'
 import GovernanceErc20Helper from '@helpers/governanceErc20'
-import { IPluginInterfaceType, type NetworksEnum } from '@types'
+import { type HexAddress, IPluginInterfaceType, type NetworksEnum } from '@types'
 import { ProxyToken } from '@modules/proxyToken'
 import { Models } from '@dbModels'
+import type Plugin from '@models/schema/plugin'
+import type PluginSetting from '@models/schema/setting'
 
 export const MemberInfo = {
   getByTokenAddress: async (
@@ -52,5 +54,53 @@ export const MemberInfo = {
     } catch (e) {
       return response
     }
+  },
+
+  canCreateProposal: async (pluginAddress: HexAddress, memberAddress: HexAddress, network: NetworksEnum) => {
+    try {
+      const plugin = await Models.Plugin.findByAddress(pluginAddress, network)
+      if (!plugin) {
+        return false
+      }
+
+      const settings = await Models.Setting.findActive({
+        daoAddress: plugin.daoAddress,
+        pluginAddress: plugin.address,
+        network: plugin.network,
+      })
+
+      switch (plugin.interfaceType) {
+        case IPluginInterfaceType.tokenVoting:
+          return await MemberInfo._checkForTokenVoting(plugin, settings, memberAddress)
+        case IPluginInterfaceType.multisig:
+          return await MemberInfo._checkForMultiSig(plugin, settings, memberAddress)
+        case IPluginInterfaceType.admin:
+          return await MemberInfo._checkForAdmin(plugin, settings, memberAddress)
+        default:
+          return false
+      }
+    } catch (e) {
+      return false
+    }
+  },
+
+  _checkForTokenVoting: async (plugin: Plugin, setting: PluginSetting, memberAddress: HexAddress) => {
+    if (!setting || !plugin.tokenAddress) return false
+    const votingPower = await GovernanceErc20Helper.getVotes(memberAddress, plugin.tokenAddress, plugin.network)
+    return Number(votingPower) > 0 && Number(votingPower) >= Number(setting.minParticipation)
+  },
+  _checkForMultiSig: async (plugin: Plugin, setting: PluginSetting, memberAddress: HexAddress) => {
+    if (!setting) return false
+
+    return setting?.onlyListed ? await Web3Helper.isMember(plugin.address, memberAddress, plugin.network) : true
+  },
+  _checkForAdmin: async (plugin: Plugin, _setting: PluginSetting, memberAddress: HexAddress) => {
+    const daoMemberMapping = await Models.DaoMemberMapping.findOne({
+      daoAddress: plugin.daoAddress,
+      memberAddress,
+      network: plugin.network,
+    })
+
+    return !!daoMemberMapping
   },
 }

--- a/src/types/queue.ts
+++ b/src/types/queue.ts
@@ -15,6 +15,7 @@ export enum EnumQueueName {
   contractDecoder = 'contract.decoder',
   tokenInfo = 'token.info',
   proposalActions = 'proposal.actions',
+  canCreateProposal = 'can.create.proposal',
 }
 
 export interface IQueueAllMetrics {
@@ -41,6 +42,12 @@ export interface IQueueContractInfo {
 export interface IQueueVoteInfo {
   proposalId: string
   userAddress: string
+}
+
+export interface IQueueCanCreateProposal {
+  memberAddress: HexAddress
+  pluginAddress: HexAddress
+  network: NetworksEnum
 }
 
 export interface IQueueMemberBalanceInfo {

--- a/test/unit/helpers/web3.spec.ts
+++ b/test/unit/helpers/web3.spec.ts
@@ -1303,4 +1303,92 @@ describe('Helpers:Web3', () => {
       expect(stubLockToken.calledOnce).to.be.true
     })
   })
+
+  describe('isMember', () => {
+    it('should return true when address is a member of the plugin', async () => {
+      const stubConfigState = {
+        getConfigItem: sandbox.stub().returns({}),
+      }
+      const stubIsMember = sandbox.stub().resolves(true)
+
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return { isListed: stubIsMember }
+          },
+        },
+        '@state/configState': {
+          ConfigState: { getInstance: () => stubConfigState },
+        },
+      })
+
+      const pluginAddress = '0xPluginAddress'
+      const memberAddress = '0xMemberAddress'
+      const network = NetworksEnum.ethereumMainnet
+
+      const result = await MockedWeb3Helper.isMember(pluginAddress, memberAddress, network)
+
+      expect(result).to.be.true
+      expect(stubIsMember.calledOnce).to.be.true
+      expect(stubIsMember.calledWith(memberAddress)).to.be.true
+    })
+
+    it('should return false when address is not a member of the plugin', async () => {
+      const stubConfigState = {
+        getConfigItem: sandbox.stub().returns({}),
+      }
+      const stubIsMember = sandbox.stub().resolves(false)
+
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return { isListed: stubIsMember }
+          },
+        },
+        '@state/configState': {
+          ConfigState: { getInstance: () => stubConfigState },
+        },
+      })
+
+      const pluginAddress = '0xPluginAddress'
+      const memberAddress = '0xMemberAddress'
+      const network = NetworksEnum.ethereumMainnet
+
+      const result = await MockedWeb3Helper.isMember(pluginAddress, memberAddress, network)
+
+      expect(result).to.be.false
+      expect(stubIsMember.calledOnce).to.be.true
+      expect(stubIsMember.calledWith(memberAddress)).to.be.true
+    })
+
+    it('should return false when an error occurs', async () => {
+      const stubConfigState = {
+        getConfigItem: sandbox.stub().returns({}),
+      }
+      const stubIsMember = sandbox.stub().rejects(new Error('Contract call failed'))
+      const stubLogger = sandbox.stub(logger, 'error')
+
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return { isListed: stubIsMember }
+          },
+        },
+        '@state/configState': {
+          ConfigState: { getInstance: () => stubConfigState },
+        },
+      })
+
+      const pluginAddress = '0xPluginAddress'
+      const memberAddress = '0xMemberAddress'
+      const network = NetworksEnum.ethereumMainnet
+
+      const result = await MockedWeb3Helper.isMember(pluginAddress, memberAddress, network)
+
+      expect(result).to.be.false
+      expect(stubIsMember.calledOnce).to.be.true
+      expect(stubLogger.calledOnce).to.be.true
+      expect(stubLogger.calledWith('Error isMember' as any)).to.be.true
+    })
+  })
 })

--- a/test/unit/services/aragon-api/controllers/proposal.spec.ts
+++ b/test/unit/services/aragon-api/controllers/proposal.spec.ts
@@ -308,199 +308,43 @@ describe('Controller: Proposal', () => {
   })
 
   describe('canCreateProposal', () => {
-    it('should return true as member can create proposal when the plugin has token address associated', async () => {
+    it('should call rabbitMq to check if the user can create proposal', async () => {
       const params = {
+        pluginAddress: '0xPluginAddress',
         memberAddress: rawMember.address,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
+        network: rawProposal.network!,
       }
 
-      const findMappingSpy = sandbox.spy(Models.DaoMemberMapping, 'findMapping')
-      const findActiveSettingSpy = sandbox.spy(Models.Setting, 'findActive')
-      const findByAddressAndTokenSpy = sandbox.spy(Models.MemberBalance, 'findByAddressAndToken')
+      const rabbitmQStub = sandbox.stub(RabbitMQHelper, 'sendMessage').resolves(true as any)
 
-      const response = await ProposalController.canCreateProposal(params as any)
+      const response = await ProposalController.canCreateProposal(params)
+
       expect(response).to.be.true
-      expect(findMappingSpy.calledOnce).to.be.true
-      expect(findActiveSettingSpy.calledOnce).to.be.true
-      expect(findByAddressAndTokenSpy.calledOnce).to.be.true
-
-      expect(
-        findMappingSpy.calledWith({
-          memberAddress: rawMember.address,
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-
-      expect(
-        findActiveSettingSpy.calledWith({
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-
-      expect(
-        findByAddressAndTokenSpy.calledWith({
-          address: rawMember.address,
-          tokenAddress: rawToken.address,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
+      expect(rabbitmQStub.calledOnce).to.be.true
+      expect(rabbitmQStub.args[0][1]).to.deep.eq({
+        id: `canCreateProposal-${params.pluginAddress}-${params.memberAddress}-${params.network}`,
+        params: {
+          pluginAddress: params.pluginAddress,
+          memberAddress: params.memberAddress,
+          network: params.network,
+        },
+      })
     })
 
-    it('should return true as member can create proposal when plugin is multisig and onlyListed is false', async () => {
-      const plugin = await Models.Plugin.findByAddress(rawProposal.pluginAddress, rawProposal.network)
-      plugin.tokenAddress = null
-      await plugin.save()
-
+    it('should return false when there is an error', async () => {
       const params = {
+        pluginAddress: '0xPluginAddress',
         memberAddress: rawMember.address,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
+        network: rawProposal.network!,
       }
 
-      const findMappingSpy = sandbox.spy(Models.DaoMemberMapping, 'findMapping')
-      const findActiveSettingSpy = sandbox.spy(Models.Setting, 'findActive')
-      const findByAddressAndTokenSpy = sandbox.spy(Models.MemberBalance, 'findByAddressAndToken')
+      sandbox.stub(RabbitMQHelper, 'sendMessage').rejects(new Error('test'))
+      const loggerStub = sandbox.stub(Logger, 'warn')
 
-      const response = await ProposalController.canCreateProposal(params as any)
-      expect(response).to.be.true
-      expect(findMappingSpy.calledOnce).to.be.true
-      expect(findActiveSettingSpy.calledOnce).to.be.true
-      expect(findByAddressAndTokenSpy.calledOnce).to.be.false
-
-      expect(
-        findMappingSpy.calledWith({
-          memberAddress: rawMember.address,
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-
-      expect(
-        findActiveSettingSpy.calledWith({
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-    })
-
-    it('should return true as member can create proposal when plugin is multisig and onlyListed is true', async () => {
-      const plugin = await Models.Plugin.findByAddress(rawProposal.pluginAddress, rawProposal.network)
-      plugin.tokenAddress = null
-      await plugin.save()
-
-      const settings = await Models.Setting.findActive({
-        daoAddress: rawProposal.daoAddress,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
-      } as any)
-      settings.onlyListed = true
-      await settings.save()
-
-      const params = {
-        memberAddress: rawMember.address,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
-      }
-
-      const findMappingSpy = sandbox.spy(Models.DaoMemberMapping, 'findMapping')
-      const findActiveSettingSpy = sandbox.spy(Models.Setting, 'findActive')
-      const findByAddressAndTokenSpy = sandbox.spy(Models.MemberBalance, 'findByAddressAndToken')
-
-      const response = await ProposalController.canCreateProposal(params as any)
-      expect(response).to.be.true
-      expect(findMappingSpy.calledOnce).to.be.true
-      expect(findActiveSettingSpy.calledOnce).to.be.true
-      expect(findByAddressAndTokenSpy.calledOnce).to.be.false
-
-      expect(
-        findMappingSpy.calledWith({
-          memberAddress: rawMember.address,
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-
-      expect(
-        findActiveSettingSpy.calledWith({
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
-    })
-
-    it('should return false if member is not found', async () => {
-      const params = {
-        memberAddress: '0xmember',
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
-      }
-
-      const findMappingSpy = sandbox.spy(Models.Member, 'findByAddress')
-
-      const response = await ProposalController.canCreateProposal(params as any)
+      const response = await ProposalController.canCreateProposal(params)
 
       expect(response).to.be.false
-
-      expect(findMappingSpy.calledOnce).to.be.true
-
-      expect(findMappingSpy.calledWith('0xmember')).to.be.true
-    })
-
-    it('should return false if plugin is not found', async () => {
-      const params = {
-        memberAddress: rawMember.address,
-        pluginAddress: '0xplugin',
-        network: rawProposal.network,
-      }
-
-      const findMappingSpy = sandbox.spy(Models.Plugin, 'findByAddress')
-
-      const response = await ProposalController.canCreateProposal(params as any)
-
-      expect(response).to.be.false
-
-      expect(findMappingSpy.calledOnce).to.be.true
-
-      expect(findMappingSpy.calledWith('0xplugin', rawProposal.network)).to.be.true
-    })
-
-    it('should return false if active settings are not found', async () => {
-      const params = {
-        memberAddress: rawMember.address,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
-      }
-
-      const settings = await Models.Setting.findActive({
-        daoAddress: rawProposal.daoAddress,
-        pluginAddress: rawProposal.pluginAddress,
-        network: rawProposal.network,
-      } as any)
-      settings.pluginAddress = '0x00'
-      await settings.save()
-
-      const findActiveSettingSpy = sandbox.spy(Models.Setting, 'findActive')
-
-      const response = await ProposalController.canCreateProposal(params as any)
-
-      expect(response).to.be.false
-
-      expect(
-        findActiveSettingSpy.calledWith({
-          daoAddress: rawProposal.daoAddress,
-          pluginAddress: rawProposal.pluginAddress,
-          network: rawProposal.network,
-        }),
-      ).to.be.true
+      expect(loggerStub.calledOnceWith('Error while checking if user can create proposal' as any)).to.be.true
     })
   })
 

--- a/test/unit/services/aragon-dao/index.spec.ts
+++ b/test/unit/services/aragon-dao/index.spec.ts
@@ -14,6 +14,8 @@ import { MemberInfo } from '@services/aragon-dao/memberInfo'
 import { VoteInfo } from '@services/aragon-dao/voteInfo'
 import ActionDecoder from '@services/aragon-dao/actionDecoder'
 import { AllMetrics } from '@services/aragon-dao/allMetrics'
+import { TaskSchedulerState } from '@state/taskSchedulerState'
+import config from '@config'
 
 describe('AragonDao: index', () => {
   let sandbox: SinonSandbox
@@ -33,7 +35,7 @@ describe('AragonDao: index', () => {
 
       await AragonDaoService.start()
 
-      expect(processStub.callCount).to.equal(11) // Total queues in the service
+      expect(processStub.callCount).to.equal(12) // Total queues in the service
       expect(processStub.calledWith(EnumQueueName.allMetrics)).to.be.true
       expect(processStub.calledWith(EnumQueueName.daoTransactions)).to.be.true
       expect(processStub.calledWith(EnumQueueName.daoAssets)).to.be.true
@@ -45,6 +47,7 @@ describe('AragonDao: index', () => {
       expect(processStub.calledWith(EnumQueueName.memberBalance)).to.be.true
       expect(processStub.calledWith(EnumQueueName.contractDecoder)).to.be.true
       expect(processStub.calledWith(EnumQueueName.proposalActions)).to.be.true
+      expect(processStub.calledWith(EnumQueueName.canCreateProposal)).to.be.true
 
       expect(loggerStub.calledOnceWith('AragonDaoService service started' as any)).to.be.true
     })
@@ -283,6 +286,73 @@ describe('AragonDao: index', () => {
         value: 1,
         network: NetworksEnum.ethereumMainnet,
       })
+    })
+
+    it('should handle canCreateProposal queue', async () => {
+      const processStub = sandbox.stub(RabbitMQHelper, 'process')
+      const memberInfoStub = sandbox.stub(MemberInfo, 'canCreateProposal').resolves()
+
+      await AragonDaoService.start()
+
+      const callIndex = processStub.args.findIndex(call => call[0] === EnumQueueName.canCreateProposal)
+      const handler = processStub.getCall(callIndex).args[1]
+      const queueName = processStub.getCall(callIndex).args[0]
+
+      await handler({
+        params: {
+          pluginAddress: '0xPluginAddress',
+          memberAddress: '0xUserAddress',
+          network: NetworksEnum.ethereumMainnet,
+        },
+      } as any)
+
+      expect(queueName).to.eq(EnumQueueName.canCreateProposal)
+      expect(memberInfoStub.calledOnceWith('0xPluginAddress', '0xUserAddress', NetworksEnum.ethereumMainnet)).to.be.true
+    })
+  })
+
+  describe('Task Scheduler', () => {
+    it('should initialize the token fetcher task scheduler', async () => {
+      sandbox.stub(RabbitMQHelper, 'process').resolves()
+
+      const mockScheduler = {
+        startTask: sandbox.stub().resolves(),
+      }
+
+      const getInstanceStub = sandbox.stub(TaskSchedulerState, 'getInstance').returns(mockScheduler as any)
+
+      sandbox.stub(config, 'SERVICES').value({
+        ARAGON_DAO: {
+          TOKEN_FETCH_INTERVAL: 60000,
+        },
+      })
+
+      sandbox.stub(logger, 'info')
+      const loggerErrorStub = sandbox.stub(logger, 'error')
+
+      await AragonDaoService.start()
+
+      expect(getInstanceStub.calledOnce).to.be.true
+
+      expect(mockScheduler.startTask.calledOnce).to.be.true
+      expect(mockScheduler.startTask.args[0][0]).to.equal('token-re-fetch')
+
+      const taskOptions = mockScheduler.startTask.args[0][1]
+
+      expect(taskOptions).to.have.property('fn')
+      expect(taskOptions).to.have.property('interval', 60000)
+      expect(taskOptions).to.have.property('checkInterval', 30000)
+      expect(taskOptions).to.have.property('runNow', true)
+      expect(taskOptions).to.have.property('stopOnError', false)
+      expect(taskOptions).to.have.property('onError')
+
+      const fnResult = taskOptions.fn()
+      expect(fnResult).to.be.an('array')
+      expect(fnResult[0][0]).to.have.property('fetchRates')
+
+      taskOptions.onError(new Error('Test error'))
+      expect(loggerErrorStub.calledOnce).to.be.true
+      expect(loggerErrorStub.args[0][0]).to.equal('Token Fetcher task error')
     })
   })
 })

--- a/test/unit/services/aragon-dao/memberInfo.spec.ts
+++ b/test/unit/services/aragon-dao/memberInfo.spec.ts
@@ -224,4 +224,315 @@ describe('AragonDao: memberInfo', () => {
       })
     })
   })
+
+  describe('canCreateProposal', () => {
+    it('should return false when plugin is not found', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves(null)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false when settings are not found', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves(null)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false for unsupported plugin interface type', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: 'unsupported',
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({} as any)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false for tokenVoting when tokenAddress is missing', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: null,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({} as any)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false for tokenVoting when voting power is 0', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: '0xTokenAddress',
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        minParticipation: 100,
+      } as any)
+
+      const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(0n)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(getVotesStub.calledOnce).to.be.true
+      expect(getVotesStub.calledWith('0xMemberAddress', '0xTokenAddress', NetworksEnum.ethereumSepolia)).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false for tokenVoting when voting power is less than minimum participation', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: '0xTokenAddress',
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        minParticipation: 100,
+      } as any)
+
+      const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(50n)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(getVotesStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return true for tokenVoting when voting power is greater than minimum participation', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: '0xTokenAddress',
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        minParticipation: 100,
+      } as any)
+
+      const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(150n)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(getVotesStub.calledOnce).to.be.true
+      expect(result).to.be.true
+    })
+
+    it('should return true for multisig when onlyListed is false', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.multisig,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        onlyListed: false,
+      } as any)
+
+      const isMemberStub = sandbox.stub(Web3Helper, 'isMember').resolves(false)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(isMemberStub.called).to.be.false
+      expect(result).to.be.true
+    })
+
+    it('should return false for multisig when onlyListed is true and member is not listed', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.multisig,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        onlyListed: true,
+      } as any)
+
+      const isMemberStub = sandbox.stub(Web3Helper, 'isMember').resolves(false)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(isMemberStub.calledOnce).to.be.true
+      expect(isMemberStub.calledWith('0xPluginAddress', '0xMemberAddress', NetworksEnum.ethereumSepolia)).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return true for multisig when onlyListed is true and member is listed', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.multisig,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        onlyListed: true,
+      } as any)
+
+      const isMemberStub = sandbox.stub(Web3Helper, 'isMember').resolves(true)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(isMemberStub.calledOnce).to.be.true
+      expect(result).to.be.true
+    })
+
+    it('should return true for admin when daoMemberMapping exists', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.admin,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({} as any)
+
+      const daoMemberMappingStub = sandbox.stub(Models.DaoMemberMapping, 'findOne').resolves({
+        daoAddress: '0xDaoAddress',
+        memberAddress: '0xMemberAddress',
+        network: NetworksEnum.ethereumSepolia,
+      } as any)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(daoMemberMappingStub.calledOnce).to.be.true
+      expect(
+        daoMemberMappingStub.calledWith({
+          daoAddress: '0xDaoAddress',
+          memberAddress: '0xMemberAddress',
+          network: NetworksEnum.ethereumSepolia,
+        }),
+      ).to.be.true
+      expect(result).to.be.true
+    })
+
+    it('should return false for admin when daoMemberMapping does not exist', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.admin,
+      } as any)
+
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({} as any)
+
+      const daoMemberMappingStub = sandbox.stub(Models.DaoMemberMapping, 'findOne').resolves(null)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(daoMemberMappingStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+
+    it('should return false on error', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').rejects(new Error('Test error'))
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(result).to.be.false
+    })
+  })
 })


### PR DESCRIPTION
## Description

This pull request introduces significant changes to the proposal creation process, decentralizing the logic and integrating RabbitMQ for asynchronous handling. It also adds new utility methods, refactors existing code, and enhances test coverage. Below are the most important changes grouped by theme:

### Proposal Creation Refactor:
* Replaced the in-line logic for determining if a member can create a proposal with a RabbitMQ-based message queue (`EnumQueueName.canCreateProposal`). This offloads the logic to a separate handler, improving scalability and modularity. (`[[1]](diffhunk://#diff-8b62e32b28b0669c1a1b366c8fa6b4864df0b805f12f96fadc9f5e04090e2cb2L58-R71)`, `[[2]](diffhunk://#diff-8ba85ea8da742031a301e2721135c6ff8ab249378576f309e18978c1647c0ed0R95-R99)`, `[[3]](diffhunk://#diff-3d4cbf63149b6ed9f9c26e5d4eefd7e11172eaf0a5ca295ee4a635d9f080a228R18)`)

### Utility Enhancements:
* Added a new `isMember` method in `Web3Helper` to check if an address is part of a multisig plugin. This method uses a retry mechanism and logs errors when they occur. (`[src/helpers/web3.tsR570-R582](diffhunk://#diff-83a7589fd13fa9bb0e290322f4e0e933625f60c8ad1169c5341b58aa2b6d36e1R570-R582)`)
* Introduced the `canCreateProposal` method in `MemberInfo` to encapsulate the logic for checking proposal creation eligibility based on plugin type (e.g., token voting, multisig, admin). (`[src/services/aragon-dao/memberInfo.tsR58-R105](diffhunk://#diff-b31cef48c8ef81a1c81309e0d98ba3646634d27a70179597a4650f18fd851988R58-R105)`)

### Type and Interface Updates:
* Added a new `IQueueCanCreateProposal` interface to define the structure of the RabbitMQ message payload for the `canCreateProposal` queue. (`[src/types/queue.tsR47-R52](diffhunk://#diff-3d4cbf63149b6ed9f9c26e5d4eefd7e11172eaf0a5ca295ee4a635d9f080a228R47-R52)`)
* Updated imports and interfaces across relevant files to support the new functionality. (`[[1]](diffhunk://#diff-8ba85ea8da742031a301e2721135c6ff8ab249378576f309e18978c1647c0ed0R7)`, `[[2]](diffhunk://#diff-b31cef48c8ef81a1c81309e0d98ba3646634d27a70179597a4650f18fd851988R58-R105)`)

### Test Suite Enhancements:
* Added unit tests for the new `isMember` method in `Web3Helper`, covering success, failure, and error scenarios. (`[test/unit/helpers/web3.spec.tsR1306-R1393](diffhunk://#diff-0b5c82d34b22e5a68396d1678b281ab0e8cd36306019b52beef667d01c4a2b16R1306-R1393)`)
* Refactored and extended tests for `ProposalController` to validate RabbitMQ integration and ensure proper error handling. (`[test/unit/services/aragon-api/controllers/proposal.spec.tsL311-R347](diffhunk://#diff-a401eec0d1164ff7ddaca8372ffeb2a0698cb75107333001a761dd27ca2a6756L311-R347)`)
* Added tests for the `AragonDaoService` to verify the processing of the `canCreateProposal` queue and the initialization of the token fetcher task scheduler. (`[[1]](diffhunk://#diff-24c10a6eba6118960c4c4ac134aceec76b865860dc9de42ee745d6b022cf8729L36-R38)`, `[[2]](diffhunk://#diff-24c10a6eba6118960c4c4ac134aceec76b865860dc9de42ee745d6b022cf8729R290-R356)`)

### General Improvements:
* Incremented the total queue count in `AragonDaoService` to reflect the addition of the `canCreateProposal` queue. (`[test/unit/services/aragon-dao/index.spec.tsL36-R38](diffhunk://#diff-24c10a6eba6118960c4c4ac134aceec76b865860dc9de42ee745d6b022cf8729L36-R38)`)

Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
