### PR TITLE
feat(plugin): enhance installation data, improved error handling, serialization manually

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -337,13 +337,9 @@ const Utils = {
       return result
     }
 
-    // Handle circular references
     if (visited.has(result)) {
       return visited.get(result)
     }
-
-    // Mark this object as visited with a temporary placeholder
-    // that will be replaced with the final result
     const placeholder = Array.isArray(result) ? [] : {}
     visited.set(result, placeholder)
 
@@ -381,12 +377,10 @@ const Utils = {
       }
     }
 
-    // Check if the object appears to be array-like
     const numericKeys = Object.keys(result).filter(key => !isNaN(parseInt(key, 10)))
     if (Object.keys(plainObject).length === 0 && numericKeys.length > 0 && 'length' in result) {
       const arr: any[] = []
 
-      // Sort the numeric keys to ensure correct order
       numericKeys
         .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
         .forEach(key => {

--- a/src/services/aragon-dao/plugin.ts
+++ b/src/services/aragon-dao/plugin.ts
@@ -39,7 +39,18 @@ const Plugin = {
       return null
     }
 
-    return Utils.JSONStringifyCircular(Utils.deepConvertToObject(pluginLog.parsed!.args))
+    try {
+      const rawPluginData = pluginLog.parsed!.args.toObject()
+      rawPluginData.versionTag = rawPluginData.versionTag.toArray()
+      rawPluginData.preparedSetupData = rawPluginData.preparedSetupData.toObject()
+      rawPluginData.preparedSetupData.helpers = rawPluginData.preparedSetupData.helpers.toArray()
+      rawPluginData.preparedSetupData.permissions = rawPluginData.preparedSetupData.permissions.toArray()
+
+      const serialize = Utils.JSONStringifyCircular(rawPluginData)
+      return JSON.parse(serialize)
+    } catch (_error: any) {
+      return null
+    }
   },
 }
 

--- a/test/unit/services/aragon-dao/plugin.spec.ts
+++ b/test/unit/services/aragon-dao/plugin.spec.ts
@@ -111,33 +111,95 @@ describe('Plugin', () => {
       }
 
       const txReceipt = { logs: [] }
-      const logArgs = {
+
+      // Create mock args with toObject and toArray methods
+      const mockVersionTag = {
+        toArray: () => [1, 2],
+      }
+
+      const mockHelpers = {
+        toArray: () => ['0xhelper1', '0xhelper2'],
+      }
+
+      const mockPermissions = {
+        toArray: () => ['permission1', 'permission2'],
+      }
+
+      const mockPreparedSetupData = {
+        toObject: () => ({
+          helpers: mockHelpers,
+          permissions: mockPermissions,
+        }),
+        helpers: mockHelpers,
+        permissions: mockPermissions,
+      }
+
+      const mockArgs = {
         plugin: pluginAddress,
         dao: '0xdaoAddress',
         preparedSetupId: '0xsetupId',
-        versionTag: { release: 1, build: 2 },
+        versionTag: mockVersionTag,
+        preparedSetupData: mockPreparedSetupData,
+        toObject: () => ({
+          plugin: pluginAddress,
+          dao: '0xdaoAddress',
+          preparedSetupId: '0xsetupId',
+          versionTag: mockVersionTag,
+          preparedSetupData: mockPreparedSetupData,
+        }),
       }
 
       const parsedLog = {
         parsed: {
-          args: logArgs,
+          args: mockArgs,
         },
       }
 
-      const expectedJson = '{"plugin":"0x1234567890123456789012345678901234567890"}'
+      const expectedResult = '{"plugin":"0x1234567890123456789012345678901234567890"}'
 
       sandbox.stub(Models.Plugin, 'findByAddress').resolves({})
       sandbox.stub(Models.LogPluginSetupProcessor, 'findOne').resolves(installationLog)
       sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves(txReceipt as any)
       sandbox.stub(Web3Utils, 'findLogsByName').returns([parsedLog as any])
-      sandbox.stub(Utils, 'JSONStringifyCircular').returns(expectedJson)
-      sandbox.stub(Utils, 'deepConvertToObject').returns(logArgs)
+      sandbox.stub(Utils, 'JSONStringifyCircular').returns(expectedResult)
 
       const result = await Plugin.getInstallationData(pluginAddress, network)
 
-      expect(result).to.equal(expectedJson)
-      expect(Utils.deepConvertToObject.calledWith(logArgs)).to.be.true
+      expect(result).to.deep.equal(JSON.parse(expectedResult))
       expect(Utils.JSONStringifyCircular.calledOnce).to.be.true
+    })
+
+    it('should return null when there is an error processing the plugin data', async () => {
+      const installationLog = {
+        transactionHash,
+        network,
+        event: IEventLogPluginType.InstallationPrepared,
+      }
+
+      const txReceipt = { logs: [] }
+
+      // Create mock args that will throw an error
+      const mockArgs = {
+        plugin: pluginAddress,
+        toObject: () => {
+          throw new Error('Conversion error')
+        },
+      }
+
+      const parsedLog = {
+        parsed: {
+          args: mockArgs,
+        },
+      }
+
+      sandbox.stub(Models.Plugin, 'findByAddress').resolves({})
+      sandbox.stub(Models.LogPluginSetupProcessor, 'findOne').resolves(installationLog)
+      sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves(txReceipt as any)
+      sandbox.stub(Web3Utils, 'findLogsByName').returns([parsedLog as any])
+
+      const result = await Plugin.getInstallationData(pluginAddress, network)
+
+      expect(result).to.be.null
     })
   })
 })


### PR DESCRIPTION
## Description

This pull request refactors the handling of plugin data in the `Plugin` service and updates the corresponding unit tests. It introduces a more robust approach to serializing and deserializing plugin data while improving error handling. Additionally, some redundant comments in utility functions were removed for cleaner code.

### Refactoring of plugin data handling:
* Updated `src/services/aragon-dao/plugin.ts` to transform `pluginLog.parsed!.args` into a structured object with `toObject` and `toArray` methods before serializing it. Added a `try-catch` block to handle potential errors during processing.

### Improvements to unit tests:
* Enhanced `test/unit/services/aragon-dao/plugin.spec.ts` by adding mock objects (`toObject` and `toArray` methods) to simulate plugin data transformations. Updated existing tests to validate the new logic and added a new test case to verify error handling when plugin data processing fails.

### Code cleanup in utilities:
* Removed redundant comments in `src/helpers/utils.ts` related to circular reference handling and array-like object processing to improve readability. [[1]](diffhunk://#diff-94e01b9bcaf37dddbea5defec6f62b685b2f2362d74b42d01d29fab89a70432bL340-L346) [[2]](diffhunk://#diff-94e01b9bcaf37dddbea5defec6f62b685b2f2362d74b42d01d29fab89a70432bL384-L389)

Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
