### PR TITLE
fix(proxyToken): set token type and underlying for escrow adapter

### DIFF
--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -114,9 +114,12 @@ export const ProxyToken = {
       network,
     })
 
+    // Set the type from token detection
     if (basicToken && tokenTypeInfo.type === ITokenType.escrowAdapter) {
       basicToken.type = tokenTypeInfo.type
-      basicToken.underlying = wrappedToken
+      if (tokenTypeInfo.type === ITokenType.escrowAdapter) {
+        basicToken.underlying = wrappedToken
+      }
     }
 
     return basicToken


### PR DESCRIPTION
## 📝 Summary

This pull request introduces a small improvement to the `ProxyToken` module. The change ensures that the detected token type is set on the `basicToken` object and that its `underlying` property is assigned when the token is an `escrowAdapter`. This helps maintain accurate token metadata during token detection.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
