### PR TITLE
feat(rabbitmq): increase default timeout for RabbitMQ connection and enhance logging

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -22,7 +22,7 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
 
     RABBITMQ: {
       URI: utils.configParser(sourceConfig, 'string', 'RABBITMQ_URI', 'amqp://guest:guest@rabbitmq:5672'),
-      TIMEOUT: utils.configParser(sourceConfig, 'number', 'RABBITMQ_TIMEOUT', 30000),
+      TIMEOUT: utils.configParser(sourceConfig, 'number', 'RABBITMQ_TIMEOUT', 60000),
       DEFAULT_CONCURRENCY: utils.configParser(sourceConfig, 'number', 'RABBITMQ_DEFAULT_CONCURRENCY', 25),
       CLEAN_QUEUE: utils.configParser(sourceConfig, 'bool', 'RABBITMQ_CLEAN_QUEUE', false),
       RECONNECT_TIME_SECONDS: utils.configParser(sourceConfig, 'number', 'RABBITMQ_RECONNECT_TIME_SECONDS', 5),

--- a/src/helpers/rabbitMQ.ts
+++ b/src/helpers/rabbitMQ.ts
@@ -160,7 +160,7 @@ const RabbitMQHelper = {
     try {
       const response = await new Promise(resolve => {
         const timeoutId = setTimeout(async () => {
-          logger.warn('Timeout waiting for response', { queueName, correlationId })
+          logger.warn('Timeout waiting for response', { queueName, correlationId, payload, opts })
           resolve(null)
         }, opts.timeout || 5000)
         channelWrapper.addSetup(async (channel: ConfirmChannel) => {


### PR DESCRIPTION
## 📝 Summary

This pull request increases the default RabbitMQ timeout and improves logging for timeouts in the RabbitMQ helper. These changes help ensure that longer-running operations have more time to complete and that timeout logs include more context for easier debugging.

**RabbitMQ configuration:**

* Increased the default `RABBITMQ_TIMEOUT` from 30,000ms to 60,000ms in `config/common.ts`, allowing more time for RabbitMQ operations before timing out.

**Logging improvements:**

* Enhanced the timeout warning log in `src/helpers/rabbitMQ.ts` to include `payload` and `opts` for better context when a timeout occurs.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
