### PR TITLE
fix: resolve Mongoose duplicate index warnings

### DIFF
--- a/src/models/schema/asset.ts
+++ b/src/models/schema/asset.ts
@@ -28,7 +28,6 @@ const customName = ICollectionNames.Asset
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ daoAddress: 1, tokenAddress: 1, network: 1, amountUsd: -1 })
 export default class Asset extends Model {
   @prop({ type: () => String, required: true, unique: true })

--- a/src/models/schema/configIndexer.ts
+++ b/src/models/schema/configIndexer.ts
@@ -18,7 +18,6 @@ const customName = ICollectionNames.ConfigIndexer
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ network: 1, lastSync: 1 })
 @index({ lastSync: 1 })
 @index({ end: -1 })

--- a/src/models/schema/dao.ts
+++ b/src/models/schema/dao.ts
@@ -61,14 +61,11 @@ class Metrics {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ address: 1, blockNumber: 1, name: 1, creatorAddress: 1, tvlUSD: 1 })
 @index({ isHidden: 1, isActive: 1, 'metrics.tvlUSD': -1 })
 @index({ address: 1, isActive: 1, isHidden: 1 })
 @index({ blockNumber: -1, address: 1, isActive: 1, isHidden: 1 })
-@index({ id: 1 }, { unique: true })
 @index({ address: 1, isActive: 1, network: 1, isHidden: 1 })
-@index({ address: 1, blockNumber: 1, name: 1, creatorAddress: 1, tvlUSD: 1 })
 @index({ address: 1, creatorAddress: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, creatorAddress: 1, isActive: 1, isHidden: 1 })
 @index({ address: 1, transactionHash: 1, isActive: 1, isHidden: 1 })
@@ -80,10 +77,8 @@ class Metrics {
 @index({ network: 1, transactionHash: 1, isActive: 1, isHidden: 1 })
 @index({ address: 1, name: 1, isActive: 1, isHidden: 1 })
 @index({ address: 1, ens: 1, isActive: 1, isHidden: 1 })
-@index({ address: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, isActive: 1, name: 1, isHidden: 1 })
-@index({ isHidden: 1, isActive: 1, 'metrics.tvlUSD': -1 })
 @index({ network: 1 })
 export default class Dao extends Model {
   @prop({ type: () => String, required: true, unique: true })

--- a/src/models/schema/daoPermission.ts
+++ b/src/models/schema/daoPermission.ts
@@ -18,7 +18,6 @@ const customName = ICollectionNames.DaoPermission
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ event: 1, daoAddress: 1, permissionId: 1, whoAddress: 1, whereAddress: 1, type: 1 })
 @index({ permissionId: 1, transactionHash: 1 })
 @index({ network: 1 })

--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -1,4 +1,4 @@
-import { index, modelOptions, prop } from '@typegoose/typegoose'
+import { modelOptions, prop } from '@typegoose/typegoose'
 import {
   HexAddress,
   type ILockIdParams,
@@ -70,7 +70,6 @@ export class LockExit {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 export default class Lock extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string

--- a/src/models/schema/lockManagerMember.ts
+++ b/src/models/schema/lockManagerMember.ts
@@ -28,7 +28,6 @@ const customName = ICollectionNames.LockManagerMember
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ network: 1, pluginAddress: 1, memberAddress: 1 })
 @index({ network: 1, pluginAddress: 1, votingPower: -1 })
 @index({ pluginAddress: 1, memberAddress: 1 })

--- a/src/models/schema/logMetadata.ts
+++ b/src/models/schema/logMetadata.ts
@@ -33,7 +33,6 @@ class Link {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ daoAddress: 1 })
 @index({ network: 1, pluginAddress: 1, blockNumber: -1 })
 export default class LogMetadata extends Model {

--- a/src/models/schema/logPluginSetupProcessor.ts
+++ b/src/models/schema/logPluginSetupProcessor.ts
@@ -41,7 +41,6 @@ class Permission {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ daoAddress: 1, pluginAddress: 1, network: 1, tokenAddress: 1 })
 @index({ network: 1 })
 export default class LogPluginSetupProcessor extends Model {

--- a/src/models/schema/member.ts
+++ b/src/models/schema/member.ts
@@ -31,7 +31,6 @@ const customName = ICollectionNames.Member
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ memberAddress: 1 })
 @index({ address: 1, ens: 1 })
 export default class Member extends Model {

--- a/src/models/schema/memberBalance.ts
+++ b/src/models/schema/memberBalance.ts
@@ -29,7 +29,6 @@ const customName = ICollectionNames.MemberBalance
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ address: 1 })
 @index({ network: 1, tokenAddress: 1, amount: 1 })
 @index({ network: 1, tokenAddress: 1, votingPower: 1 })

--- a/src/models/schema/memberMetrics.ts
+++ b/src/models/schema/memberMetrics.ts
@@ -18,7 +18,6 @@ const customName = ICollectionNames.MemberMetrics
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ address: 1 })
 @index({ address: 1, network: 1, pluginAddress: 1 })
 export default class MemberMetrics extends Model {

--- a/src/models/schema/memberTransaction.ts
+++ b/src/models/schema/memberTransaction.ts
@@ -25,7 +25,6 @@ const customName = ICollectionNames.MemberTransaction
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ address: 1, network: 1, transactionHash: 1, blockNumber: 1, tokenAddress: 1 })
 @index({ blockNumber: -1, id: -1 })
 @index({ tokenAddress: 1 })

--- a/src/models/schema/migration.ts
+++ b/src/models/schema/migration.ts
@@ -19,7 +19,6 @@ const customName = ICollectionNames.Migration
     customName,
   },
 })
-@index({ filename: 1 }, { unique: true })
 @index({ status: 1 })
 @index({ executedAt: -1 })
 export default class Migration extends Model {

--- a/src/models/schema/plugin.ts
+++ b/src/models/schema/plugin.ts
@@ -92,7 +92,6 @@ class Link {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ network: 1, address: 1, daoAddress: 1, tokenAddress: 1 })
 @index({ network: 1, tokenAddress: 1 })
 @index({ network: 1, status: 1, interfaceType: 1 })

--- a/src/models/schema/pluginRepo.ts
+++ b/src/models/schema/pluginRepo.ts
@@ -18,7 +18,6 @@ const customName = ICollectionNames.PluginRepo
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ pluginRepo: 1 })
 export default class PluginRepo extends Model {
   @prop({ type: () => String, required: true, unique: true })

--- a/src/models/schema/selectorPermission.ts
+++ b/src/models/schema/selectorPermission.ts
@@ -1,4 +1,4 @@
-import { index, modelOptions, prop } from '@typegoose/typegoose'
+import { index, modelOptions, prop, Severity } from '@typegoose/typegoose'
 import {
   HexAddress,
   ICollectionNames,
@@ -14,6 +14,7 @@ import ModelUtils from '@models/utils/models'
 
 const customName = ICollectionNames.SelectorPermission
 
+@modelOptions({ schemaOptions: { _id: false }, options: { allowMixed: Severity.ALLOW } })
 export class ActionDecoded {
   @prop({ type: () => String, default: null })
   public functionName!: string | null
@@ -60,7 +61,6 @@ export class Disallowed {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ pluginAddress: 1, daoAddress: 1, conditionAddress: 1 })
 @index({ network: 1, transactionHash: 1 })
 @index({ pluginAddress: 1, selector: 1 })

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -104,7 +104,6 @@ export class Stages {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ pluginAddress: 1, blockNumber: 1 })
 export default class Setting extends Model {
   @prop({ type: () => String, required: true, unique: true })

--- a/src/models/schema/taskRun.ts
+++ b/src/models/schema/taskRun.ts
@@ -1,4 +1,4 @@
-import { index, modelOptions, prop } from '@typegoose/typegoose'
+import { index, modelOptions, prop, Severity } from '@typegoose/typegoose'
 import { Model, type SaveOptions, Schema } from 'mongoose'
 import * as _ from 'lodash'
 import { ICollectionNames, IEnumTaskStatus } from '@types'
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 const customName = ICollectionNames.TaskRun
 
+@modelOptions({ schemaOptions: { _id: false }, options: { allowMixed: Severity.ALLOW } })
 class Task {
   @prop({ type: () => String, required: true })
   public taskName!: string
@@ -47,7 +48,6 @@ class Task {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ serviceName: 1, createdAt: -1 })
 @index({ createdAt: 1 })
 export default class TaskRun extends Model {

--- a/src/models/schema/taskService.ts
+++ b/src/models/schema/taskService.ts
@@ -18,7 +18,6 @@ const customName = ICollectionNames.TaskService
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ serviceName: 1 }, { unique: true }) // Add index for serviceName
 @index({ nextStartAt: 1 }) // Add index for nextStartAt queries
 @index({ lockedUntil: 1 }) // Add index for lock queries

--- a/src/models/schema/token.ts
+++ b/src/models/schema/token.ts
@@ -31,7 +31,6 @@ const customName = ICollectionNames.Token
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ name: -1 })
 @index({ refetch: 1 })
 @index({ address: 1, network: 1 })

--- a/src/models/schema/transaction.ts
+++ b/src/models/schema/transaction.ts
@@ -74,7 +74,6 @@ class Token {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ fromAddress: 1, toAddress: 1, tokenAddress: 1, daoAddress: 1 })
 @index({ id: -1, blockNumber: -1, network: 1, daoAddress: 1 })
 @index({ blockNumber: -1 })

--- a/src/models/schema/vote.ts
+++ b/src/models/schema/vote.ts
@@ -43,7 +43,6 @@ export class VoteCleared {
     customName,
   },
 })
-@index({ id: 1 }, { unique: true })
 @index({ network: 1, blockNumber: 1, daoAddress: 1, pluginAddress: 1, memberAddress: 1 })
 @index({ network: 1, pluginAddress: 1, proposalIndex: 1 })
 @index({ network: 1, pluginAddress: 1, memberAddress: 1, proposalIndex: 1, blockNumber: -1 })


### PR DESCRIPTION
- Remove @index({ id: 1 }) decorators as unique: true in prop creates index automatically
- Remove duplicate compound indexes in dao.ts
- Fix migration.ts filename index duplication
- Add Severity.ALLOW to ActionDecoded and Task classes to suppress Mixed type warnings
- Maintain unique constraints at property level for better MongoDB/Mongoose practices

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📝 Summary

Explain the purpose of these changes and what problem they solve.

**Task:** [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
