### PR TITLE
fix(lock): rename memberMetrics to metrics for clarity

### DIFF
--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -562,7 +562,7 @@ export default class Lock extends Model {
           ens: '$memberInfo.ens',
           avatar: '$memberInfo.avatar',
           votingPower: 1,
-          memberMetrics: {
+          metrics: {
             $ifNull: [
               {
                 $arrayElemAt: ['$memberMetrics', 0],


### PR DESCRIPTION
## 📝 Summary

This pull request updates the `Lock` model in `src/models/schema/lock.ts` to rename a property for consistency and clarity.

* **Property renaming for consistency:**
  * Renamed the `memberMetrics` property to `metrics` within the `Lock` model to align with naming conventions and improve clarity.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
