### PR TITLE
fix: change logger error to warn for minLockSet event in governanceVe…

### DIFF
--- a/src/handlers/governanceVeHandler.ts
+++ b/src/handlers/governanceVeHandler.ts
@@ -309,7 +309,7 @@ export const GovernanceVeHandler = {
     })
 
     if (plugins.length === 0) {
-      logger.error('Plugin not found for minLockSet event', llo({ info }))
+      logger.warn('Plugin not found for minLockSet event', llo({ info }))
       return
     }
 

--- a/test/unit/handlers/governanceVeHandler.spec.ts
+++ b/test/unit/handlers/governanceVeHandler.spec.ts
@@ -1808,7 +1808,7 @@ describe('Handler:GovernanceVeHandler', () => {
   describe('minLockSet', () => {
     it('should skip if plugin not found', async () => {
       const stubPluginFind = sandbox.stub(Models.Plugin, 'find').resolves([])
-      const stubLogger = sandbox.stub(logger, 'error')
+      const stubLogger = sandbox.stub(logger, 'warn')
       const stubSettingFindActive = sandbox.stub(Models.Setting, 'findActive')
 
       const mockInfo = {


### PR DESCRIPTION
…Handler

## 📝 Summary


This pull request makes a minor change to the logging behavior for the "plugin not found" case in the `GovernanceVeHandler`. The log level for this event is changed from `error` to `warn`, and the corresponding unit test is updated to reflect this change.

Logging updates:

* Changed the log level from `error` to `warn` when no plugin is found for the `minLockSet` event in `governanceVeHandler.ts`.
* Updated the unit test in `governanceVeHandler.spec.ts` to expect a `warn` log instead of `error` for this scenario.

**Task:** [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
