### PR TITLE
fix(netspec): handle optional chaining for tags in Natspec details

### DIFF
--- a/src/helpers/contractNetspec.ts
+++ b/src/helpers/contractNetspec.ts
@@ -225,10 +225,10 @@ export function collapseNatspec(natspec: Record<string, NatspecContract>, contra
       collapsed.details = Object.fromEntries(
         Object.entries(collapsed.details).map(([name, details]) => {
           if (details.tags?.['inheritdoc'] !== undefined) {
-            const inheritDetails = natspec[details.tags['inheritdoc'] as string]?.details[name]
+            const inheritDetails = natspec[details.tags?.['inheritdoc'] as string]?.details[name]
             if (inheritDetails !== undefined) {
-              delete details.tags['inheritdoc']
-              details.tags = { ...inheritDetails.tags, ...details.tags }
+              details.tags?.['inheritdoc'] && delete details.tags['inheritdoc']
+              details.tags = { ...inheritDetails.tags, ...(details.tags || {}) }
             }
           }
           if (details.tags && Object.keys(details.tags).length === 0) {


### PR DESCRIPTION
## 📝 Summary

This pull request includes a small but important change to improve the robustness of the `collapseNatspec` function in `src/helpers/contractNetspec.ts`. The change ensures safer handling of optional `tags` objects by adding nullish checks.

* [`src/helpers/contractNetspec.ts`](diffhunk://#diff-ba5ec5bbad3f8bf9b6f6f8e3a846ad12bc5ac5355ffe4c98e756cc217f755ce5L227-R234): Updated conditions to check for the existence of `tags` using optional chaining (`?.`) before accessing or manipulating its properties. This prevents potential runtime errors when `tags` is undefined.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
