### PR TITLE
feat(ci): add Slack release notifications (BE-173)

### DIFF
--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -376,28 +376,17 @@ jobs:
           fi
 
           if [[ "$STATUS" == "success" ]]; then
-            MESSAGE="  ✅ Backend Deployment successful!
-            📋 Summary:
-            Environment: $ENVIRONMENT
-            Branch: $BRANCH
-            Deployed by: $ACTOR
-            Details: $RUN_URL"
+            MESSAGE="✅ Backend Deployment successful!\n📋 Summary:\nEnvironment: $ENVIRONMENT\nBranch: $BRANCH\nDeployed by: $ACTOR\nDetails: $RUN_URL"
           else
-            MESSAGE=" ❌ Backend Deployment failed!
-            📋 Summary:
-            Environment: $ENVIRONMENT
-            Branch: $BRANCH
-            Attempted by: $ACTOR
-            Details: $RUN_URL
-            ${MENTION}"
+            MESSAGE="❌ Backend Deployment failed!\n📋 Summary:\nEnvironment: $ENVIRONMENT\nBranch: $BRANCH\nAttempted by: $ACTOR\nDetails: $RUN_URL\n${MENTION}"
+          fi
 
-            curl -X POST \
+          curl -X POST \
             -H 'Content-type: application/json; charset=utf-8' \
             --data "{ \"text\": \"${MESSAGE}\" }" \
             "${SLACK_URL}"
-          fi
 
-          echo ${MESSAGE}
+          echo -e "${MESSAGE}"
 
           
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,14 @@ jobs:
           GPG_PASSPHRASE: op://kv_backend2_infra/arabot-1_SIGN_CERTS/credential
           GPG_PRIVATE_KEY: op://kv_backend2_infra/arabot-1_SIGN_CERTS/private_key
           GITHUB_RELEASE_TOKEN: "op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential"
-      
+          SLACK_BOT_TOKEN: "op://kv_backend2_infra/SLACK_BOT_TOKEN/credential"
+          SLACK_CHANNEL_ID: "op://kv_backend2_infra/SLACK_CHANNEL_ID/credential"
+
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
           token: "${{ steps.op-secrets.outputs.GITHUB_RELEASE_TOKEN }}"
+          fetch-depth: 0
 
       - name: Install Node.js
         uses: actions/setup-node@v5
@@ -34,6 +37,7 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6.3.0
         with:
@@ -41,7 +45,13 @@ jobs:
           passphrase: ${{ steps.op-secrets.outputs.GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
+
+      - name: Generate release summary before semantic-release
+        id: summary
+        run: node .github/workflows/scripts/generateReleaseSummary.js
+
       - name: Run Semantic Release
+        id: semantic
         env:
           GITHUB_TOKEN: "${{ steps.op-secrets.outputs.GITHUB_RELEASE_TOKEN }}"
           GIT_AUTHOR_NAME: "arabot-1"
@@ -52,4 +62,42 @@ jobs:
 
       - name: Get latest release version
         id: get_version
-        run: echo "VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')" >> $GITHUB_ENV
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack - Release Published
+        if: steps.get_version.outputs.version != ''
+        env:
+          SLACK_BOT_TOKEN: "${{ steps.op-secrets.outputs.SLACK_BOT_TOKEN }}"
+          SLACK_CHANNEL_ID: "${{ steps.op-secrets.outputs.SLACK_CHANNEL_ID }}"
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          SUMMARY="${{ steps.summary.outputs.summary }}"
+          RELEASE_URL="https://github.com/aragon/app-backend/releases/tag/${VERSION}"
+
+          MESSAGE=":rocket: *Backend Release ${VERSION}*
+          Release: ${RELEASE_URL}
+
+          ${SUMMARY}"
+
+          node .github/workflows/scripts/slackNotify.js "${MESSAGE}"
+
+      - name: Back-merge main into staging and development
+        env:
+          GITHUB_TOKEN: "${{ steps.op-secrets.outputs.GITHUB_RELEASE_TOKEN }}"
+        run: |
+          git fetch origin staging development
+
+          for branch in staging development; do
+            echo "Back-merging main into $branch..."
+            git checkout "$branch"
+            git merge origin/main --no-edit || {
+              echo "::warning::Merge conflict back-merging main into $branch. Please resolve manually."
+              git merge --abort
+              continue
+            }
+            git push origin "$branch"
+            echo "Successfully back-merged main into $branch"
+          done

--- a/.github/workflows/scripts/generateReleaseSummary.js
+++ b/.github/workflows/scripts/generateReleaseSummary.js
@@ -1,0 +1,93 @@
+const { execSync } = require('node:child_process')
+const fs = require('node:fs')
+
+const runGit = command => {
+  try {
+    return execSync(command).toString().trim()
+  } catch (error) {
+    console.error(`Failed to run git command: ${command}`, error)
+    return ''
+  }
+}
+
+const generateSummary = async ({ core }) => {
+  const previousTag = runGit('git tag --list "v*" --sort=-v:refname | head -n 1')
+  const range = previousTag ? `${previousTag}..HEAD` : 'HEAD'
+  console.log(`Generating release summary for range: ${range}`)
+
+  const log = runGit(`git log ${range} --pretty=format:"%s"`)
+  const lines = log.split('\n').filter(Boolean)
+
+  const categories = {
+    features: [],
+    fixes: [],
+    others: [],
+  }
+
+  for (const line of lines) {
+    const lower = line.toLowerCase()
+
+    // Skip release commits and merge commits
+    if (lower.startsWith('chore(release)') || lower.startsWith('merge')) {
+      continue
+    }
+
+    let category = 'others'
+    if (lower.startsWith('feat')) {
+      category = 'features'
+    } else if (lower.startsWith('fix')) {
+      category = 'fixes'
+    } else if (lower.startsWith('perf')) {
+      category = 'features'
+    }
+
+    // Clean conventional commit prefix
+    let cleanLine = line.replace(/^(feat|fix|chore|docs|style|refactor|perf|test)(\(.*\))?:\s*/, '').trim()
+
+    // Linkify PR numbers (#123 -> [#123](url))
+    cleanLine = cleanLine.replace(/\(#(\d+)\)/g, '([#$1](https://github.com/aragon/app-backend/pull/$1))')
+
+    if (cleanLine) {
+      categories[category].push(cleanLine)
+    }
+  }
+
+  let summary = ''
+
+  if (categories.features.length > 0) {
+    summary += '## Features\n'
+    categories.features.forEach(item => (summary += `- ${item}\n`))
+    summary += '\n'
+  }
+
+  if (categories.fixes.length > 0) {
+    summary += '## Fixes\n'
+    categories.fixes.forEach(item => (summary += `- ${item}\n`))
+    summary += '\n'
+  }
+
+  if (categories.others.length > 0) {
+    summary += '## Other Changes\n'
+    categories.others.forEach(item => (summary += `- ${item}\n`))
+    summary += '\n'
+  }
+
+  if (!summary) {
+    summary = 'No significant changes detected.'
+  }
+
+  core.setOutput('summary', summary)
+  console.log('Release summary generated:\n' + summary)
+}
+
+if (require.main === module) {
+  const core = {
+    setOutput: (name, value) => {
+      const outputFile = process.env.GITHUB_OUTPUT
+      if (outputFile) {
+        fs.appendFileSync(outputFile, `${name}<<EOF\n${value}\nEOF\n`)
+      }
+    },
+  }
+  generateSummary({ core })
+}

--- a/.github/workflows/scripts/slackNotify.js
+++ b/.github/workflows/scripts/slackNotify.js
@@ -1,0 +1,86 @@
+const https = require('node:https')
+const fs = require('node:fs')
+
+const markdownToMrkdwn = text => {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<$2|$1>')
+    .replace(/^#{1,6}\s+(.+)$/gm, '*$1*')
+    .replace(/^-\s+/gm, '• ')
+}
+
+const postMessage = (token, channel, text, threadTs) =>
+  new Promise((resolve, reject) => {
+    const payload = { channel, text }
+    if (threadTs) {
+      payload.thread_ts = threadTs
+    }
+
+    const data = JSON.stringify(payload)
+
+    const options = {
+      hostname: 'slack.com',
+      port: 443,
+      path: '/api/chat.postMessage',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'Content-Length': Buffer.byteLength(data),
+      },
+    }
+
+    const req = https.request(options, res => {
+      let body = ''
+      res.on('data', chunk => (body += chunk))
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try {
+            const parsed = JSON.parse(body)
+            if (parsed.ok) {
+              resolve(parsed.ts)
+            } else {
+              reject(new Error(`Slack API error: ${parsed.error}`))
+            }
+          } catch (e) {
+            reject(new Error('Failed to parse Slack response', e))
+          }
+        } else {
+          reject(new Error(`Slack request failed: ${res.statusCode}`))
+        }
+      })
+    })
+
+    req.on('error', e => reject(e))
+    req.write(data)
+    req.end()
+  })
+
+if (require.main === module) {
+  const token = process.env.SLACK_BOT_TOKEN
+  const channel = process.env.SLACK_CHANNEL_ID
+  const threadTs = process.env.SLACK_THREAD_TS
+  const message = process.argv[2]
+
+  if (!(token && channel)) {
+    console.log('Skipping Slack notification: Missing token or channel.')
+    process.exit(0)
+  }
+
+  if (!message) {
+    console.error('Missing message argument.')
+    process.exit(1)
+  }
+
+  postMessage(token, channel, markdownToMrkdwn(message), threadTs)
+    .then(ts => {
+      console.log(`Message sent. TS: ${ts}`)
+      const outputFile = process.env.GITHUB_OUTPUT
+      if (outputFile) {
+        fs.appendFileSync(outputFile, `ts=${ts}\n`)
+      }
+    })
+    .catch(err => {
+      console.error('Failed to send Slack message:', err)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary
- Add Slack release notifications similar to the `app` repo's release bot
- Fix deploy notifications (was only sending on failure, now sends on success too)
- Add auto back-merge of main into staging/development after each release

## Changes
- **`generateReleaseSummary.js`** — parses git log, categorizes commits (Features/Fixes/Others), linkifies PR numbers
- **`slackNotify.js`** — sends formatted messages to Slack via Bot API
- **`release.yml`** — generates summary, sends to Slack, back-merges main
- **`app-deploy-docker.yml`** — fix: send Slack on success too (not just failure)

## Prerequisites
DevOps needs to add to 1Password vault `kv_backend2_infra`:
- `SLACK_BOT_TOKEN`
- `SLACK_CHANNEL_ID`

## Test plan
- [ ] CI passes
- [ ] Verify Slack secrets are configured
- [ ] Verify notification on next release