### PR TITLE
fix(decodeAction): ensure links and stageNames default to empty arrays

### DIFF
--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -369,10 +369,10 @@ class DecodeActions {
             name: existingMetadata.name,
             description: existingMetadata.description,
             avatar: existingMetadata.avatar,
-            links: existingMetadata.links,
+            links: existingMetadata.links || [],
             logo: existingMetadata.logo,
             processKey: existingMetadata.processKey,
-            stageNames: existingMetadata.stageNames,
+            stageNames: existingMetadata.stageNames || [],
           }
         : {}
 


### PR DESCRIPTION
## 📝 Summary

This pull request makes a small fix to the `DecodeActions` class in `src/helpers/decodeAction.ts`. The change ensures that the `links` and `stageNames` properties are always set to arrays, even if the existing metadata does not provide them. This helps prevent potential errors when these properties are accessed elsewhere in the code.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
