### PR TITLE
feat(logging): change error logging to warning for token information retrieval failures, happens due to scam token

### DIFF
--- a/src/modules/transfers/transferProcessor.ts
+++ b/src/modules/transfers/transferProcessor.ts
@@ -92,7 +92,7 @@ export abstract class TransferProcessor {
 
     if (!token) {
       logger.warn(
-        'Failed to get token information. Possible Scan Token',
+        'Failed to get token information. Possible Scam Token',
         llo({ tokenAddress, network: data.network, type: data.type }),
       )
       return null

--- a/src/modules/transfers/transferProcessor.ts
+++ b/src/modules/transfers/transferProcessor.ts
@@ -91,7 +91,10 @@ export abstract class TransferProcessor {
     const token = await ProxyToken.saveAndGetToken(tokenAddress, data.network)
 
     if (!token) {
-      logger.error('Failed to get token information', llo({ tokenAddress, network: data.network, type: data.type }))
+      logger.warn(
+        'Failed to get token information. Possible Scan Token',
+        llo({ tokenAddress, network: data.network, type: data.type }),
+      )
       return null
     }
 

--- a/test/unit/modules/transfers/erc20TransferProcessor.spec.ts
+++ b/test/unit/modules/transfers/erc20TransferProcessor.spec.ts
@@ -455,13 +455,13 @@ describe('Transfers: Erc20TransferProcessor', () => {
       }
 
       saveAndGetTokenStub.resolves(null)
-      const errorStub = sandbox.stub(logger, 'error')
+      const warnStub = sandbox.stub(logger, 'warn')
 
       const result = await processor['addTokenMetadata'](data as any)
 
       expect(result).to.be.null
-      expect(errorStub.calledOnce).to.be.true
-      expect(errorStub.firstCall.args[0]).to.include('Failed to get token information')
+      expect(warnStub.calledOnce).to.be.true
+      expect(warnStub.firstCall.args[0]).to.include('Failed to get token information. Possible Scan Token')
     })
   })
 

--- a/test/unit/modules/transfers/erc20TransferProcessor.spec.ts
+++ b/test/unit/modules/transfers/erc20TransferProcessor.spec.ts
@@ -461,7 +461,7 @@ describe('Transfers: Erc20TransferProcessor', () => {
 
       expect(result).to.be.null
       expect(warnStub.calledOnce).to.be.true
-      expect(warnStub.firstCall.args[0]).to.include('Failed to get token information. Possible Scan Token')
+      expect(warnStub.firstCall.args[0]).to.include('Failed to get token information. Possible Scam Token')
     })
   })
 


### PR DESCRIPTION
## 📝 Summary

This pull request updates the handling and logging of missing token information in the transfer processing logic. Specifically, it changes the log level from error to warning and updates the log message to clarify the possible cause. The corresponding unit test is also updated to reflect these changes.

**Logging improvements:**

* Changed the log level from `error` to `warn` and updated the log message to indicate a "Possible Scam Token" when token information cannot be retrieved in `transferProcessor.ts`.

**Test updates:**

* Updated the unit test in `erc20TransferProcessor.spec.ts` to stub and assert the `warn` logger instead of `error`, and to check for the new log message.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
