### PR TITLE
fix(memberController): handle errors in member pagination and return empty response

### DIFF
--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -121,7 +121,7 @@ export class MemberGovernanceFactory {
       // If we reach here, the plugin type is not supported
       throw new Error(`Unsupported plugin interface type: ${plugin.interfaceType}`)
     } catch (error) {
-      logger.error('Unable to create governance from plugin', llo({ plugin, error }))
+      logger.warn('Unable to create governance from plugin', llo({ plugin, error }))
       throw error
     }
   }

--- a/src/services/aragon-api/controllers/member.ts
+++ b/src/services/aragon-api/controllers/member.ts
@@ -17,6 +17,7 @@ import PairDataModule from '@modules/pairData'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import config from '@config'
 import { MemberGovernanceFactory } from '@src/governance'
+import ModelUtils from '@models/utils/models'
 
 const MemberController = {
   getMembersWithPagination: async (
@@ -35,11 +36,15 @@ const MemberController = {
     const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network)
     assertExposable(plugin, ErrorKeyEnum.notFound)
 
-    const governance = MemberGovernanceFactory.createFromPlugin(plugin)
-    return governance.findAndPaginateMembers({
-      paginationParams,
-      extraParams,
-    })
+    try {
+      const governance = MemberGovernanceFactory.createFromPlugin(plugin)
+      return governance.findAndPaginateMembers({
+        paginationParams,
+        extraParams,
+      })
+    } catch (error) {
+      return ModelUtils.paginateEmptyResponse(paginationParams.pageSize!)
+    }
   },
 
   getMemberByAddress: async (


### PR DESCRIPTION
## 📝 Summary

This pull request introduces improved error handling for member pagination in the `MemberController` and refines logging for governance plugin errors. The main changes focus on making the system more robust when encountering unsupported or problematic plugins, ensuring that errors do not cause unhandled exceptions and that responses remain consistent.

**Error handling improvements:**

* In `MemberController.getMembersWithPagination`, added a try-catch block around the creation and use of the governance instance. If an error is thrown (e.g., due to an unsupported plugin), the controller now returns an empty paginated response using `ModelUtils.paginateEmptyResponse` instead of propagating the error.
* Imported `ModelUtils` in `member.ts` to support the new empty pagination response logic.

**Logging refinement:**

* In `MemberGovernanceFactory.createFromPlugin`, changed error logging from `logger.error` to `logger.warn` when unable to create governance from a plugin, reflecting that this situation may be expected in some cases and is not always a critical error.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
