### PR TITLE
fix(rate-limiting): improve handling of rate limit errors in blockchain log crawler

### DIFF
--- a/src/modules/blockchainLogCrawler.ts
+++ b/src/modules/blockchainLogCrawler.ts
@@ -19,6 +19,7 @@ import { retryRequest } from '@helpers/retryRequest'
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import axios from 'axios'
+import BottleneckModule from '@modules/bottleneck'
 
 const llo = logger.logMeta.bind(null, { service: 'modules:EventCrawler' })
 
@@ -216,33 +217,30 @@ class BlockchainLogCrawler {
         }
 
         const batchSizeErrors = failedRequests.filter((resp: any) => this.isBatchSizeError(resp.error))
+        const rateLimitErrors = failedRequests.filter((resp: any) => this.isRateLimited(resp.error))
+
         if (batchSizeErrors.length > 0) {
           if (this.crawlSetting.batchSize > 1) {
             this.crawlSetting.batchSize = Math.max(1, Math.floor(this.crawlSetting.batchSize / 3))
             toBlock = this.resizeToBlock(currentBlock, latestBlock)
-            logger.verbose(
-              'Trying to cut after failure',
-              llo({
-                currentBlock,
-                toBlock,
-                latestBlock,
-                batchSize: this.crawlSetting.batchSize,
-                runCount: this.crawlSetting.runCount,
-              }),
-            )
-          } else {
-            const error = batchSizeErrors[0].error
-            logger.error('Batch size too small, stopping crawl', llo({ ...this.parseCrawlerInfoLog(), error }))
-            this.crawlSetting.shutdown = true
-            this.crawlParams.onError(error)
-            break
+            continue
           }
-        } else {
-          const error = failedRequests[0].error
-          await this.handleErrors(error)
+          const error = batchSizeErrors[0].error
+          logger.error('Batch size too small, stopping crawl', llo({ ...this.parseCrawlerInfoLog(), error }))
           this.crawlSetting.shutdown = true
+          this.crawlParams.onError(error)
           break
         }
+
+        if (rateLimitErrors.length > 0) {
+          await this.handleErrors(rateLimitErrors[0].error)
+          continue
+        }
+
+        const error = failedRequests[0].error
+        await this.handleErrors(error)
+        this.crawlSetting.shutdown = true
+        break
       } catch (error) {
         await this.handleErrors(error)
         this.crawlSetting.shutdown = true
@@ -314,9 +312,13 @@ class BlockchainLogCrawler {
     }
 
     try {
-      const response: any = await axios.post(url, requests, {
-        headers: { 'Content-Type': 'application/json' },
-      })
+      const response = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(this.crawlParams.network).schedule(async () =>
+          axios.post(url, requests, {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      )
 
       const validResponses = response.data.filter((resp: any) => !resp.error && resp.result)
       if (validResponses.length === response.data.length) {
@@ -387,9 +389,13 @@ class BlockchainLogCrawler {
         return req
       }, [])
 
-      const response: any = await axios.post(url, batchRequests, {
-        headers: { 'Content-Type': 'application/json' },
-      })
+      const response = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(this.crawlParams.network).schedule(async () =>
+          axios.post(url, batchRequests, {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      )
 
       return response.data
     } catch (error: any) {
@@ -407,7 +413,8 @@ class BlockchainLogCrawler {
 
   async handleErrors(error: any) {
     if (this.isRateLimited(error)) {
-      await utils.wait(1000)
+      const backoffTime = Math.min(500 * (this.crawlSetting.runCount || 1), 10000)
+      await utils.wait(backoffTime)
     } else {
       this.crawlSetting.shutdown = true
       this.crawlParams.onError(error)
@@ -667,7 +674,10 @@ class BlockchainLogCrawler {
   }
 
   isRateLimited(error: any): boolean {
-    const messages = ['Your app has exceeded its compute units per second capacity']
+    const messages = [
+      'Your app has exceeded its compute units per second capacity',
+      'Too many requests, reason: call rate limit exhausted',
+    ]
 
     return messages.some(msg => error.message?.includes(msg))
   }

--- a/test/unit/modules/blockchainLogCrawler.spec.ts
+++ b/test/unit/modules/blockchainLogCrawler.spec.ts
@@ -378,6 +378,32 @@ describe('Module: blockchainLogCrawler', () => {
       expect(result.toBlock).to.equal(133) //as divide by 3
     })
 
+    it('should handle rate limiting error', async () => {
+      const crawler = new BlockchainLogCrawler({
+        ...crawlerConfig,
+        events: [
+          { topic: '0xTopic', event: 'Test', config: [{ abi: ['event Test()'], handler: sandbox.stub().resolves() }] },
+        ],
+      })
+
+      const rateLimitError = { error: { message: 'Too many requests, reason: call rate limit exhausted' } }
+      const executeBatchStub = sandbox
+        .stub(crawler, 'executeBatchRequest')
+        .onFirstCall()
+        .resolves([rateLimitError])
+        .onSecondCall()
+        .resolves([{ result: [{ blockNumber: '0x65', transactionIndex: '0x1', logIndex: '0x0' }] }])
+
+      const utilsStub = sandbox.stub(Utils, 'wait').resolves()
+
+      const result = await crawler.getLogsByBatch(100, 200)
+
+      expect(executeBatchStub.calledTwice).to.be.true
+      expect(result.logs).to.have.lengthOf(1)
+      expect(result.toBlock).to.equal(200)
+      expect(utilsStub.calledOnce).to.be.true
+    })
+
     it('should stop crawling when batch size is already at minimum', async () => {
       const crawler = new BlockchainLogCrawler({
         ...crawlerConfig,


### PR DESCRIPTION
This pull request enhances the `BlockchainLogCrawler` to improve handling of rate-limiting errors and optimize request retries. Key changes include adding rate-limiting logic, integrating a request scheduling library, and expanding test coverage to validate the new functionality.

### Enhancements to rate-limiting handling:
* Added logic to detect additional rate-limiting error messages (`'Too many requests, reason: call rate limit exhausted'`) in the `isRateLimited` method.
* Introduced a dynamic backoff mechanism in the `handleErrors` method to wait for an appropriate time before retrying when rate-limited.

### Integration of request scheduling:
* Replaced direct `axios.post` calls with a combination of `retryRequest` and `BottleneckModule.getNodeLimiter` to schedule and retry requests efficiently. [[1]](diffhunk://#diff-e1117e422a9f3f7fa569dc31550af04d22dbd8c83cde3fbd1612e395eb7a64c3L317-R321) [[2]](diffhunk://#diff-e1117e422a9f3f7fa569dc31550af04d22dbd8c83cde3fbd1612e395eb7a64c3L390-R398)

### Test coverage improvements:
* Added a unit test to validate the handling of rate-limiting errors, ensuring the crawler retries correctly and processes logs after recovery.

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
