### PR TITLE
fix(memberInfo): check balance or voting power in the api can create proposal

### DIFF
--- a/src/services/aragon-dao/memberInfo.ts
+++ b/src/services/aragon-dao/memberInfo.ts
@@ -100,8 +100,13 @@ export const MemberInfo = {
 
   _checkForTokenVoting: async (plugin: Plugin, setting: PluginSetting, memberAddress: HexAddress) => {
     if (!setting || !plugin.tokenAddress) return false
-    const votingPower = await GovernanceErc20Helper.getVotes(memberAddress, plugin.tokenAddress, plugin.network)
-    return Number(votingPower) > 0 && Number(votingPower) >= Number(setting.minParticipation)
+
+    const [votingPower, balance] = await Promise.all([
+      GovernanceErc20Helper.getVotes(memberAddress, plugin.tokenAddress, plugin.network),
+      Web3Helper.getERC20Balance(memberAddress, plugin.tokenAddress, plugin.network),
+    ])
+    const userBalance = Math.max(Number(votingPower), Number(balance))
+    return userBalance > 0 && userBalance >= Number(setting.minParticipation)
   },
 
   _checkForMultiSig: async (plugin: Plugin, setting: PluginSetting, memberAddress: HexAddress) => {

--- a/test/unit/services/aragon-dao/memberInfo.spec.ts
+++ b/test/unit/services/aragon-dao/memberInfo.spec.ts
@@ -303,7 +303,37 @@ describe('AragonDao: memberInfo', () => {
       expect(result).to.be.false
     })
 
-    it('should return false for tokenVoting when voting power is 0', async () => {
+    it('should return true when voting power is 0 and there is the balance', async () => {
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        daoAddress: '0xDaoAddress',
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumSepolia,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: '0xTokenAddress',
+      } as any)
+      const settingsStub = sandbox.stub(Models.Setting, 'findActive').resolves({
+        minParticipation: 100,
+      } as any)
+
+      const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(0n)
+      const getBalanceStub = sandbox.stub(Web3Helper, 'getERC20Balance').resolves(200n)
+
+      const result = await MemberInfo.canCreateProposal(
+        '0xPluginAddress',
+        '0xMemberAddress',
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(pluginStub.calledOnce).to.be.true
+      expect(settingsStub.calledOnce).to.be.true
+      expect(getVotesStub.calledOnce).to.be.true
+      expect(getVotesStub.calledWith('0xMemberAddress', '0xTokenAddress', NetworksEnum.ethereumSepolia)).to.be.true
+      expect(getBalanceStub.calledOnce).to.be.true
+      expect(getBalanceStub.calledWith('0xMemberAddress', '0xTokenAddress', NetworksEnum.ethereumSepolia)).to.be.true
+      expect(result).to.be.true
+    })
+
+    it('should return false for tokenVoting when voting power is 0 and balance also 0', async () => {
       const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
         daoAddress: '0xDaoAddress',
         address: '0xPluginAddress',
@@ -317,6 +347,7 @@ describe('AragonDao: memberInfo', () => {
       } as any)
 
       const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(0n)
+      sandbox.stub(Web3Helper, 'getERC20Balance').resolves(0n)
 
       const result = await MemberInfo.canCreateProposal(
         '0xPluginAddress',
@@ -345,6 +376,7 @@ describe('AragonDao: memberInfo', () => {
       } as any)
 
       const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(50n)
+      sandbox.stub(Web3Helper, 'getERC20Balance').resolves(0n)
 
       const result = await MemberInfo.canCreateProposal(
         '0xPluginAddress',
@@ -372,6 +404,7 @@ describe('AragonDao: memberInfo', () => {
       } as any)
 
       const getVotesStub = sandbox.stub(GovernanceErc20Helper, 'getVotes').resolves(150n)
+      sandbox.stub(Web3Helper, 'getERC20Balance').resolves(200n)
 
       const result = await MemberInfo.canCreateProposal(
         '0xPluginAddress',


### PR DESCRIPTION
## 📝 Summary

This pull request enhances the logic for determining a member's ability to create proposals in token-based voting within the Aragon DAO system. It introduces a more comprehensive check by considering both voting power and token balance, and updates the associated unit tests to reflect these changes.

### Enhancements to Proposal Eligibility Logic:
* Updated the `_checkForTokenVoting` method in `src/services/aragon-dao/memberInfo.ts` to consider both voting power and ERC-20 token balance when determining if a member meets the minimum participation requirement. The higher of the two values is used for the comparison.

### Unit Test Updates:
* Added a new test case to verify that a member with zero voting power but sufficient token balance can still create a proposal.
* Updated existing test cases to include stubs for the `Web3Helper.getERC20Balance` method, ensuring the new balance check logic is properly validated:
  - Test case for zero voting power and zero balance.
  - Test case for non-zero voting power and zero balance.
  - Test case for both non-zero voting power and balance.

**Task:** [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
