### PR TITLE
feat(token): linking of existing token holders to plugins and mark it as synced on configIndexer

### DIFF
--- a/src/services/aragon-plugins/logTokenVoting.ts
+++ b/src/services/aragon-plugins/logTokenVoting.ts
@@ -64,8 +64,12 @@ export const LogTokenVoting = {
       onlyHistorical: isHistorical,
       network: plugin.network,
       events: [...configEscrowAdapterILogs, ...configEscrowILogs, ...configExitQueueLogs],
-      address: [plugin.tokenAddress],
-      fromBlock: plugin?.blockNumber,
+      address: [
+        plugin.tokenAddress,
+        plugin.votingEscrow?.escrowAddress!,
+        plugin.votingEscrow?.exitQueueAddress!,
+      ].filter(Boolean),
+      fromBlock: token.blockNumber || plugin.blockNumber,
       onError: async (error: any, log: any) => LogTokenVoting.processError(error, plugin, log),
       logService: `${plugin.interfaceType}-${plugin.network}-${plugin.address}-${plugin.votingEscrow?.escrowAddress}`,
       stopOnError: true,
@@ -148,6 +152,8 @@ export const LogTokenVoting = {
 
     logger.verbose('Start Token Sync', llo({ ...infoLogs, ...{ syncStrategy: 'BlockchainLogCrawler' } }))
 
+    const tokenLastSyncBlock = await TokenHolderSync.getTokenLastSyncBlock(token)
+
     const tokenCrawler = new BlockchainLogCrawler({
       onlyHistorical: isHistorical,
       network: plugin.network,
@@ -159,7 +165,13 @@ export const LogTokenVoting = {
       stopOnError: true,
     })
 
-    const crawlers: any = [pluginCrawler.crawl(), tokenCrawler.crawl()]
+    const crawlers: any = [pluginCrawler.crawl()]
+    if (tokenLastSyncBlock) {
+      crawlers.push(TokenHolderSync.linkPluginToExistingTokenHolders(plugin, token, tokenLastSyncBlock))
+    } else {
+      crawlers.push(tokenCrawler.crawl())
+    }
+
     await Promise.all(crawlers)
 
     logger.verbose(

--- a/src/services/aragon-plugins/tokenHolderSync.ts
+++ b/src/services/aragon-plugins/tokenHolderSync.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import logger from '@logger'
 import { type IEnumIndexerServiceStatic, TokenSyncTagName, IGovernanceErc20Logs, type IIndexerConfig } from '@types'
 import BlockchainLogCrawler from '@modules/blockchainLogCrawler'
@@ -249,5 +250,72 @@ export const TokenHolderSync = {
         lastSyncBlock: syncStatBlock,
       }),
     )
+  },
+  getTokenLastSyncBlock: async (token: Token) => {
+    const syncTag = await Models.ConfigIndexer.findOne({
+      network: token.network,
+      regex: { $regex: `${token.address}$` },
+    })
+
+    return syncTag?.lastSync || 0
+  },
+  linkPluginToExistingTokenHolders: async (plugin: Plugin, token: Token, lastSync: number) => {
+    const membersFromToken = await Models.Member.find({
+      tokenAddress: token.address,
+      network: token.network,
+    }).distinct('memberAddress')
+
+    if (membersFromToken.length === 0) return
+
+    const membersDataToSave = membersFromToken.reduce(
+      (membersData: any, memberAddress: any) => {
+        const daoRelation = {
+          memberAddress,
+          daoAddress: plugin.daoAddress,
+          pluginAddress: plugin.address,
+          tokenAddress: token.address,
+          network: plugin.network,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          __v: 0,
+        }
+        const memberMetrics = {
+          network: plugin.network,
+          address: memberAddress,
+          pluginAddress: plugin.address,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          __v: 0,
+        }
+
+        membersData.daoRelation.push(daoRelation)
+        membersData.metrics.push({
+          id: Models.MemberMetrics.getEntityId(memberMetrics),
+          ...memberMetrics,
+        })
+
+        return membersData
+      },
+      { daoRelation: [], metrics: [] },
+    )
+
+    try {
+      await Promise.all([
+        Models.DaoMemberMapping.insertMany(membersDataToSave.daoRelation, { ordered: false, lean: true }),
+        Models.MemberMetrics.insertMany(membersDataToSave.metrics, { ordered: false, lean: true }),
+      ])
+      await Models.ConfigIndexer.create({
+        network: plugin.network,
+        service: TokenHolderSync.getTagName(plugin, token, TokenSyncTagName.Default),
+        lastSync,
+      })
+    } catch (e: any) {
+      logger.error('Error linking plugin to existing token holders', {
+        error: e,
+        pluginAddress: plugin.address,
+        tokenAddress: token.address,
+        network: plugin.network,
+      })
+    }
   },
 }

--- a/test/unit/services/aragon-plugins/logTokenVoting.spec.ts
+++ b/test/unit/services/aragon-plugins/logTokenVoting.spec.ts
@@ -268,6 +268,77 @@ describe('AragonPlugins: LogTokenVoting', () => {
       expect(processErrorStub.calledOnce).to.be.true
       expect(processErrorStub.calledWith(error, pluginStub, { logIndex: 2, transactionHash: '0xhash2' })).to.be.true
     })
+
+    it('should use linkPluginToExistingTokenHolders when token has an existing sync block', async () => {
+      const token = {
+        address: '0x123',
+        network: NetworksEnum.ethereumSepolia,
+        type: ITokenType.ERC20,
+        blockNumber: 100,
+      } as any
+
+      const plugin = {
+        address: '0x456',
+        tokenAddress: token.address,
+        network: token.network,
+        blockNumber: 200,
+        interfaceType: 'tokenVoting',
+      } as any
+
+      const getTokenLastSyncBlockStub = sandbox.stub(TokenHolderSync, 'getTokenLastSyncBlock').resolves(150)
+      const isTokenNotEligibleStub = sandbox.stub(TokenHolderSync, 'isTokenNotEligibleForSync').resolves(false)
+
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves()
+
+      const linkPluginStub = sandbox.stub(TokenHolderSync, 'linkPluginToExistingTokenHolders').resolves()
+
+      sandbox.stub(logger, 'verbose')
+
+      await LogTokenVoting.erc20Governance(plugin, token)
+
+      expect(isTokenNotEligibleStub.calledOnce).to.be.true
+      expect(getTokenLastSyncBlockStub.calledOnce).to.be.true
+      expect(getTokenLastSyncBlockStub.calledWith(token)).to.be.true
+      expect(crawlStub.calledOnce).to.be.true
+      expect(linkPluginStub.calledOnce).to.be.true
+      expect(linkPluginStub.calledWith(plugin, token, 150)).to.be.true
+    })
+
+    it('should use tokenCrawler when token has no existing sync block', async () => {
+      // Setup
+      const token = {
+        address: '0x123',
+        network: NetworksEnum.ethereumSepolia,
+        type: ITokenType.ERC20,
+        blockNumber: 100,
+      } as any
+
+      const plugin = {
+        address: '0x456',
+        tokenAddress: token.address,
+        network: token.network,
+        blockNumber: 200,
+        interfaceType: 'tokenVoting',
+      } as any
+
+      const getTokenLastSyncBlockStub = sandbox.stub(TokenHolderSync, 'getTokenLastSyncBlock').resolves(0)
+      const isTokenNotEligibleStub = sandbox.stub(TokenHolderSync, 'isTokenNotEligibleForSync').resolves(false)
+
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves()
+
+      const linkPluginStub = sandbox.stub(TokenHolderSync, 'linkPluginToExistingTokenHolders').resolves()
+
+      sandbox.stub(logger, 'verbose')
+
+      // Act
+      await LogTokenVoting.erc20Governance(plugin, token)
+
+      // Assert
+      expect(isTokenNotEligibleStub.calledOnce).to.be.true
+      expect(getTokenLastSyncBlockStub.calledOnce).to.be.true
+      expect(crawlStub.calledTwice).to.be.true
+      expect(linkPluginStub.called).to.be.false
+    })
   })
 
   describe('veGovernance', () => {

--- a/test/unit/services/aragon-plugins/tokenHolderSync.spec.ts
+++ b/test/unit/services/aragon-plugins/tokenHolderSync.spec.ts
@@ -391,4 +391,124 @@ describe('AragonPlugins: TokenHolderSync', () => {
       expect(Array.isArray(result)).to.be.true
     })
   })
+
+  describe('linkPluginToExistingTokenHolders', () => {
+    beforeEach(() => {
+      sandbox.restore()
+    })
+    it('should not process anything if no token holders exist', async () => {
+      const spyDaoMemberMappingInsertMany = sandbox.spy(Models.DaoMemberMapping, 'insertMany')
+
+      await TokenHolderSync.linkPluginToExistingTokenHolders(mockPlugin, mockToken, 1000)
+
+      expect(spyDaoMemberMappingInsertMany.called).to.be.false
+    })
+
+    it('should link existing token holders to plugin and create config indexer entry', async () => {
+      const mockHolders = ['0xHolder1', '0xHolder2']
+
+      const memberFindStub = sandbox.stub(Models.Member, 'find')
+      memberFindStub.returns({
+        distinct: sandbox.stub().resolves(mockHolders),
+      })
+      const spyDaoMemberMappingInsertMany = sandbox.spy(Models.DaoMemberMapping, 'insertMany')
+      const spyMemberMetricsInsertMany = sandbox.spy(Models.MemberMetrics, 'insertMany')
+      const spyConfigIndexerCreate = sandbox.spy(Models.ConfigIndexer, 'create')
+
+      const lastSyncBlock = 1500
+
+      // Act
+      await TokenHolderSync.linkPluginToExistingTokenHolders(mockPlugin, mockToken, lastSyncBlock)
+
+      // Assert
+      expect(
+        memberFindStub.calledWith({
+          tokenAddress: mockToken.address,
+          network: mockToken.network,
+        }),
+      ).to.be.true
+
+      const daoMemberMappings = await Models.DaoMemberMapping.find({
+        pluginAddress: mockPlugin.address,
+        tokenAddress: mockToken.address,
+        network: mockPlugin.network,
+      })
+
+      expect(spyDaoMemberMappingInsertMany.calledOnce).to.be.true
+      expect(spyMemberMetricsInsertMany.calledOnce).to.be.true
+
+      expect(daoMemberMappings.length).to.equal(mockHolders.length)
+      const memberMetrics = await Models.MemberMetrics.find({
+        pluginAddress: mockPlugin.address,
+        network: mockPlugin.network,
+      })
+
+      expect(memberMetrics.length).to.equal(mockHolders.length)
+
+      expect(spyConfigIndexerCreate.calledOnce).to.be.true
+      const configIndexer = await Models.ConfigIndexer.findOne({
+        network: mockPlugin.network,
+        service: TokenHolderSync.getTagName(mockPlugin, mockToken, TokenSyncTagName.Default),
+      })
+      expect(configIndexer).to.not.be.null
+      expect(configIndexer.lastSync).to.equal(lastSyncBlock)
+    })
+
+    it('should handle errors during insertion and still create config indexer entry', async () => {
+      // Setup - mock some token holders
+      const mockHolders = ['0xHolder1', '0xHolder2']
+
+      // Stub Member.find().distinct to return our mock holders
+      const memberFindStub = sandbox.stub(Models.Member, 'find')
+      memberFindStub.returns({
+        distinct: sandbox.stub().resolves(mockHolders),
+      })
+
+      const insertManyStub = sandbox.stub(Models.DaoMemberMapping, 'insertMany')
+      insertManyStub.throws(new Error('Database error'))
+
+      // Spy on other methods
+      const spyConfigIndexerCreate = sandbox.spy(Models.ConfigIndexer, 'create')
+      const spyLoggerError = sandbox.stub(logger, 'error')
+
+      // Act
+      await TokenHolderSync.linkPluginToExistingTokenHolders(mockPlugin, mockToken, 1000)
+
+      // Assert
+      expect(spyLoggerError.calledOnce).to.be.true
+      expect(spyConfigIndexerCreate.calledOnce).to.be.false
+    })
+
+    it('should return the last sync block if config exists', async () => {
+      // Setup
+      const mockLastSync = 5000
+
+      const findOneStub = sandbox.stub(Models.ConfigIndexer, 'findOne')
+      findOneStub.resolves({ lastSync: mockLastSync })
+
+      // Act
+      const result = await TokenHolderSync.getTokenLastSyncBlock(mockToken)
+
+      // Assert
+      expect(result).to.equal(mockLastSync)
+      expect(findOneStub.calledOnce).to.be.true
+      expect(findOneStub.firstCall.args[0]).to.deep.include({
+        network: mockToken.network,
+        regex: { $regex: `${mockToken.address}$` },
+      })
+    })
+
+    it('should return 0 if no config exists', async () => {
+      // Setup
+      const findOneStub = sandbox.stub(Models.ConfigIndexer, 'findOne')
+      findOneStub.resolves(null)
+
+      // Act
+      const result = await TokenHolderSync.getTokenLastSyncBlock(mockToken)
+
+      // Assert
+      expect(result).to.equal(0)
+      expect(findOneStub.calledOnce).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
## 📝 Summary

This pull request introduces enhancements to the `LogTokenVoting` and `TokenHolderSync` modules to improve token synchronization and plugin integration. Key updates include handling existing token synchronization blocks, linking plugins to token holders, and adding comprehensive unit tests to ensure reliability.

### Enhancements to `LogTokenVoting`:

* Updated the `address` and `fromBlock` fields to include additional plugin-related addresses and fallback logic for block numbers to improve token synchronization. (`src/services/aragon-plugins/logTokenVoting.ts`, [src/services/aragon-plugins/logTokenVoting.tsL67-R72](diffhunk://#diff-f9639d6c4fe8238ea4decbd7ae21d23bf52ea8a7002bbe84847c87642af610f4L67-R72))
* Introduced logic to check for an existing token sync block and conditionally use `linkPluginToExistingTokenHolders` or `tokenCrawler` for token synchronization. (`src/services/aragon-plugins/logTokenVoting.ts`, [[1]](diffhunk://#diff-f9639d6c4fe8238ea4decbd7ae21d23bf52ea8a7002bbe84847c87642af610f4R155-R156) [[2]](diffhunk://#diff-f9639d6c4fe8238ea4decbd7ae21d23bf52ea8a7002bbe84847c87642af610f4L162-R174)

### Additions to `TokenHolderSync`:

* Added the `getTokenLastSyncBlock` method to retrieve the last synchronization block for a token. (`src/services/aragon-plugins/tokenHolderSync.ts`, [src/services/aragon-plugins/tokenHolderSync.tsR254-R320](diffhunk://#diff-855b5314232f2d21ab8944ed12703ac6dfeffa9b58897c013320d7cc17c16d1bR254-R320))
* Implemented `linkPluginToExistingTokenHolders` to associate plugins with existing token holders and update related database entries. (`src/services/aragon-plugins/tokenHolderSync.ts`, [src/services/aragon-plugins/tokenHolderSync.tsR254-R320](diffhunk://#diff-855b5314232f2d21ab8944ed12703ac6dfeffa9b58897c013320d7cc17c16d1bR254-R320))

### Unit Test Enhancements:

* Added tests for `LogTokenVoting` to validate the behavior of token synchronization with and without an existing sync block. (`test/unit/services/aragon-plugins/logTokenVoting.spec.ts`, [test/unit/services/aragon-plugins/logTokenVoting.spec.tsR271-R341](diffhunk://#diff-41f7e13f8533965a0d68cfc3f918a713c604a0756897cf885d9590bfa2d4b651R271-R341))
* Added tests for `TokenHolderSync` to verify the functionality of `linkPluginToExistingTokenHolders` and `getTokenLastSyncBlock`, including error handling and database updates. (`test/unit/services/aragon-plugins/tokenHolderSync.spec.ts`, [test/unit/services/aragon-plugins/tokenHolderSync.spec.tsR394-R513](diffhunk://#diff-a8dddac58fafd54819552b72477b80910ee14b9ebb8983f502d5db45d6871cc5R394-R513))

**Task:** [APP-4353](https://aragonassociation.atlassian.net/browse/APP-4353)

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)


[APP-4353]: https://aragonassociation.atlassian.net/browse/APP-4353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ