### PR TITLE
fix(member): update tokenAddress handling logic in member retrieval

### DIFF
--- a/src/services/aragon-api/controllers/member.ts
+++ b/src/services/aragon-api/controllers/member.ts
@@ -51,7 +51,7 @@ const MemberController = {
     const member = await Models.Member.findMemberByAddress(address, extraParams)
 
     assertExposable(member, ErrorKeyEnum.notFound)
-    if ((extraParams.tokenAddress || extraParams.pluginAddress) && extraParams.network) {
+    if (extraParams.pluginAddress && extraParams.tokenAddress && extraParams.network) {
       try {
         const balanceInfo = (await RabbitMQHelper.sendMessage(
           EnumQueueName.memberBalance,

--- a/test/unit/services/aragon-api/controllers/member.spec.ts
+++ b/test/unit/services/aragon-api/controllers/member.spec.ts
@@ -540,39 +540,6 @@ describe('Controller: Member', () => {
         ErrorKeyEnum.notFound,
       )
     })
-
-    it('should use pluginAddress as tokenAddress when tokenAddress not provided', async () => {
-      const mockMemberData = {
-        address: rawMember.address,
-        ens: rawMember.ens,
-        avatar: rawMember.avatar,
-        votingPower: null,
-      }
-
-      sandbox.stub(Models.Member, 'findMemberByAddress').resolves(mockMemberData as any)
-      const stubSendMessage = sandbox.stub(RabbitMQHelper, 'sendMessage').resolves({
-        votingPower: '500',
-        balance: '1000',
-        currentDelegate: null,
-      })
-
-      const response = await MemberController.getMemberByAddress(
-        rawMember.address as HexAddress,
-        {
-          daoAddress: rawDao.address,
-          network: rawDao.network,
-          pluginAddress: rawPlugin.address,
-        },
-        {},
-      )
-
-      expect(stubSendMessage.calledOnce).to.be.true
-      expect(stubSendMessage.firstCall.args[1].id).to.equal(
-        `memberBalance-${rawMember.address}-${rawPlugin.address}-${rawDao.network}`,
-      )
-      expect(stubSendMessage.firstCall.args[1].params.tokenAddress).to.be.undefined
-      expect(response.votingPower).to.equal('500')
-    })
   })
 
   describe('isMemberOfPlugin', () => {


### PR DESCRIPTION
## 📝 Summary

This pull request refines the logic for fetching a member's balance information and updates the related unit tests. The most significant change is that the member controller now requires both `pluginAddress` and `tokenAddress` (along with `network`) to fetch balance info, instead of using `pluginAddress` as a fallback for `tokenAddress`. The corresponding unit test for the old fallback behavior has been removed.

### Controller logic update

* Updated the condition in `MemberController.getMemberByAddress` to require that both `pluginAddress` and `tokenAddress` (as well as `network`) are provided before attempting to fetch balance information, preventing the use of `pluginAddress` as a fallback for `tokenAddress`.

### Unit test cleanup

* Removed the unit test that checked for the fallback behavior where `pluginAddress` would be used as `tokenAddress` if the latter was not provided, aligning tests with the new stricter parameter requirements.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
