### PR TITLE
fix(spp): fix of parent proposals during any error on spp pair

### DIFF
--- a/tools/fixSppPair.ts
+++ b/tools/fixSppPair.ts
@@ -1,4 +1,4 @@
-import { EnumConnection, type IService, NetworksEnum } from '@types'
+import { EnumConnection, type IService, type NetworksEnum } from '@types'
 import logger from '@logger'
 import { Models } from '@dbModels'
 import { ProposalHandler } from '@handlers/proposalHandler'
@@ -9,30 +9,46 @@ export const FixSppPair: IService = {
   NEED_CONNECTIONS: [EnumConnection.MONGODB, EnumConnection.BLOCKCHAIN],
 
   start: async () => {
-    const proposalParent = await Models.Proposal.findOne({
-      daoAddress: '0xBe31BC9278e4745d9D04F4A9113B71Db3Bdc7E43',
+    const parentProposals = await Models.Proposal.find({
       pluginSubdomain: 'spp',
       isSubProposal: false,
-      network: NetworksEnum.cornMainnet,
+      stageIndex: { $exists: false },
     })
 
-    if (!proposalParent) {
-      logger.error('Proposal parent not found', llo())
+    if (!parentProposals || parentProposals.length === 0) {
+      logger.info('No broken parent proposals found for SPP', llo())
       return
     }
 
-    const info = {
-      transactionHash: proposalParent.transactionHash,
-      blockNumber: proposalParent.blockNumber,
-      network: proposalParent.pluginAddress,
-      address: proposalParent.address,
-    } as any
+    for (const proposalParent of parentProposals) {
+      const info = {
+        transactionHash: proposalParent.transactionHash,
+        blockNumber: proposalParent.blockNumber,
+        network: proposalParent.network as NetworksEnum,
+        address: proposalParent.pluginAddress,
+      }
 
-    await ProposalHandler.pairSppProposals(
-      proposalParent,
-      await Models.Plugin.findOne({ address: proposalParent.pluginAddress, network: proposalParent.network }),
-      info,
-    )
+      logger.info('Fixing SPP pair', llo({ info }))
+
+      await ProposalHandler.pairSppProposals(
+        proposalParent,
+        await Models.Plugin.findOne({ address: proposalParent.pluginAddress, network: proposalParent.network }),
+        info as any,
+      )
+
+      const parentProposal = await Models.Proposal.findOne({
+        pluginSubdomain: 'spp',
+        isSubProposal: false,
+        pluginAddress: proposalParent.pluginAddress,
+        proposalIndex: proposalParent.proposalIndex,
+      })
+
+      if (parentProposal && parentProposal.stageIndex !== undefined && parentProposal.subProposals?.length) {
+        logger.info('SPP Stage Indexed Issue Fixed', llo({ info }))
+      } else {
+        logger.error('Failed to fix SPP stage index', llo({ info }))
+      }
+    }
 
     logger.info('End fixSppPair', llo())
   },


### PR DESCRIPTION
## 📝 Summary

This pull request updates the `FixSppPair` service in `tools/fixSppPair.ts` to improve the handling of broken parent proposals and enhance logging for better debugging. The most important changes include modifying the query logic for parent proposals, adding a loop to process multiple parent proposals, and improving error handling and logging.

### Changes to query logic and proposal processing:

* Updated the query for parent proposals to retrieve all proposals with `pluginSubdomain: 'spp'`, `isSubProposal: false`, and without a `stageIndex`, instead of querying for a single proposal with a specific `daoAddress`. (`[tools/fixSppPair.tsL12-R52](diffhunk://#diff-c150b32b2cf82e41b40a4f647a32d208d99906a7aa5a17a95f8b2a81a4dba3bfL12-R52)`)
* Added a loop to process each parent proposal individually, enabling the service to handle multiple broken parent proposals. (`[tools/fixSppPair.tsL12-R52](diffhunk://#diff-c150b32b2cf82e41b40a4f647a32d208d99906a7aa5a17a95f8b2a81a4dba3bfL12-R52)`)

### Improvements to error handling and logging:

* Replaced the error log for a missing parent proposal with an info log when no broken parent proposals are found. (`[tools/fixSppPair.tsL12-R52](diffhunk://#diff-c150b32b2cf82e41b40a4f647a32d208d99906a7aa5a17a95f8b2a81a4dba3bfL12-R52)`)
* Added detailed logs for each proposal being processed, including success and failure messages for fixing the SPP stage index. (`[tools/fixSppPair.tsL12-R52](diffhunk://#diff-c150b32b2cf82e41b40a4f647a32d208d99906a7aa5a17a95f8b2a81a4dba3bfL12-R52)`)

### Minor code adjustments:

* Fixed the import statement for `NetworksEnum` to include the `type` keyword for consistency. (`[tools/fixSppPair.tsL1-R1](diffhunk://#diff-c150b32b2cf82e41b40a4f647a32d208d99906a7aa5a17a95f8b2a81a4dba3bfL1-R1)`)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
