### PR TITLE
feat(APP-539): remove deprecated fields and update logic for linked accounts

### DIFF
--- a/src/handlers/permissionHandler.ts
+++ b/src/handlers/permissionHandler.ts
@@ -220,11 +220,9 @@ export const PermissionHandler = {
       return
     }
 
-    const parentEffectiveParent = parentAccount.parentAccount ?? parentAccount.parentDao
-    const linkedEffectiveChildren = linkedAccount.linkedAccounts?.length
-      ? linkedAccount.linkedAccounts
-      : linkedAccount.subDaos
-    const linkedEffectiveParent = linkedAccount.parentAccount ?? linkedAccount.parentDao
+    const parentEffectiveParent = parentAccount.parentAccount
+    const linkedEffectiveChildren = linkedAccount.linkedAccounts
+    const linkedEffectiveParent = linkedAccount.parentAccount
 
     // Constraint: A DAO that is already a child cannot become a parent
     if (parentEffectiveParent) {
@@ -283,14 +281,11 @@ export const PermissionHandler = {
    */
   linkDaos: async (parentAccount: Dao, linkedAccount: Dao, network: NetworksEnum) => {
     await DbTx.executeTxFn(async ({ session }) => {
-      const linkedEffectiveParent = linkedAccount.parentAccount ?? linkedAccount.parentDao
-      if (linkedEffectiveParent !== parentAccount.address) {
+      if (linkedAccount.parentAccount !== parentAccount.address) {
         await linkedAccount.update({ parentAccount: parentAccount.address }, { session })
       }
 
-      const currentLinkedAccounts = parentAccount.linkedAccounts?.length
-        ? parentAccount.linkedAccounts
-        : parentAccount.subDaos || []
+      const currentLinkedAccounts = parentAccount.linkedAccounts || []
       if (!currentLinkedAccounts.includes(linkedAccount.address)) {
         const updatedLinkedAccounts = [...new Set([...currentLinkedAccounts, linkedAccount.address])]
         await parentAccount.update({ linkedAccounts: updatedLinkedAccounts }, { session })
@@ -333,9 +328,7 @@ export const PermissionHandler = {
 
     if (!parentAccount || !linkedAccount) return
 
-    // Check if link exists (fallback to legacy field for pre-migration docs)
-    const linkedEffectiveParent = linkedAccount.parentAccount ?? linkedAccount.parentDao
-    if (linkedEffectiveParent !== parentAccountAddress) return
+    if (linkedAccount.parentAccount !== parentAccountAddress) return
 
     // Unlink the DAOs
     await PermissionHandler.unlinkDaos(parentAccount, linkedAccount, network)
@@ -348,9 +341,7 @@ export const PermissionHandler = {
     await DbTx.executeTxFn(async ({ session }) => {
       await linkedAccount.update({ parentAccount: null }, { session })
 
-      const currentLinkedAccounts = parentAccount.linkedAccounts?.length
-        ? parentAccount.linkedAccounts
-        : parentAccount.subDaos || []
+      const currentLinkedAccounts = parentAccount.linkedAccounts || []
       const updatedLinkedAccounts = currentLinkedAccounts.filter((addr: string) => addr !== linkedAccount.address)
       await parentAccount.update({ linkedAccounts: updatedLinkedAccounts }, { session })
 

--- a/src/models/schema/dao.ts
+++ b/src/models/schema/dao.ts
@@ -147,14 +147,6 @@ export default class Dao extends Model {
   @prop({ type: () => [String], default: [] })
   public linkedAccounts?: string[]
 
-  /** @deprecated Legacy field kept for pre-migration backward compat. Remove after migration confirmed. */
-  @prop({ type: () => String })
-  public parentDao?: string | null
-
-  /** @deprecated Legacy field kept for pre-migration backward compat. Remove after migration confirmed. */
-  @prop({ type: () => [String] })
-  public subDaos?: string[]
-
   @prop({ type: () => Metrics, _id: false, default: {} })
   public metrics?: Metrics
 
@@ -282,8 +274,6 @@ export default class Dao extends Model {
       {
         $addFields: {
           creatorAddress: '$$REMOVE',
-          parentAccount: { $ifNull: ['$parentAccount', '$parentDao'] },
-          linkedAccounts: { $ifNull: ['$linkedAccounts', '$subDaos'] },
         },
       },
       {
@@ -292,8 +282,6 @@ export default class Dao extends Model {
           __v: 0,
           isActive: 0,
           isHidden: 0,
-          parentDao: 0,
-          subDaos: 0,
           createdAt: 0,
           updatedAt: 0,
         },
@@ -375,7 +363,7 @@ export default class Dao extends Model {
       {
         $lookup: {
           from: ICollectionNames.Dao,
-          let: { parentAccountId: { $ifNull: ['$parentAccount', '$parentDao'] } },
+          let: { parentAccountId: '$parentAccount' },
           pipeline: [
             {
               $match: {
@@ -413,13 +401,13 @@ export default class Dao extends Model {
       },
       {
         $addFields: {
-          parentAccount: { $arrayElemAt: ['$parentAccount', 0] },
+          parentAccount: { $ifNull: [{ $arrayElemAt: ['$parentAccount', 0] }, null] },
         },
       },
       {
         $lookup: {
           from: ICollectionNames.Dao,
-          let: { linkedAccountIds: { $ifNull: ['$linkedAccounts', { $ifNull: ['$subDaos', []] }] } },
+          let: { linkedAccountIds: { $ifNull: ['$linkedAccounts', []] } },
           pipeline: [
             {
               $match: {

--- a/src/models/utils/aggregation.ts
+++ b/src/models/utils/aggregation.ts
@@ -807,18 +807,13 @@ export const AggregationQueryHelper = {
                 $concatArrays: [
                   ['$$targetDaoAddress'],
                   {
-                    $let: {
-                      vars: { parent: { $ifNull: ['$parentAccount', '$parentDao'] } },
-                      in: {
-                        $cond: {
-                          if: { $ne: ['$$parent', null] },
-                          then: ['$$parent'],
-                          else: [],
-                        },
-                      },
+                    $cond: {
+                      if: { $ne: ['$parentAccount', null] },
+                      then: ['$parentAccount'],
+                      else: [],
                     },
                   },
-                  { $ifNull: ['$linkedAccounts', { $ifNull: ['$subDaos', []] }] },
+                  { $ifNull: ['$linkedAccounts', []] },
                 ],
               },
             },

--- a/src/services/aragon-api/routers/schema/pagination.ts
+++ b/src/services/aragon-api/routers/schema/pagination.ts
@@ -9,7 +9,6 @@ const PaginationSchema = {
     ens: ValidationSchema.joiEns.optional(),
     proposalId: Joi.string().optional(),
     onlyActive: Joi.boolean().optional(),
-    includeSubDaos: Joi.boolean().optional(),
     includeLinkedAccounts: Joi.boolean().optional(),
   }),
 

--- a/src/services/aragon-api/routers/v2/proposal.ts
+++ b/src/services/aragon-api/routers/v2/proposal.ts
@@ -31,8 +31,7 @@ const ProposalRouter = {
       pairParams: {
         daoId: ctx.query.daoId as string,
         onlyActive: Utils.parseBoolean(ctx.query.onlyActive),
-        includeSubDaos: Utils.parseBoolean(ctx.query.includeSubDaos),
-        includeLinkedAccounts: Utils.parseBoolean(ctx.query.includeLinkedAccounts ?? ctx.query.includeSubDaos),
+        includeLinkedAccounts: Utils.parseBoolean(ctx.query.includeLinkedAccounts),
       },
       requireRule: RequireRules.daoIdOrNetworkWithAddress(['daoAddress', 'pluginAddress', 'creatorAddress']),
       schemas: {

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -44,8 +44,6 @@ export interface IPairParams {
   proposalId?: string
   tokenAddress?: HexAddress
   onlyActive?: boolean
-  /** @deprecated Use includeLinkedAccounts. Kept for backward compatibility during rename. */
-  includeSubDaos?: boolean
   includeLinkedAccounts?: boolean
 }
 

--- a/test/unit/models/schema/dao.spec.ts
+++ b/test/unit/models/schema/dao.spec.ts
@@ -737,42 +737,15 @@ describe('Model: Dao', () => {
         expect(result.data[0].address).to.eq('0x2222222222222222222222222222222222222222')
       })
 
-      it('should populate linkedAccounts from legacy subDaos before migration runs', async () => {
-        const legacyDaoAddress = '0x3333333333333333333333333333333333333333'
-        const legacyChildAddress = '0x5555555555555555555555555555555555555555'
-
-        await Models.Dao.collection.insertOne({
-          id: `${NetworksEnum.baseMainnet}-${legacyDaoAddress}`,
-          address: legacyDaoAddress,
-          creatorAddress: '0x6666666666666666666666666666666666666666',
-          network: NetworksEnum.baseMainnet,
-          isActive: true,
-          isHidden: false,
-          name: 'legacy-dao',
-          subDaos: [legacyChildAddress],
-        })
-
-        await Models.Dao.collection.insertOne({
-          id: `${NetworksEnum.baseMainnet}-${legacyChildAddress}`,
-          address: legacyChildAddress,
-          creatorAddress: '0x7777777777777777777777777777777777777777',
-          network: NetworksEnum.baseMainnet,
-          isActive: true,
-          isHidden: false,
-          name: 'legacy-child',
-          subDaos: [],
-        })
-
+      it('should return linkedAccounts in response', async () => {
         const result = await Models.Dao.findWithPaginationWithoutPlugins({
           extraParams: {},
           paginationParams: { page: 1, pageSize: 10 },
-          extraQueryData: { daoAddresses: [legacyDaoAddress] },
+          extraQueryData: { daoAddresses: ['0x1111111111111111111111111111111111111111'] },
         })
 
         expect(result.data).to.have.length(1)
-        expect(result.data[0].linkedAccounts).to.deep.equal([legacyChildAddress])
-        expect(result.data[0]).to.not.have.property('subDaos')
-        expect(result.data[0]).to.not.have.property('parentDao')
+        expect(result.data[0].linkedAccounts).to.deep.equal(['0x2222222222222222222222222222222222222222'])
       })
     })
 
@@ -823,51 +796,17 @@ describe('Model: Dao', () => {
         expect(result.linkedAccounts).to.be.an('array')
       })
 
-      it('should resolve parentAccount and linkedAccounts from legacy fields before migration runs', async () => {
+      it('should return parentAccount and linkedAccounts in response', async () => {
         sandbox.restore()
 
-        const legacyParentAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        const legacyChildAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-
-        await Models.Dao.collection.insertMany([
-          {
-            id: `${NetworksEnum.baseMainnet}-${legacyParentAddress}`,
-            address: legacyParentAddress,
-            creatorAddress: '0xcccccccccccccccccccccccccccccccccccccccc',
-            network: NetworksEnum.baseMainnet,
-            isActive: true,
-            isHidden: false,
-            name: 'legacy-parent',
-            metrics: { tvlUSD: 10 },
-            parentDao: null,
-            subDaos: [legacyChildAddress],
-          },
-          {
-            id: `${NetworksEnum.baseMainnet}-${legacyChildAddress}`,
-            address: legacyChildAddress,
-            creatorAddress: '0xdddddddddddddddddddddddddddddddddddddddd',
-            network: NetworksEnum.baseMainnet,
-            isActive: true,
-            isHidden: false,
-            name: 'legacy-child',
-            metrics: { tvlUSD: 5 },
-            parentDao: legacyParentAddress,
-            subDaos: [],
-          },
-        ])
-
-        const parentResult = await Models.Dao.getDaoDetailsWithoutPlugins(legacyParentAddress, NetworksEnum.baseMainnet)
-        const childResult = await Models.Dao.getDaoDetailsWithoutPlugins(
-          legacyChildAddress,
-          NetworksEnum.baseMainnet,
-          true,
+        const result = await Models.Dao.getDaoDetailsWithoutPlugins(
+          '0x1111111111111111111111111111111111111111',
+          NetworksEnum.polygonMainnet,
         )
 
-        expect(parentResult.linkedAccounts).to.have.length(1)
-        expect(parentResult.linkedAccounts[0].address).to.eq(legacyChildAddress)
-        expect(childResult.parentAccount?.address).to.eq(legacyParentAddress)
-        expect(parentResult).to.not.have.property('subDaos')
-        expect(childResult).to.not.have.property('parentDao')
+        expect(result.linkedAccounts).to.have.length(1)
+        expect(result.linkedAccounts[0].address).to.eq('0x2222222222222222222222222222222222222222')
+        expect(result.parentAccount).to.be.null
       })
 
       it('should aggregate TVL from linkedAccounts', async () => {

--- a/test/unit/modules/dispatchSimulation/addressMapper.spec.ts
+++ b/test/unit/modules/dispatchSimulation/addressMapper.spec.ts
@@ -67,8 +67,8 @@ describe('Module: dispatchSimulation/addressMapper', () => {
       })
     })
 
-    describe('resolve - subDAO addresses', () => {
-      it('should resolve subDAO addresses', () => {
+    describe('resolve - linked account addresses', () => {
+      it('should resolve linked account addresses', () => {
         const dao = {
           address: '0x1111111111111111111111111111111111111111',
           name: 'Main DAO',

--- a/test/unit/services/aragon-api/controllers/plugin.spec.ts
+++ b/test/unit/services/aragon-api/controllers/plugin.spec.ts
@@ -202,7 +202,7 @@ describe('Controller: Plugin', () => {
           },
         },
       ]
-      findByAddressStub.resolves({ address: daoAddress, subDaos: [] })
+      findByAddressStub.resolves({ address: daoAddress, linkedAccounts: [] })
       findByDaoAddressesWithDetailsStub.resolves(mockPlugins)
 
       await PluginController.getPluginsByDaoWithDetails({ daoAddress, network })

--- a/test/unit/services/aragon-api/routers/v2/proposal.spec.ts
+++ b/test/unit/services/aragon-api/routers/v2/proposal.spec.ts
@@ -82,7 +82,6 @@ describe('RouterV2: Proposal', () => {
       expect(stubCtrl.args[0][1]).to.deep.eq(expectedExtraParams)
       expect(stubCtrl.args[0][2]).to.deep.eq({
         onlyActive: true,
-        includeSubDaos: undefined,
         includeLinkedAccounts: undefined,
         daoId: 'ethereum-mainnet-0x0eB63a3565942D16C1c1211bD78F1B3Dcfe1A254',
       })
@@ -139,7 +138,6 @@ describe('RouterV2: Proposal', () => {
       expect(stubCtrl.args[0][2]).to.deep.eq({
         daoId: filterParams.daoId,
         onlyActive: undefined,
-        includeSubDaos: undefined,
         includeLinkedAccounts: undefined,
       })
     })
@@ -190,7 +188,6 @@ describe('RouterV2: Proposal', () => {
       expect(stubCtrl.args[0][2]).to.deep.eq({
         daoId: undefined,
         onlyActive: undefined,
-        includeSubDaos: undefined,
         includeLinkedAccounts: undefined,
       })
     })


### PR DESCRIPTION

## 📝 Summary

This commit removes legacy fields related to subDaos and parentDao from the Dao model, ensuring that linked accounts are now consistently used. The PermissionHandler and related services have been updated to reflect these changes, enhancing clarity and maintainability. Additionally, tests have been adjusted to verify the new structure and ensure backward compatibility.

https://linear.app/aragon/issue/APP-539/4-backend-remove-backward-compat-subdao-param-alias

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
