### PR TITLE
feat(plugin): add abandoned status for uninstalled plugins and update…

### DIFF
--- a/src/handlers/pluginSetupProcessorHandler.ts
+++ b/src/handlers/pluginSetupProcessorHandler.ts
@@ -310,7 +310,7 @@ export const PluginSetupProcessorHandler = {
       transactionHash: info.transactionHash,
       transactionIndex: info.transactionIndex,
       logIndex: info.logIndex,
-      permissions: Utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
+      permissions: utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
       sender: parsedEvent.args.sender,
       daoAddress,
       preparedSetupId: parsedEvent.args.preparedSetupId,

--- a/src/handlers/pluginSetupProcessorHandler.ts
+++ b/src/handlers/pluginSetupProcessorHandler.ts
@@ -6,11 +6,11 @@ import {
   type ILogInfo,
   IPluginActionType,
   IPluginInterfaceType,
+  IPluginStatus,
   ISPPLogs,
 } from '@types'
 import { Interface, type LogDescription, type TransactionReceipt } from 'ethers'
 import { Models } from '@dbModels'
-import Utils from '@helpers/utils'
 import Web3Helper from '@helpers/web3'
 import { ProxyToken } from '@modules/proxyToken'
 import { PluginHandler } from '@src/handlers/pluginHandler'
@@ -27,6 +27,8 @@ import Web3Utils from '@helpers/web3Utils'
 import VotingEscrowDetector from '@helpers/votingEscrowDetector'
 import GovernanceVeHelper from '@helpers/governanceVe'
 import LockToVoteHelper from '@helpers/lockToVoteHelper'
+import { PluginSlug } from '@helpers/pluginSlug'
+import utils from '@helpers/utils'
 
 const llo = logger.logMeta.bind(null, { service: 'handlers:pluginSetupProcessorHandler' })
 
@@ -74,7 +76,7 @@ export const PluginSetupProcessorHandler = {
           transactionHash: info.transactionHash,
           transactionIndex: info.transactionIndex,
           logIndex: info.logIndex,
-          permissions: Utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
+          permissions: utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
           sender: parsedEvent.args.sender,
           daoAddress,
           preparedSetupId: parsedEvent.args.preparedSetupId,
@@ -229,7 +231,7 @@ export const PluginSetupProcessorHandler = {
       transactionHash: info.transactionHash,
       transactionIndex: info.transactionIndex,
       logIndex: info.logIndex,
-      permissions: Utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
+      permissions: utils.parsePermissions(parsedEvent.args?.preparedSetupData?.permissions),
       sender: parsedEvent.args.sender,
       daoAddress,
       preparedSetupId: parsedEvent.args.preparedSetupId,
@@ -313,7 +315,7 @@ export const PluginSetupProcessorHandler = {
       daoAddress,
       preparedSetupId: parsedEvent.args.preparedSetupId,
       pluginSetupRepo: parsedEvent.args.pluginSetupRepo,
-      pluginAddress: parsedEvent.args.plugin,
+      pluginAddress: parsedEvent.args.plugin || parsedEvent.args.setupPayload.plugin,
       release: parsedEvent.args.versionTag.release,
       build: parsedEvent.args.versionTag.build,
       blockNumber: info.blockNumber,
@@ -366,6 +368,49 @@ export const PluginSetupProcessorHandler = {
       llo,
     )
     await PluginSetupProcessorHandler.pluginHandler(IPluginActionType.uninstalled, logDb)
+
+    const plugin = await Models.Plugin.findOne({
+      network: logDb.network,
+      daoAddress: logDb.daoAddress,
+      address: logDb.pluginAddress,
+      status: IPluginStatus.uninstalled,
+    })
+
+    if (plugin?.subPlugins?.length) {
+      const addresses = [...new Set(plugin.subPlugins.flatMap(w => w.addresses))]
+
+      await utils.asyncParallel(
+        addresses.map(pluginAddress => async () => {
+          const existingPlugin = await Models.Plugin.findOne({
+            network: info.network,
+            address: pluginAddress,
+          })
+
+          if (!existingPlugin) return // nothing to update
+
+          const uninstalledPlugin = await DbOperations.updateDocument(
+            existingPlugin,
+            {
+              status: IPluginStatus.abandoned,
+              uninstalled: {
+                status: true,
+                transactionHash: plugin.transactionHash,
+                blockNumber: plugin.blockNumber,
+                blockTimestamp: 0,
+              },
+            },
+            { logId: existingPlugin.id },
+            'Uninstall plugin',
+            llo,
+          )
+
+          await PluginSlug.deleteSlug(uninstalledPlugin)
+        }),
+        (error: { message: any }) => {
+          logger.error(`Failed to uninstall subPlugin: ${error.message}`, { error })
+        },
+      )
+    }
   },
 
   findAndUpdateTokenAddress: async (pluginDb: Plugin, info: ILogInfo) => {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -34,6 +34,7 @@ export enum IPluginStatus {
   installed = 'installed',
   deprecated = 'deprecated',
   uninstalled = 'uninstalled',
+  abandoned = 'abandoned',
 }
 
 export enum IPluginSlug {

--- a/test/lib/unit-dep/utils.ts
+++ b/test/lib/unit-dep/utils.ts
@@ -21,6 +21,7 @@ import PluginRepoMockData from '@test/unit-dep/mockData/pluginRepo.json'
 import ProviderModule from '@modules/provider'
 import { ethers } from 'ethers'
 import { LogLockToVote } from '@plugins/logLockToVote'
+
 const UnitDepUtils = {
   getData: async (
     abi: any,
@@ -267,7 +268,14 @@ const UnitDepUtils = {
       fromBlock: fromBlock ?? 0,
       toBlock: 'latest',
       topics: [
-        [configIndexer.filter(config => config.event === 'InstallationPrepared')[0].topic],
+        configIndexer
+          .filter(
+            config =>
+              config.event === 'InstallationPrepared' ||
+              config.event === 'UninstallationPrepared' ||
+              config.event === 'UpdatePrepared',
+          )
+          .map(config => config.topic),
         null,
         [daoAddressFilter],
       ],

--- a/test/unit/handlers/pluginSetupProcessorHandler.spec.ts
+++ b/test/unit/handlers/pluginSetupProcessorHandler.spec.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 import { expect } from 'chai'
 import logger from '@logger'
-import { IEventLogPluginType, ILogInfo, IPluginInterfaceType, NetworksEnum } from '@types'
+import { IEventLogPluginType, ILogInfo, IPluginInterfaceType, IPluginStatus, NetworksEnum } from '@types'
 import { beforeEach } from 'mocha'
 import { PluginSetupProcessorHandler } from '@handlers/pluginSetupProcessorHandler'
 import { Models } from '@dbModels'
@@ -961,6 +961,31 @@ describe('Indexer: PluginSetupProcessorHandler', () => {
         },
       }
 
+      const subPlugin = await Models.Plugin.create({
+        id: 'test-plugin-1',
+        address: '0xsubplugin-1',
+        daoAddress: fakeEvent.args.dao,
+        tokenAddress: '0xTokenAddress',
+        network: logInfo.network,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: 'installed',
+        transactionHash: '0xhash',
+        blockNumber: 1000,
+      })
+
+      const plugin = await Models.Plugin.create({
+        id: 'test-plugin',
+        address: fakeEvent.args.plugin,
+        daoAddress: fakeEvent.args.dao,
+        tokenAddress: '0xTokenAddress',
+        network: logInfo.network,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: 'uninstalled',
+        transactionHash: '0xhash',
+        blockNumber: 1000,
+        subPlugins: [{ addresses: [subPlugin.address] }],
+      })
+
       const loggerStub = sandbox.stub(logger, 'verbose')
       const findTxSpy = sandbox.spy(Models.LogPluginSetupProcessor, 'findExistingLog')
       const stubFindDao = sandbox.stub(Models.Dao, 'findByAddress').resolves(true)
@@ -979,24 +1004,27 @@ describe('Indexer: PluginSetupProcessorHandler', () => {
           event: IEventLogPluginType.UninstallationApplied,
         }),
       ).to.be.true
-      expect(loggerStub.calledOnce).to.be.true
+      expect(loggerStub.calledTwice).to.be.true
 
-      const pluginDb = await Models.LogPluginSetupProcessor.findExistingLog({
+      const logPluginDb = await Models.LogPluginSetupProcessor.findExistingLog({
         network: logInfo.network,
         transactionHash: logInfo.transactionHash,
         transactionIndex: logInfo.transactionIndex,
         logIndex: logInfo.logIndex,
         event: IEventLogPluginType.UninstallationApplied,
       })
-      expect(pluginDb.transactionHash).to.eq(logInfo.transactionHash)
-      expect(pluginDb.blockNumber).to.eq(logInfo.blockNumber)
-      expect(pluginDb.network).to.eq(logInfo.network)
-      expect(pluginDb.event).to.eq(IEventLogPluginType.UninstallationApplied)
-      expect(pluginDb.daoAddress).to.eq(fakeEvent.args.dao)
-      expect(pluginDb.preparedSetupId).to.eq(fakeEvent.args.preparedSetupId)
-      expect(pluginDb.pluginAddress).to.eq(fakeEvent.args.plugin)
+      expect(logPluginDb.transactionHash).to.eq(logInfo.transactionHash)
+      expect(logPluginDb.blockNumber).to.eq(logInfo.blockNumber)
+      expect(logPluginDb.network).to.eq(logInfo.network)
+      expect(logPluginDb.event).to.eq(IEventLogPluginType.UninstallationApplied)
+      expect(logPluginDb.daoAddress).to.eq(fakeEvent.args.dao)
+      expect(logPluginDb.preparedSetupId).to.eq(fakeEvent.args.preparedSetupId)
+      expect(logPluginDb.pluginAddress).to.eq(fakeEvent.args.plugin)
       expect(PluginSetupProcessorHandlerAggLogStub.calledOnce).to.be.true
       expect(PluginSetupProcessorHandlerAggLogStub.calledWith(IPluginActionType.uninstalled)).to.be.true
+
+      const updatedSubPlugin = await subPlugin.reload()
+      expect(updatedSubPlugin.status).to.eq(IPluginStatus.abandoned)
     })
 
     it('dao not found error', async () => {


### PR DESCRIPTION
## 📝 Summary


This pull request introduces enhancements to the plugin uninstallation workflow, specifically improving how sub-plugins are handled when a parent plugin is uninstalled. It also adds a new plugin status, refines utility usage, and updates tests to ensure the new logic is correctly validated.

### Plugin uninstallation and sub-plugin handling

* When a plugin is uninstalled, any sub-plugins associated with it are now marked as `abandoned` and their slugs are deleted. This is done in parallel for efficiency, and error handling is included for failed updates.
* The status `abandoned` is introduced in the `IPluginStatus` enum to represent sub-plugins that are no longer active due to their parent being uninstalled.

### Utility and code consistency improvements

* The code now consistently uses the lowercase `utils` import instead of the uppercase `Utils` for parsing permissions, ensuring uniformity and preventing potential import issues. [[1]](diffhunk://#diff-acaed484cdf12ba121e5719e91053cb6626809929075a9eefb81c4defbfbc493R9-L13) [[2]](diffhunk://#diff-acaed484cdf12ba121e5719e91053cb6626809929075a9eefb81c4defbfbc493R30-R31) [[3]](diffhunk://#diff-acaed484cdf12ba121e5719e91053cb6626809929075a9eefb81c4defbfbc493L77-R79) [[4]](diffhunk://#diff-acaed484cdf12ba121e5719e91053cb6626809929075a9eefb81c4defbfbc493L232-R234)
* The logic for determining `pluginAddress` now falls back to `setupPayload.plugin` if `plugin` is not present, improving robustness.

### Testing enhancements

* Unit tests for the plugin uninstallation flow have been updated to create and verify sub-plugins, ensuring that sub-plugins are correctly marked as `abandoned` when their parent plugin is uninstalled. [[1]](diffhunk://#diff-84decad047f9d3684744c7b5a8c3c229fc49043e7fe28810e698d05af630c17aR964-R988) [[2]](diffhunk://#diff-84decad047f9d3684744c7b5a8c3c229fc49043e7fe28810e698d05af630c17aL982-R1027)

### Indexer and event handling updates

* The event filtering logic in tests now supports multiple plugin-related events (`InstallationPrepared`, `UninstallationPrepared`, `UpdatePrepared`), making the test coverage more comprehensive.

These changes collectively strengthen the plugin management system, especially around sub-plugin lifecycle and status tracking.

**Task:** [APP-0000](https://aragonassociation.atlassian.net/browse/APP-0000)

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
