### PR TITLE
fix: revert replace ens

### DIFF
--- a/src/services/aragon-api/controllers/dao.ts
+++ b/src/services/aragon-api/controllers/dao.ts
@@ -34,7 +34,7 @@ const DaoController = {
   },
 
   getDaoByEns: async (ens: string, network: NetworksEnum): Promise<IDaoResponse> => {
-    const dao = await Models.Dao.findOne({ subdomain: ens, network, isHidden: { $ne: true }, isActive: { $eq: true } })
+    const dao = await Models.Dao.findOne({ ens, network, isHidden: { $ne: true }, isActive: { $eq: true } })
     assertExposable(dao, ErrorKeyEnum.notFound)
     return await Models.Dao.getDaoDetails(dao.address, dao.network)
   },

--- a/src/services/aragon-api/routers/schema/dao.ts
+++ b/src/services/aragon-api/routers/schema/dao.ts
@@ -50,7 +50,7 @@ const DaoSchema = {
     network: Joi.string()
       .valid(...Object.values(NetworksEnum))
       .required(),
-    ens: Joi.string().required(),
+    ens: ValidationSchema.joiEns.required(),
   }),
 }
 

--- a/test/unit/services/aragon-api/controllers/dao.spec.ts
+++ b/test/unit/services/aragon-api/controllers/dao.spec.ts
@@ -209,14 +209,14 @@ describe('Controller: Dao', () => {
       // Create a DAO with ENS
       const daoWithEns = {
         ...DaoList[1],
-        subdomain: 'test-dao',
+        ens: 'test-dao.eth',
       }
       const daoDB = await Models.Dao.create(daoWithEns)
 
       // Add stub for getDaoDetails to verify it's called with correct parameters
       const getDaoDetailsStub = sandbox.stub(Models.Dao, 'getDaoDetails').resolves({ id: daoDB.id } as any)
 
-      const dao = await DaoController.getDaoByEns(daoDB.subdomain, daoDB.network)
+      const dao = await DaoController.getDaoByEns(daoDB.ens, daoDB.network)
 
       expect(dao.id).to.eq(daoDB.id)
       expect(getDaoDetailsStub.calledOnce).to.be.true

--- a/test/unit/services/aragon-api/routers/dao.spec.ts
+++ b/test/unit/services/aragon-api/routers/dao.spec.ts
@@ -230,7 +230,7 @@ describe('Router: Dao', () => {
   it('should throw an error for invalid ENS format', async () => {
     const params = {
       network: NetworksEnum.ethereumMainnet,
-      ens: '', // Missing .eth suffix
+      ens: 'invalid-ens', // Missing .eth suffix
     }
 
     const stubCtrl = sandbox.stub(DaoController, 'getDaoByEns').returns(true as any)


### PR DESCRIPTION
This pull request updates the DAO service to replace the use of the `subdomain` field with the `ens` field for DAO identification. The changes include updates to the controller, schema validation, and associated unit tests to reflect this shift.

### Changes to DAO service:

* **Controller update**:
  - Updated `getDaoByEns` in `src/services/aragon-api/controllers/dao.ts` to query DAOs using the `ens` field instead of `subdomain`.

* **Schema validation**:
  - Replaced the plain string validation for the `ens` field with `ValidationSchema.joiEns` to enforce stricter ENS format checks.

### Test updates:

* **Controller tests**:
  - Modified test data and assertions in `dao.spec.ts` to use the `ens` field instead of `subdomain`.

* **Router tests**:
  - Updated `dao.spec.ts` to test invalid ENS formats with the new validation logic.## Description

Please include a summary of the change and be sure you follow the contributions rules we do provide [here](./CONTRIBUTIONS.md)

Task: [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the test network.
