### PR TITLE
feat(routescan): add RouteScan API integration and CornProvider module

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -60,6 +60,14 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
       BASE_URI: utils.configParser(sourceConfig, 'string', 'ETHERSCAN_API_BASE_URL', 'https://api.etherscan.io/v2/api'),
       API_KEY: utils.configParser(sourceConfig, 'string', 'ETHERSCAN_API_KEY', null),
     },
+    ROUTESCAN_API: {
+      BASE_URI: utils.configParser(
+        sourceConfig,
+        'string',
+        'ROUTESCAN_API_BASE_URL',
+        'https://api.routescan.io/v2/network/mainnet/evm',
+      ),
+    },
 
     ALCHEMY_PRICE_API: {
       URI: utils.configParser(sourceConfig, 'string', 'ALCHEMY_PRICE_API_URI', 'https://api.g.alchemy.com/prices/v1'),

--- a/src/helpers/routeScanHelper.ts
+++ b/src/helpers/routeScanHelper.ts
@@ -1,0 +1,64 @@
+import logger from '@logger'
+import axios from 'axios'
+import config from '@config'
+import { type IEtherScanSource, type NetworksEnum } from '@types'
+import { retryRequest } from '@helpers/retryRequest'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+
+const llo = logger.logMeta.bind(null, { service: 'helpers:RouteScanHelper' })
+
+const RouteScanHelper = {
+  axiosInstance: (chainId: number) =>
+    axios.create({
+      baseURL: `${config.ROUTESCAN_API.BASE_URI}/${chainId}/etherscan/api`,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+
+  _rpCall: async (params: object, network: NetworksEnum) => {
+    try {
+      const chainId = ProviderModule.getChainId(network)
+
+      const response = await retryRequest(async () =>
+        BottleneckModule.getEtherScanLimiter(network).schedule(async () =>
+          RouteScanHelper.axiosInstance(chainId).get('', { params }),
+        ),
+      )
+      return response?.data
+    } catch (error) {
+      logger.error('Error in RouteScan API call', llo({ error }))
+      throw error
+    }
+  },
+
+  fetchContractSourceCode: async ({ address, network }): Promise<IEtherScanSource[] | null> => {
+    const params = {
+      module: 'contract',
+      action: 'getsourcecode',
+      address,
+    }
+
+    try {
+      const result = await RouteScanHelper._rpCall(params, network)
+      if (
+        result.status === '1' &&
+        result.message === 'OK' &&
+        result.result.length > 0 &&
+        result.result[0].SourceCode !== ''
+      ) {
+        return [
+          {
+            SourceCode: result.result[0].SourceCode,
+            ContractName: result.result[0].ContractName,
+            ABI: result.result[0].ABI,
+          },
+        ]
+      }
+    } catch (error) {
+      logger.error('Error fetchContractSourceCode from RouteScan', llo({ params, network, error }))
+    }
+    return null
+  },
+}
+
+export default RouteScanHelper

--- a/src/modules/proxyProvider/cornProvider.ts
+++ b/src/modules/proxyProvider/cornProvider.ts
@@ -1,0 +1,26 @@
+import { type IWeb3Provider } from '@types'
+import BlockScoutProvider from '@modules/proxyProvider/blockscoutProvider'
+import RouteScanHelper from '@helpers/routeScanHelper'
+
+const CornProvider: Pick<
+  IWeb3Provider,
+  'fetchAddressTxns' | 'getTokenBalances' | 'fetchBasicTokenInfo' | 'fetchContractSourceCode'
+> = {
+  getTokenBalances: async ({ address, network }) => {
+    return BlockScoutProvider.getTokenBalances({ address, network })
+  },
+
+  fetchAddressTxns: async ({ address, network }) => {
+    return BlockScoutProvider.fetchAddressTxns({ address, network })
+  },
+
+  fetchBasicTokenInfo: async ({ address, network }) => {
+    return BlockScoutProvider.fetchBasicTokenInfo({ address, network })
+  },
+
+  fetchContractSourceCode: async ({ address, network }) => {
+    return RouteScanHelper.fetchContractSourceCode({ address, network })
+  },
+}
+
+export default CornProvider

--- a/src/modules/proxyProvider/index.ts
+++ b/src/modules/proxyProvider/index.ts
@@ -2,7 +2,7 @@ import { type IWeb3Provider, IWeb3ProxyMethod, NetworksEnum } from '@types'
 import Web3Provider from '@modules/proxyProvider/web3Provider'
 import PeaqProvider from '@modules/proxyProvider/peaqProvider'
 import ChilizProvider from '@modules/proxyProvider/chilizProvider'
-import BlockScoutProvider from '@modules/proxyProvider/blockscoutProvider'
+import CornProvider from '@modules/proxyProvider/cornProvider'
 
 const ProxyWeb3Provider: IWeb3Provider & { forward: any; getProvider: any; getDefaultProvider: any } = {
   getProvider(network: NetworksEnum) {
@@ -12,7 +12,7 @@ const ProxyWeb3Provider: IWeb3Provider & { forward: any; getProvider: any; getDe
       case NetworksEnum.chilizMainnet:
         return ChilizProvider
       case NetworksEnum.cornMainnet:
-        return BlockScoutProvider
+        return CornProvider
       default:
         return Web3Provider
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,6 +44,9 @@ export interface IConfig {
     BASE_URI: string
     API_KEY: string
   }
+  ROUTESCAN_API: {
+    BASE_URI: string
+  }
   ALCHEMY_PRICE_API: {
     URI: string
     API_KEY: string

--- a/test/unit/helpers/routeScan.spec.ts
+++ b/test/unit/helpers/routeScan.spec.ts
@@ -1,0 +1,162 @@
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+import { expect } from 'chai'
+import RouteScanHelper from '@helpers/routeScanHelper'
+import logger from '@logger'
+import { NetworksEnum } from '@types'
+import axios from 'axios'
+import config from '@config'
+import ProviderModule from '@modules/provider'
+
+describe('Helpers: RouteScan', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox && sandbox.restore()
+  })
+
+  it('axiosInstance', async () => {
+    const stubAxios = sandbox.stub(axios, 'create')
+    RouteScanHelper.axiosInstance(1)
+    expect(stubAxios.calledOnce).to.be.true
+  })
+
+  describe('_rpCall', () => {
+    it('Should make a successful _rpCall', async () => {
+      const expectedResult = { data: { status: '1', message: 'OK', result: [{ SourceCode: 'code' }] } }
+      const getCall = sandbox.stub().resolves(expectedResult)
+      const axiosInstanceStub = sandbox.stub(RouteScanHelper, 'axiosInstance').returns({
+        get: getCall,
+      } as any)
+
+      sandbox.stub(ProviderModule, 'getChainId').returns(1)
+
+      sandbox.stub(config, 'ROUTESCAN_API').value({
+        BASE_URI: 'https://api.routescan.io/v2/network/mainnet/evm',
+      })
+
+      const result = await RouteScanHelper._rpCall(
+        {
+          module: 'contract',
+          action: 'getsourcecode',
+        },
+        NetworksEnum.ethereumMainnet,
+      )
+
+      expect(result).to.deep.equal(expectedResult.data)
+      expect(axiosInstanceStub.calledOnce).to.be.true
+      expect(getCall.calledOnce).to.be.true
+      expect(getCall.firstCall.args[1]).to.be.deep.equal({
+        params: {
+          module: 'contract',
+          action: 'getsourcecode',
+        },
+      })
+    })
+
+    it('Should handle errors in _rpCall', async () => {
+      const expectedResult = new Error('RPC Call Failed')
+      const getCall = sandbox.stub().rejects(expectedResult)
+      sandbox.stub(RouteScanHelper, 'axiosInstance').returns({
+        get: getCall,
+      } as any)
+      const loggerStub = sandbox.stub(logger, 'error')
+
+      await expect(
+        RouteScanHelper._rpCall(
+          {
+            module: 'contract',
+            action: 'getsourcecode',
+          },
+          NetworksEnum.ethereumMainnet,
+        ),
+      ).to.be.rejectedWith(expectedResult)
+
+      expect(loggerStub.calledOnce).to.be.true
+      expect(loggerStub.firstCall.args[0]).to.equal('Error in RouteScan API call')
+    })
+  })
+
+  describe('fetchContractSourceCode', () => {
+    it('should fetch contract source code successfully', async () => {
+      const mockResponse = {
+        status: '1',
+        message: 'OK',
+        result: [{ SourceCode: 'SourceCode', ContractName: 'ContractName', ABI: 'ABI' }],
+      }
+
+      const rpcCallStub = sandbox.stub(RouteScanHelper, '_rpCall').resolves(mockResponse)
+
+      const result = await RouteScanHelper.fetchContractSourceCode({
+        address: '0xf96e6FD76BD0A15580604e1Ea5818D448b1041C0',
+        network: NetworksEnum.ethereumSepolia,
+      })
+
+      expect(result?.[0]).to.deep.equal({
+        SourceCode: 'SourceCode',
+        ContractName: 'ContractName',
+        ABI: 'ABI',
+      })
+
+      expect(rpcCallStub.calledOnce).to.be.true
+      expect(rpcCallStub.firstCall.args[0]).to.deep.equal({
+        module: 'contract',
+        action: 'getsourcecode',
+        address: '0xf96e6FD76BD0A15580604e1Ea5818D448b1041C0',
+      })
+    })
+
+    it('should return null if source code is empty', async () => {
+      const mockResponse = {
+        status: '1',
+        message: 'OK',
+        result: [{ SourceCode: '', ContractName: 'ContractName', ABI: 'ABI' }],
+      }
+
+      sandbox.stub(RouteScanHelper, '_rpCall').resolves(mockResponse)
+
+      const result = await RouteScanHelper.fetchContractSourceCode({
+        address: '0xf96e6FD76BD0A15580604e1Ea5818D448b1041C0',
+        network: NetworksEnum.ethereumSepolia,
+      })
+
+      expect(result).to.be.null
+    })
+
+    it('should return null if the API response status is not "1"', async () => {
+      const mockResponse = {
+        status: '0',
+        message: 'NOTOK',
+        result: [],
+      }
+
+      sandbox.stub(RouteScanHelper, '_rpCall').resolves(mockResponse)
+
+      const result = await RouteScanHelper.fetchContractSourceCode({
+        address: '0xf96e6FD76BD0A15580604e1Ea5818D448b1041C0',
+        network: NetworksEnum.ethereumSepolia,
+      })
+
+      expect(result).to.be.null
+    })
+
+    it('should handle errors when fetching contract source code fails', async () => {
+      const expectedError = new Error('Failed to fetch contract source code')
+      sandbox.stub(RouteScanHelper, '_rpCall').rejects(expectedError)
+      const loggerStub = sandbox.stub(logger, 'error')
+
+      const result = await RouteScanHelper.fetchContractSourceCode({
+        address: '0xf96e6FD76BD0A15580604e1Ea5818D448b1041C0',
+        network: NetworksEnum.ethereumSepolia,
+      })
+
+      expect(result).to.be.null
+      expect(loggerStub.calledOnce).to.be.true
+      expect(loggerStub.args[0][0]).to.include('Error fetchContractSourceCode from RouteScan')
+    })
+  })
+})

--- a/test/unit/modules/proxyProvider/cornProvider.spec.ts
+++ b/test/unit/modules/proxyProvider/cornProvider.spec.ts
@@ -1,0 +1,95 @@
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+import { expect } from 'chai'
+import CornProvider from '@modules/proxyProvider/cornProvider'
+import BlockScoutProvider from '@modules/proxyProvider/blockscoutProvider'
+import RouteScanHelper from '@helpers/routeScanHelper'
+import { NetworksEnum } from '@types'
+
+describe('Modules: CornProvider', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox && sandbox.restore()
+  })
+
+  describe('getTokenBalances', () => {
+    it('should delegate to BlockScoutProvider.getTokenBalances', async () => {
+      // Arrange
+      const address = '0x1234567890abcdef1234567890abcdef12345678'
+      const network = NetworksEnum.cornMainnet
+      const expectedResult = [{ tokenBalance: '100', contractAddress: '0xabc' }]
+
+      const blockscoutStub = sandbox.stub(BlockScoutProvider, 'getTokenBalances').resolves(expectedResult)
+
+      // Act
+      const result = await CornProvider.getTokenBalances({ address, network })
+
+      // Assert
+      expect(result).to.equal(expectedResult)
+      expect(blockscoutStub.calledOnce).to.be.true
+      expect(blockscoutStub.firstCall.args[0]).to.deep.equal({ address, network })
+    })
+  })
+
+  describe('fetchAddressTxns', () => {
+    it('should delegate to BlockScoutProvider.fetchAddressTxns', async () => {
+      // Arrange
+      const address = '0x1234567890abcdef1234567890abcdef12345678'
+      const network = NetworksEnum.cornMainnet
+      const expectedResult = [{ hash: '0xtx1', value: '1.0' }]
+
+      const blockscoutStub = sandbox.stub(BlockScoutProvider, 'fetchAddressTxns').resolves(expectedResult)
+
+      // Act
+      const result = await CornProvider.fetchAddressTxns({ address, network })
+
+      // Assert
+      expect(result).to.equal(expectedResult)
+      expect(blockscoutStub.calledOnce).to.be.true
+      expect(blockscoutStub.firstCall.args[0]).to.deep.equal({ address, network })
+    })
+  })
+
+  describe('fetchBasicTokenInfo', () => {
+    it('should delegate to BlockScoutProvider.fetchBasicTokenInfo', async () => {
+      // Arrange
+      const address = '0x1234567890abcdef1234567890abcdef12345678'
+      const network = NetworksEnum.cornMainnet
+      const expectedResult = { symbol: 'TEST', name: 'Test Token' }
+
+      const blockscoutStub = sandbox.stub(BlockScoutProvider, 'fetchBasicTokenInfo').resolves(expectedResult)
+
+      // Act
+      const result = await CornProvider.fetchBasicTokenInfo({ address, network })
+
+      // Assert
+      expect(result).to.equal(expectedResult)
+      expect(blockscoutStub.calledOnce).to.be.true
+      expect(blockscoutStub.firstCall.args[0]).to.deep.equal({ address, network })
+    })
+  })
+
+  describe('fetchContractSourceCode', () => {
+    it('should delegate to RouteScanHelper.fetchContractSourceCode', async () => {
+      // Arrange
+      const address = '0x1234567890abcdef1234567890abcdef12345678'
+      const network = NetworksEnum.cornMainnet
+      const expectedResult = [{ SourceCode: 'contract Test {}', ContractName: 'Test' }]
+
+      const routeScanStub = sandbox.stub(RouteScanHelper, 'fetchContractSourceCode').resolves(expectedResult as any)
+
+      // Act
+      const result = await CornProvider.fetchContractSourceCode({ address, network })
+
+      // Assert
+      expect(result).to.equal(expectedResult)
+      expect(routeScanStub.calledOnce).to.be.true
+      expect(routeScanStub.firstCall.args[0]).to.deep.equal({ address, network })
+    })
+  })
+})

--- a/test/unit/modules/proxyProvider/index.spec.ts
+++ b/test/unit/modules/proxyProvider/index.spec.ts
@@ -5,10 +5,10 @@ import Web3Provider from '@modules/proxyProvider/web3Provider'
 import PeaqProvider from '@modules/proxyProvider/peaqProvider'
 import ProxyWeb3Provider from '@modules/proxyProvider'
 import ChilizProvider from '@modules/proxyProvider/chilizProvider'
-import BlockscoutProvider from '@modules/proxyProvider/blockscoutProvider' // Adjust import path as needed
+import CornProvider from '@modules/proxyProvider/cornProvider' // Updated import
 
 describe('ProxyWeb3Provider', () => {
-  let sandbox
+  let sandbox: sinon.SinonSandbox
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
@@ -34,9 +34,9 @@ describe('ProxyWeb3Provider', () => {
       expect(provider).to.equal(ChilizProvider)
     })
 
-    it('should return BlockScoutProvider for cornMainnet network', () => {
+    it('should return CornProvider for cornMainnet network', () => {
       const provider = ProxyWeb3Provider.getProvider(NetworksEnum.cornMainnet)
-      expect(provider).to.equal(BlockscoutProvider)
+      expect(provider).to.equal(CornProvider)
     })
   })
 

--- a/tools/syncProposalAction.ts
+++ b/tools/syncProposalAction.ts
@@ -1,4 +1,4 @@
-import { EnumConnection, type IService } from '@types'
+import { EnumConnection, type IService, NetworksEnum } from '@types'
 import { Models } from '@dbModels'
 import { ProposalHandler } from '@src/handlers/proposalHandler'
 import ProviderModule from '@modules/provider'
@@ -11,16 +11,10 @@ export const SyncProposalAction: IService = {
 
   start: async () => {
     await ProviderModule.connectToAllNetworks()
-    // if the rawAction length is greator then 0
-    let proposals = await Models.Proposal.find({
-      actions: {
-        $elemMatch: {
-          type: { $in: ['Unknown', 'MetadataUpdate'] },
-        },
-      },
+    const proposals = await Models.Proposal.find({
+      daoAddress: '0x8112b792C31d94C186e7e3Ad2c35b07534084ce2',
+      network: NetworksEnum.cornMainnet,
     })
-
-    proposals = proposals.slice(460 + 304 + 714, proposals.length)
 
     logger.info(`Found ${proposals.length} proposals with rawActions`, llo({ proposals: proposals.length }))
     let counter = 0


### PR DESCRIPTION
## 📝 Summary

Add RouteScan API integration and CornProvider module

**Task:** [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## 🔄 What Changed

This pull request introduces a new `CornProvider` module and integrates it into the codebase, replacing the previous `BlockScoutProvider` for the `cornMainnet` network. It also introduces the `RouteScanHelper` utility for interacting with the RouteScan API, adds unit tests for new functionality, and updates configuration types to support the RouteScan API.

### Integration of `CornProvider`:

* [`src/modules/proxyProvider/cornProvider.ts`](diffhunk://#diff-f35f7ffc60a960b5539679a542295c55f1c2d13340e561172639a1db7c96afbaR1-R26): Created the `CornProvider` module, delegating most functionality to `BlockScoutProvider` but using `RouteScanHelper` for fetching contract source code.
* [`src/modules/proxyProvider/index.ts`](diffhunk://#diff-f7c5e1da568b2c778aad393b015c2939796ca77daa14830f306f8affff52a156L5-R5): Updated `ProxyWeb3Provider` to use `CornProvider` instead of `BlockScoutProvider` for the `cornMainnet` network. [[1]](diffhunk://#diff-f7c5e1da568b2c778aad393b015c2939796ca77daa14830f306f8affff52a156L5-R5) [[2]](diffhunk://#diff-f7c5e1da568b2c778aad393b015c2939796ca77daa14830f306f8affff52a156L15-R15)

### Addition of `RouteScanHelper`:

* [`src/helpers/routeScanHelper.ts`](diffhunk://#diff-76c5f8a19c128d34104c7cce5463cde4c1e94bd85f0c62f8fdbf3a796ef63c80R1-R64): Introduced `RouteScanHelper` to interact with the RouteScan API, including methods for making API calls and fetching contract source code.
* [`config/common.ts`](diffhunk://#diff-e2ecc8e5133f2fbd80e6d9d5ae7dd923894f56b17f362af076a49b5aae96f492R63-R70): Added configuration for the RouteScan API, including the `ROUTESCAN_API_BASE_URL`.
* [`src/types/config.ts`](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aR47-R49): Updated the `IConfig` interface to include the `ROUTESCAN_API` configuration.

### Unit Tests for New Features:

* [`test/unit/helpers/routeScan.spec.ts`](diffhunk://#diff-00cf3958ba15b8104a58f1f07d2e5a226a71abc2cefbcb620bd7fd516d9b5189R1-R162): Added unit tests for `RouteScanHelper`, covering API call handling, error handling, and contract source code fetching.
* [`test/unit/modules/proxyProvider/cornProvider.spec.ts`](diffhunk://#diff-dc362cab79be00519f52baf8833b61932d5c418b1cf5f2bfa65f0222375c6ac0R1-R95): Added unit tests for `CornProvider`, verifying delegation to `BlockScoutProvider` and `RouteScanHelper`.
* [`test/unit/modules/proxyProvider/index.spec.ts`](diffhunk://#diff-7afcfcd48a30bca26eb23ef0dbe124cf35256a997315252a40ceef2ce99c0da1L8-R11): Updated tests to reflect the replacement of `BlockScoutProvider` with `CornProvider` for the `cornMainnet` network. [[1]](diffhunk://#diff-7afcfcd48a30bca26eb23ef0dbe124cf35256a997315252a40ceef2ce99c0da1L8-R11) [[2]](diffhunk://#diff-7afcfcd48a30bca26eb23ef0dbe124cf35256a997315252a40ceef2ce99c0da1L37-R39)

### Changes to Proposal Synchronization:

* [`tools/syncProposalAction.ts`](diffhunk://#diff-20c8a156f22ec8b49589971589ba0fbf4a68ba0dc67d969e56b2b898bf184273L1-R1): Modified the proposal synchronization logic to target proposals on the `cornMainnet` network with a specific DAO address. [[1]](diffhunk://#diff-20c8a156f22ec8b49589971589ba0fbf4a68ba0dc67d969e56b2b898bf184273L1-R1) [[2]](diffhunk://#diff-20c8a156f22ec8b49589971589ba0fbf4a68ba0dc67d969e56b2b898bf184273L14-L24)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
