### PR TITLE
feat(BE-183): optimize real-time indexer for high-volume VE event batches

### DIFF
--- a/src/handlers/capitalDistributorHandler.ts
+++ b/src/handlers/capitalDistributorHandler.ts
@@ -459,7 +459,6 @@ export const CapitalDistributorHandler = {
         }
       }
 
-      // Campaign updates — batch $inc claimCount + sequential totalClaimed (few campaigns, BigInt string)
       if (campaignUpdates.size > 0) {
         const campaignIds: string[] = []
         const campaignOps: any[] = []

--- a/src/handlers/capitalDistributorHandler.ts
+++ b/src/handlers/capitalDistributorHandler.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import MetadataRefetchHelper from '@helpers/metadataRefetch'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import DbTx from '@modules/dbTx'
@@ -348,5 +349,158 @@ export const CapitalDistributorHandler = {
     )
 
     await campaign?.update({ ended: true })
+  },
+
+  payoutClaimedBatch: async (events: Array<{ parsedEvent: LogDescription; info: ILogInfo }>) => {
+    if (events.length === 0) return
+
+    try {
+      const startTime = Date.now()
+      const network = events[0].info.network
+
+      // Validate plugins
+      const pluginAddresses = [...new Set(events.map(e => e.info.address))]
+      const plugins = await Models.Plugin.find({ address: { $in: pluginAddresses }, network }).lean()
+      if (!plugins || plugins.length === 0) return
+      const validPlugins = new Set(plugins.map((p: any) => p.address))
+
+      const validEvents = events.filter(({ info }) => validPlugins.has(info.address))
+      if (validEvents.length === 0) return
+
+      // Batch fetch timestamps
+      const blockNumbers = validEvents.map(e => e.info.blockNumber)
+      const from = Math.min(...blockNumbers)
+      const to = Math.max(...blockNumbers)
+      const rawTimestamps = await Web3BatchHelper.getBlocksTimestamps(from, to, network)
+      const timestamps = new Map<number, number>()
+      for (const [key, ts] of Object.entries(rawTimestamps)) {
+        timestamps.set(Number(key.split('-').pop()), ts)
+      }
+
+      // Build reward upsert ops (create if not exists) + push claims in one bulkWrite
+      const rewardOps: any[] = []
+      // Track per-campaign claim counts and amounts for campaign updates
+      const campaignUpdates = new Map<string, { address: string; claimCount: number; totalClaimed: bigint }>()
+
+      for (const { parsedEvent, info } of validEvents) {
+        const { campaignId, recipient, amount } = parsedEvent.args
+        const cid = campaignId.toString()
+        const rewardId = `${network}-${info.address}-${cid}-${recipient}`
+        const blockTimestamp = timestamps.get(info.blockNumber) || 0
+
+        // Upsert reward + push claim, skip if claim with same txHash already exists
+        rewardOps.push({
+          updateOne: {
+            filter: { id: rewardId, 'claims.transactionHash': { $ne: info.transactionHash } },
+            update: {
+              $setOnInsert: {
+                id: rewardId,
+                pluginAddress: info.address,
+                network,
+                campaignId: cid,
+                userAddress: recipient,
+                amount: amount.toString(),
+              },
+              $push: {
+                claims: {
+                  claimedAmount: amount.toString(),
+                  transactionHash: info.transactionHash,
+                  blockNumber: info.blockNumber,
+                  blockTimestamp,
+                },
+              },
+            },
+            upsert: true,
+          },
+        })
+
+        // Accumulate campaign updates
+        const campaignKey = `${info.address}-${cid}`
+        if (!campaignUpdates.has(campaignKey)) {
+          campaignUpdates.set(campaignKey, { address: info.address, claimCount: 0, totalClaimed: 0n })
+        }
+        const cu = campaignUpdates.get(campaignKey)!
+        cu.claimCount++
+        cu.totalClaimed += amount
+      }
+
+      // Execute reward upserts ($push claims + $setOnInsert for new rewards)
+      if (rewardOps.length > 0) {
+        await Models.CampaignReward.bulkWrite(rewardOps, { ordered: false })
+
+        // Recalculate totalClaimed per reward from claims array
+        // Group claim amounts by rewardId to avoid re-fetching
+        const claimsByReward = new Map<string, bigint>()
+        for (const { parsedEvent, info } of validEvents) {
+          const rewardId = `${network}-${info.address}-${parsedEvent.args.campaignId.toString()}-${parsedEvent.args.recipient}`
+          claimsByReward.set(rewardId, (claimsByReward.get(rewardId) || 0n) + parsedEvent.args.amount)
+        }
+
+        // Batch fetch current totalClaimed and update
+        const rewardIds = [...claimsByReward.keys()]
+        const existingRewards = await Models.CampaignReward.find(
+          { id: { $in: rewardIds } },
+          { id: 1, totalClaimed: 1 },
+        ).lean()
+
+        const rewardUpdateOps = existingRewards.map((r: any) => {
+          const currentTotal = BigInt(r.totalClaimed || '0')
+          const added = claimsByReward.get(r.id) || 0n
+          return {
+            updateOne: {
+              filter: { id: r.id },
+              update: { $set: { totalClaimed: (currentTotal + added).toString() } },
+            },
+          }
+        })
+
+        if (rewardUpdateOps.length > 0) {
+          await Models.CampaignReward.bulkWrite(rewardUpdateOps, { ordered: false })
+        }
+      }
+
+      // Campaign updates — batch $inc claimCount + sequential totalClaimed (few campaigns, BigInt string)
+      if (campaignUpdates.size > 0) {
+        const campaignIds: string[] = []
+        const campaignOps: any[] = []
+
+        for (const [campaignKey, { address, claimCount }] of campaignUpdates) {
+          const cid = campaignKey.substring(address.length + 1)
+          campaignIds.push(cid)
+          campaignOps.push({
+            updateOne: {
+              filter: { pluginAddress: address, network, campaignId: cid },
+              update: { $inc: { claimCount } },
+            },
+          })
+        }
+        await Models.Campaign.bulkWrite(campaignOps, { ordered: false })
+
+        // totalClaimed — read current, add batch amount, write back (few campaigns)
+        for (const [campaignKey, { address, totalClaimed }] of campaignUpdates) {
+          const cid = campaignKey.substring(address.length + 1)
+          const campaign = await Models.Campaign.findCampaignById(address, network, cid)
+          if (campaign) {
+            const currentTotal = BigInt(campaign.totalClaimed || '0')
+            campaign.totalClaimed = (currentTotal + totalClaimed).toString()
+            await campaign.save()
+          }
+        }
+      }
+
+      const blocks = validEvents.map(e => e.info.blockNumber)
+      logger.info(
+        'PayoutClaimedBatch processed',
+        llo({
+          count: validEvents.length,
+          duration: `${Date.now() - startTime}ms`,
+          fromBlock: Math.min(...blocks),
+          toBlock: Math.max(...blocks),
+        }),
+      )
+    } catch (error) {
+      logger.error('PayoutClaimedBatch - error', llo({ error, eventCount: events.length }))
+      throw error
+    }
   },
 }

--- a/src/handlers/capitalDistributorHandler.ts
+++ b/src/handlers/capitalDistributorHandler.ts
@@ -358,143 +358,105 @@ export const CapitalDistributorHandler = {
       const startTime = Date.now()
       const network = events[0].info.network
 
-      // Validate plugins
+      // 1. Filter to events with valid plugins
       const pluginAddresses = [...new Set(events.map(e => e.info.address))]
       const plugins = await Models.Plugin.find({ address: { $in: pluginAddresses }, network }).lean()
       if (!plugins || plugins.length === 0) return
       const validPlugins = new Set(plugins.map((p: any) => p.address))
-
       const validEvents = events.filter(({ info }) => validPlugins.has(info.address))
       if (validEvents.length === 0) return
 
-      // Batch fetch timestamps
+      // 2. Fetch block timestamps
       const blockNumbers = validEvents.map(e => e.info.blockNumber)
-      const from = Math.min(...blockNumbers)
-      const to = Math.max(...blockNumbers)
-      const rawTimestamps = await Web3BatchHelper.getBlocksTimestamps(from, to, network)
+      const rawTimestamps = await Web3BatchHelper.getBlocksTimestamps(
+        Math.min(...blockNumbers),
+        Math.max(...blockNumbers),
+        network,
+      )
       const timestamps = new Map<number, number>()
       for (const [key, ts] of Object.entries(rawTimestamps)) {
         timestamps.set(Number(key.split('-').pop()), ts)
       }
 
-      // Build reward upsert ops (create if not exists) + push claims in one bulkWrite
-      const rewardOps: any[] = []
-      // Track per-campaign claim counts and amounts for campaign updates
-      const campaignUpdates = new Map<string, { address: string; claimCount: number; totalClaimed: bigint }>()
-
-      for (const { parsedEvent, info } of validEvents) {
+      // 3. Upsert rewards with claims (dedup via $addToSet)
+      const rewardOps = validEvents.map(({ parsedEvent, info }) => {
         const { campaignId, recipient, amount } = parsedEvent.args
-        const cid = campaignId.toString()
-        const rewardId = `${network}-${info.address}-${cid}-${recipient}`
-        const blockTimestamp = timestamps.get(info.blockNumber) || 0
-
-        // Upsert reward + push claim, skip if claim with same txHash already exists
-        rewardOps.push({
+        const rewardId = `${network}-${info.address}-${campaignId}-${recipient}`
+        return {
           updateOne: {
-            filter: { id: rewardId, 'claims.transactionHash': { $ne: info.transactionHash } },
+            filter: { id: rewardId },
             update: {
               $setOnInsert: {
                 id: rewardId,
                 pluginAddress: info.address,
                 network,
-                campaignId: cid,
+                campaignId: campaignId.toString(),
                 userAddress: recipient,
                 amount: amount.toString(),
               },
-              $push: {
+              $addToSet: {
                 claims: {
                   claimedAmount: amount.toString(),
                   transactionHash: info.transactionHash,
                   blockNumber: info.blockNumber,
-                  blockTimestamp,
+                  blockTimestamp: timestamps.get(info.blockNumber) || 0,
                 },
               },
             },
             upsert: true,
           },
-        })
-
-        // Accumulate campaign updates
-        const campaignKey = `${info.address}-${cid}`
-        if (!campaignUpdates.has(campaignKey)) {
-          campaignUpdates.set(campaignKey, { address: info.address, claimCount: 0, totalClaimed: 0n })
         }
-        const cu = campaignUpdates.get(campaignKey)!
+      })
+      await Models.CampaignReward.bulkWrite(rewardOps, { ordered: false })
+
+      // 4. Recalculate reward totalClaimed from actual claims in DB
+      const rewardIds = [...new Set(rewardOps.map(op => op.updateOne.filter.id))]
+      const rewards = await Models.CampaignReward.find({ id: { $in: rewardIds } }, { id: 1, claims: 1 }).lean()
+      const rewardUpdateOps = rewards.map((r: any) => {
+        const total = (r.claims || []).reduce((sum: bigint, c: any) => sum + BigInt(c.claimedAmount || '0'), 0n)
+        return { updateOne: { filter: { id: r.id }, update: { $set: { totalClaimed: total.toString() } } } }
+      })
+      if (rewardUpdateOps.length > 0) {
+        await Models.CampaignReward.bulkWrite(rewardUpdateOps, { ordered: false })
+      }
+
+      // 5. Update campaign claimCount + totalClaimed
+      const campaignClaims = new Map<string, { address: string; claimCount: number; totalClaimed: bigint }>()
+      for (const { parsedEvent, info } of validEvents) {
+        const key = `${info.address}-${parsedEvent.args.campaignId}`
+        const cu = campaignClaims.get(key) || { address: info.address, claimCount: 0, totalClaimed: 0n }
         cu.claimCount++
-        cu.totalClaimed += amount
+        cu.totalClaimed += parsedEvent.args.amount
+        campaignClaims.set(key, cu)
       }
 
-      // Execute reward upserts ($push claims + $setOnInsert for new rewards)
-      if (rewardOps.length > 0) {
-        await Models.CampaignReward.bulkWrite(rewardOps, { ordered: false })
-
-        // Recalculate totalClaimed per reward from claims array
-        // Group claim amounts by rewardId to avoid re-fetching
-        const claimsByReward = new Map<string, bigint>()
-        for (const { parsedEvent, info } of validEvents) {
-          const rewardId = `${network}-${info.address}-${parsedEvent.args.campaignId.toString()}-${parsedEvent.args.recipient}`
-          claimsByReward.set(rewardId, (claimsByReward.get(rewardId) || 0n) + parsedEvent.args.amount)
-        }
-
-        // Batch fetch current totalClaimed and update
-        const rewardIds = [...claimsByReward.keys()]
-        const existingRewards = await Models.CampaignReward.find(
-          { id: { $in: rewardIds } },
-          { id: 1, totalClaimed: 1 },
-        ).lean()
-
-        const rewardUpdateOps = existingRewards.map((r: any) => {
-          const currentTotal = BigInt(r.totalClaimed || '0')
-          const added = claimsByReward.get(r.id) || 0n
-          return {
-            updateOne: {
-              filter: { id: r.id },
-              update: { $set: { totalClaimed: (currentTotal + added).toString() } },
-            },
-          }
-        })
-
-        if (rewardUpdateOps.length > 0) {
-          await Models.CampaignReward.bulkWrite(rewardUpdateOps, { ordered: false })
-        }
-      }
-
-      if (campaignUpdates.size > 0) {
-        const campaignIds: string[] = []
-        const campaignOps: any[] = []
-
-        for (const [campaignKey, { address, claimCount }] of campaignUpdates) {
-          const cid = campaignKey.substring(address.length + 1)
-          campaignIds.push(cid)
-          campaignOps.push({
-            updateOne: {
-              filter: { pluginAddress: address, network, campaignId: cid },
-              update: { $inc: { claimCount } },
-            },
-          })
-        }
+      const campaignOps = [...campaignClaims.entries()].map(([key, { address, claimCount }]) => ({
+        updateOne: {
+          filter: { pluginAddress: address, network, campaignId: key.substring(address.length + 1) },
+          update: { $inc: { claimCount } },
+        },
+      }))
+      if (campaignOps.length > 0) {
         await Models.Campaign.bulkWrite(campaignOps, { ordered: false })
+      }
 
-        // totalClaimed — read current, add batch amount, write back (few campaigns)
-        for (const [campaignKey, { address, totalClaimed }] of campaignUpdates) {
-          const cid = campaignKey.substring(address.length + 1)
-          const campaign = await Models.Campaign.findCampaignById(address, network, cid)
-          if (campaign) {
-            const currentTotal = BigInt(campaign.totalClaimed || '0')
-            campaign.totalClaimed = (currentTotal + totalClaimed).toString()
-            await campaign.save()
-          }
+      for (const [key, { address, totalClaimed }] of campaignClaims) {
+        const cid = key.substring(address.length + 1)
+        const campaign = await Models.Campaign.findCampaignById(address, network, cid)
+        if (campaign) {
+          const currentTotal = BigInt(campaign.totalClaimed || '0')
+          campaign.totalClaimed = (currentTotal + totalClaimed).toString()
+          await campaign.save()
         }
       }
 
-      const blocks = validEvents.map(e => e.info.blockNumber)
       logger.info(
         'PayoutClaimedBatch processed',
         llo({
           count: validEvents.length,
           duration: `${Date.now() - startTime}ms`,
-          fromBlock: Math.min(...blocks),
-          toBlock: Math.max(...blocks),
+          fromBlock: Math.min(...blockNumbers),
+          toBlock: Math.max(...blockNumbers),
         }),
       )
     } catch (error) {

--- a/src/handlers/gaugeHandler.ts
+++ b/src/handlers/gaugeHandler.ts
@@ -27,7 +27,7 @@ export const GaugeHandler = {
       ])
 
       if (!plugin) {
-        logger.warn('plugin not found in gaugeCreated', llo({ info, parsedEvent }))
+        logger.warn('plugin not found in gaugeCreated', llo({ info, parsedEvent: parsedEvent.args }))
         return
       }
 
@@ -164,7 +164,7 @@ export const GaugeHandler = {
       pluginAddress: info.address,
     })
     if (!gauge) {
-      logger.warn('No gauge found gaugeVoted', llo({ info, parsedEvent }))
+      logger.warn('No gauge found gaugeVoted', llo({ info, args: parsedEvent.args }))
       return
     }
 
@@ -188,7 +188,7 @@ export const GaugeHandler = {
         transactionIndex: info.transactionIndex,
         logIndex: info.logIndex,
         blockNumber: info.blockNumber,
-        blockTimestamp: (await Web3Helper.getBlockTimestamp(info.blockNumber, info.network)) || undefined,
+        blockTimestamp: (await info.context!.getBlockTimestamp(info.blockNumber)) || undefined,
         gaugeAddress: gauge.address,
         pluginAddress: gauge.pluginAddress,
         memberAddress: parsedEvent.args.voter,
@@ -233,7 +233,7 @@ export const GaugeHandler = {
       pluginAddress: info.address,
     })
     if (!gauge) {
-      logger.warn('No gauge found gaugeReset', llo({ info, parsedEvent }))
+      logger.warn('No gauge found gaugeReset', llo({ info, parsedEvent: parsedEvent.args }))
       return
     }
 
@@ -252,7 +252,7 @@ export const GaugeHandler = {
       const plugin = await gauge.getPlugin()
       const settings = await plugin.getActiveSettings()
 
-      const blockTimestamp = (await Web3Helper.getBlockTimestamp(info.blockNumber, info.network)) || undefined
+      const blockTimestamp = (await info.context!.getBlockTimestamp(info.blockNumber)) || undefined
 
       await Models.VoteGauge.create({
         network: info.network,

--- a/src/handlers/gaugeHandler.ts
+++ b/src/handlers/gaugeHandler.ts
@@ -1,6 +1,5 @@
 import { Models } from '@dbModels'
 import MetadataRefetchHelper from '@helpers/metadataRefetch'
-import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import type VoteGauge from '@models/schema/voteGauge'

--- a/src/handlers/governanceErc20Handler.ts
+++ b/src/handlers/governanceErc20Handler.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import utils from '@helpers/utils'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import logger from '@logger'
 import type Plugin from '@models/schema/plugin'
 import { ProxyToken } from '@modules/proxyToken'
@@ -319,13 +320,82 @@ export const GovernanceErc20Handler = {
         fromDelegate: parsedEvent.args.fromDelegate,
         toDelegate: parsedEvent.args.toDelegate,
         blockNumber: info.blockNumber,
-        blockTimestamp: await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
+        blockTimestamp: await info.context!.getBlockTimestamp(info.blockNumber),
         transactionHash: info.transactionHash,
         transactionIndex: info.transactionIndex,
         logIndex: info.logIndex,
       })
     } catch (error) {
       logger.error('DelegateChanged - error', llo({ error, parsedEvent, info }))
+    }
+  },
+
+  delegateChangedBatch: async (events: Array<{ parsedEvent: LogDescription; info: ILogInfo }>) => {
+    if (events.length === 0) return
+
+    try {
+      const startTime = Date.now()
+      const network = events[0].info.network
+
+      const tokenAddresses = [...new Set(events.map(e => e.info.address))]
+      const plugins = await Models.Plugin.find({ tokenAddress: { $in: tokenAddresses }, network }).lean()
+      if (!plugins || plugins.length === 0) return
+      const validTokens = new Set(plugins.map((p: any) => p.tokenAddress))
+
+      // Batch fetch timestamps
+      const blockNumbers = events.map(e => e.info.blockNumber)
+      const from = Math.min(...blockNumbers)
+      const to = Math.max(...blockNumbers)
+      const rawTimestamps = await Web3BatchHelper.getBlocksTimestamps(from, to, network)
+      const timestamps = new Map<number, number>()
+      for (const [key, ts] of Object.entries(rawTimestamps)) {
+        timestamps.set(Number(key.split('-').pop()), ts)
+      }
+
+      const ops = events
+        .filter(({ info }) => validTokens.has(info.address))
+        .map(({ parsedEvent, info }) => {
+          const id = `${info.network}-${info.transactionHash}-${info.transactionIndex}-${info.logIndex}`
+          return {
+            updateOne: {
+              filter: { id },
+              update: {
+                $setOnInsert: {
+                  id,
+                  tokenAddress: info.address,
+                  network: info.network,
+                  delegator: parsedEvent.args.delegator,
+                  fromDelegate: parsedEvent.args.fromDelegate,
+                  toDelegate: parsedEvent.args.toDelegate,
+                  blockNumber: info.blockNumber,
+                  blockTimestamp: timestamps.get(info.blockNumber) || 0,
+                  transactionHash: info.transactionHash,
+                  transactionIndex: info.transactionIndex,
+                  logIndex: info.logIndex,
+                },
+              },
+              upsert: true,
+            },
+          }
+        })
+
+      if (ops.length > 0) {
+        await Models.LogDelegateChanged.bulkWrite(ops, { ordered: false })
+      }
+
+      const blocks = events.map(e => e.info.blockNumber)
+      logger.info(
+        'DelegateChangedBatch processed',
+        llo({
+          count: ops.length,
+          duration: `${Date.now() - startTime}ms`,
+          fromBlock: Math.min(...blocks),
+          toBlock: Math.max(...blocks),
+        }),
+      )
+    } catch (error) {
+      logger.error('DelegateChangedBatch - error', llo({ error, eventCount: events.length }))
+      throw error
     }
   },
 }

--- a/src/handlers/governanceErc20Handler.ts
+++ b/src/handlers/governanceErc20Handler.ts
@@ -1,6 +1,5 @@
 import { Models } from '@dbModels'
 import utils from '@helpers/utils'
-import Web3Helper from '@helpers/web3'
 import Web3BatchHelper from '@helpers/web3BatchHelper'
 import logger from '@logger'
 import type Plugin from '@models/schema/plugin'

--- a/src/handlers/governanceVeBatchHandler.ts
+++ b/src/handlers/governanceVeBatchHandler.ts
@@ -119,28 +119,37 @@ export class VeBatchProcessor {
   }
 
   async createMembers(): Promise<this> {
-    const members = new Set<string>()
-    for (const { eventName, parsed } of this.events) {
-      const addr = parsed.args.depositor || parsed.args.sender || parsed.args._sender || parsed.args.holder
-      if (addr) members.add(addr)
-      if (eventName === 'TokensDelegated') members.add(parsed.args.delegatee)
-    }
-    if (members.size === 0) return this
+    const memberBlocks = new Map<string, { min: number; max: number }>()
 
-    const maxBlock = Math.max(...this.events.map(e => e.info.blockNumber))
-    const ops = [...members].map(addr => {
+    const track = (addr: string, blockNumber: number) => {
       const address = ethers.getAddress(addr)
-      return {
-        updateOne: {
-          filter: { id: address },
-          update: {
-            $setOnInsert: { id: address, address, firstActivity: maxBlock },
-            $max: { lastActivity: maxBlock },
-          },
-          upsert: true,
-        },
+      const existing = memberBlocks.get(address)
+      if (!existing) {
+        memberBlocks.set(address, { min: blockNumber, max: blockNumber })
+      } else {
+        existing.min = Math.min(existing.min, blockNumber)
+        existing.max = Math.max(existing.max, blockNumber)
       }
-    })
+    }
+
+    for (const { eventName, parsed, info } of this.events) {
+      const addr = parsed.args.depositor || parsed.args.sender || parsed.args._sender || parsed.args.holder
+      if (addr) track(addr, info.blockNumber)
+      if (eventName === 'TokensDelegated') track(parsed.args.delegatee, info.blockNumber)
+    }
+
+    if (memberBlocks.size === 0) return this
+
+    const ops = [...memberBlocks.entries()].map(([address, blocks]) => ({
+      updateOne: {
+        filter: { id: address },
+        update: {
+          $setOnInsert: { id: address, address, firstActivity: blocks.min },
+          $max: { lastActivity: blocks.max },
+        },
+        upsert: true,
+      },
+    }))
     await this.chunkedBulkWrite(Models.Member, ops)
     return this
   }
@@ -520,7 +529,7 @@ export class VeBatchProcessor {
         network: info.network,
         interfaceType: IPluginInterfaceType.tokenVoting,
         tokenType: ITokenType.escrowAdapter,
-        extraParams: { escrowAdapterAddress: info.address },
+        extraParams: { escrowAdapterAddress: plugins[0].tokenAddress },
       })
       await gov.updateDaoMetrics()
     }

--- a/src/handlers/governanceVeBatchHandler.ts
+++ b/src/handlers/governanceVeBatchHandler.ts
@@ -56,10 +56,6 @@ interface PluginMaps {
   tokenMap: Map<string, Plugin[]>
 }
 
-// ---------------------------------------------------------------------------
-// VeBatchProcessor
-// ---------------------------------------------------------------------------
-
 export class VeBatchProcessor {
   private readonly network: NetworksEnum
   private readonly tickCtx: TickContext
@@ -69,8 +65,6 @@ export class VeBatchProcessor {
     this.network = network
     this.tickCtx = tickCtx
   }
-
-  // -- Setup ----------------------------------------------------------------
 
   parseLogs(logs: Log[]): this {
     for (const log of logs) {
@@ -153,8 +147,6 @@ export class VeBatchProcessor {
     await this.chunkedBulkWrite(Models.Member, ops)
     return this
   }
-
-  // -- Bulk Operations ------------------------------------------------------
 
   async processDeposits(): Promise<void> {
     const events = this.byEvent('Deposit')
@@ -273,7 +265,6 @@ export class VeBatchProcessor {
     const events = this.byEvent(action === 'delegate' ? 'TokensDelegated' : 'TokensUndelegated')
     if (events.length === 0) return
 
-    // Pre-fetch all block timestamps in parallel
     const blockNumbers = [...new Set(events.map(e => e.info.blockNumber))]
     const timestamps = new Map<number, number>()
     await Promise.all(blockNumbers.map(async bn => timestamps.set(bn, await this.tickCtx.getBlockTimestamp(bn))))
@@ -385,7 +376,6 @@ export class VeBatchProcessor {
     const events = this.byEvent('Merged')
     if (events.length === 0) return
 
-    // Batch fetch all fromLock amounts in one query
     const fromTokenIds = events.map(e => e.parsed.args._from.toString())
     const fromLocks = await Models.Lock.find({
       network: this.network,
@@ -437,7 +427,6 @@ export class VeBatchProcessor {
   }
 
   async processMetrics(): Promise<void> {
-    // Collect unique member:plugin pairs with their max blockNumber
     const metricsMap = new Map<string, { member: string; plugin: Plugin; blockNumber: number }>()
 
     for (const { parsed, info, plugins, eventName } of this.events) {
@@ -461,7 +450,6 @@ export class VeBatchProcessor {
 
     if (metricsMap.size === 0) return
 
-    // Bulk upsert PluginMetrics — no proposal/vote counting needed for VE events
     const ops = [...metricsMap.values()].map(({ member, plugin, blockNumber }) => {
       const id = `${this.network}-${member}-${plugin.address}`
       return {
@@ -486,8 +474,6 @@ export class VeBatchProcessor {
 
     await this.chunkedBulkWrite(Models.PluginMetrics, ops)
   }
-
-  // -- Helpers --------------------------------------------------------------
 
   private static readonly BULK_CHUNK_SIZE = 500
 
@@ -584,10 +570,6 @@ export class VeBatchProcessor {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Public API (used by PoolingCrawler)
-// ---------------------------------------------------------------------------
-
 export const GovernanceVeBatchHandler = {
   async processVeEventsBatch(logs: Log[], network: NetworksEnum): Promise<void> {
     if (logs.length === 0) return
@@ -605,8 +587,6 @@ export const GovernanceVeBatchHandler = {
       await processor.resolvePlugins()
       await processor.createMembers()
 
-      // Order matters: deposit creates locks, delegation references them,
-      // split/merge mutate them, exit/withdraw finalize them
       const timings: Record<string, number> = {}
       const time = async (name: string, fn: () => Promise<void>) => {
         const t = Date.now()

--- a/src/handlers/governanceVeBatchHandler.ts
+++ b/src/handlers/governanceVeBatchHandler.ts
@@ -1,0 +1,626 @@
+import { ExitQueue } from '@artifacts/ExitQueue'
+import { VotingEscrow } from '@artifacts/VotingEscrow'
+import { VotingEscrowIncreasing } from '@artifacts/VotingEscrowIncreasing'
+import { Models } from '@dbModels'
+import logger from '@logger'
+import type Plugin from '@models/schema/plugin'
+import { TickContext } from '@modules/crawlers/tickContext'
+import { MemberGovernanceFactory } from '@src/governance'
+import { type HexAddress, type ILogInfo, IPluginInterfaceType, ITokenType, type NetworksEnum } from '@types'
+import { ethers, Interface, type Log, type LogDescription } from 'ethers'
+
+const llo = logger.logMeta.bind(null, { service: 'handlers:GovernanceVeBatch' })
+
+// ---------------------------------------------------------------------------
+// Topic Registration
+// ---------------------------------------------------------------------------
+
+const veIncreasingInterface = new Interface(VotingEscrowIncreasing.abi)
+const exitQueueInterface = new Interface(ExitQueue.abi)
+const votingEscrowInterface = new Interface(VotingEscrow.abi)
+
+const veTopicMap = new Map<string, { eventName: string; iface: Interface }>()
+
+const registerTopics = (events: string[], iface: Interface) => {
+  for (const eventName of events) {
+    const topic = iface.getEvent(eventName)?.topicHash
+    if (topic) veTopicMap.set(topic, { eventName, iface })
+  }
+}
+
+registerTopics(['Deposit', 'Withdraw', 'Split', 'Merged'], veIncreasingInterface)
+registerTopics(['ExitQueuedV2'], exitQueueInterface)
+registerTopics(['TokensDelegated', 'TokensUndelegated'], votingEscrowInterface)
+
+export const VE_TOPICS = new Set(veTopicMap.keys())
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const ESCROW_EVENTS = new Set(['Deposit', 'Withdraw', 'Split', 'Merged'])
+const EXIT_QUEUE_EVENTS = new Set(['ExitQueuedV2'])
+const TOKEN_EVENTS = new Set(['TokensDelegated', 'TokensUndelegated'])
+
+interface VeEvent {
+  log: Log
+  eventName: string
+  parsed: LogDescription
+  info: ILogInfo
+  plugins: Plugin[]
+}
+
+interface PluginMaps {
+  escrowMap: Map<string, Plugin[]>
+  exitQueueMap: Map<string, Plugin[]>
+  tokenMap: Map<string, Plugin[]>
+}
+
+// ---------------------------------------------------------------------------
+// VeBatchProcessor
+// ---------------------------------------------------------------------------
+
+export class VeBatchProcessor {
+  private readonly network: NetworksEnum
+  private readonly tickCtx: TickContext
+  private events: VeEvent[] = []
+
+  constructor(network: NetworksEnum, tickCtx: TickContext) {
+    this.network = network
+    this.tickCtx = tickCtx
+  }
+
+  // -- Setup ----------------------------------------------------------------
+
+  parseLogs(logs: Log[]): this {
+    for (const log of logs) {
+      const topicInfo = veTopicMap.get(log.topics[0])
+      if (!topicInfo) continue
+      try {
+        const parsed = topicInfo.iface.parseLog({ topics: log.topics as string[], data: log.data })
+        if (!parsed) continue
+        this.events.push({
+          log,
+          eventName: topicInfo.eventName,
+          parsed,
+          plugins: [],
+          info: {
+            network: this.network,
+            blockNumber: log.blockNumber,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.index ?? (log as any).logIndex,
+            transactionHash: log.transactionHash as HexAddress,
+            address: ethers.getAddress(log.address) as HexAddress,
+            eventName: topicInfo.eventName,
+            context: this.tickCtx,
+          },
+        })
+      } catch (_) {}
+    }
+    return this
+  }
+
+  async resolvePlugins(): Promise<this> {
+    const maps = await this.fetchPluginMaps()
+
+    this.events = this.events.filter(e => {
+      const map = ESCROW_EVENTS.has(e.eventName)
+        ? maps.escrowMap
+        : EXIT_QUEUE_EVENTS.has(e.eventName)
+          ? maps.exitQueueMap
+          : maps.tokenMap
+      const plugins = map.get(e.info.address)
+      if (!plugins?.length) return false
+      e.plugins = plugins
+      return true
+    })
+
+    return this
+  }
+
+  async createMembers(): Promise<this> {
+    const members = new Set<string>()
+    for (const { eventName, parsed } of this.events) {
+      const addr = parsed.args.depositor || parsed.args.sender || parsed.args._sender || parsed.args.holder
+      if (addr) members.add(addr)
+      if (eventName === 'TokensDelegated') members.add(parsed.args.delegatee)
+    }
+    if (members.size === 0) return this
+
+    const maxBlock = Math.max(...this.events.map(e => e.info.blockNumber))
+    const ops = [...members].map(addr => {
+      const address = ethers.getAddress(addr)
+      return {
+        updateOne: {
+          filter: { id: address },
+          update: {
+            $setOnInsert: { id: address, address, firstActivity: maxBlock },
+            $max: { lastActivity: maxBlock },
+          },
+          upsert: true,
+        },
+      }
+    })
+    await this.chunkedBulkWrite(Models.Member, ops)
+    return this
+  }
+
+  // -- Bulk Operations ------------------------------------------------------
+
+  async processDeposits(): Promise<void> {
+    const events = this.byEvent('Deposit')
+    if (events.length === 0) return
+
+    const delegationByTx = this.buildDelegationLookup()
+    const lockOps: any[] = []
+    const delegateOps: any[] = []
+
+    for (const { parsed, info, plugins } of events) {
+      const member = parsed.args.depositor
+      const tokenId = parsed.args.tokenId.toString()
+      const { nftLockAddress, exitQueueAddress } = plugins[0].votingEscrow!
+      const tokenAddress = plugins[0].tokenAddress
+      const id = `${info.network}-${info.transactionHash}-${info.transactionIndex}-${info.logIndex}-${tokenAddress}-${info.address}-${member}-${tokenId}`
+
+      lockOps.push({
+        updateOne: {
+          filter: { id },
+          update: {
+            $setOnInsert: {
+              id,
+              network: info.network,
+              escrowAddress: info.address,
+              transactionHash: info.transactionHash,
+              transactionIndex: info.transactionIndex,
+              logIndex: info.logIndex,
+              blockNumber: info.blockNumber,
+              memberAddress: member,
+              nftAddress: nftLockAddress,
+              tokenAddress,
+              exitQueueAddress,
+              tokenId,
+              amount: parsed.args.value.toString(),
+              epochStartAt: Number(parsed.args.startTs),
+              totalLocked: parsed.args.newTotalLocked.toString(),
+            },
+          },
+          upsert: true,
+        },
+      })
+
+      const delegatee = delegationByTx.get(info.transactionHash)?.get(tokenId)
+      if (delegatee) {
+        delegateOps.push({
+          updateOne: {
+            filter: { network: info.network, tokenAddress, tokenId },
+            update: { $set: { delegateReceiverAddress: delegatee } },
+          },
+        })
+      }
+    }
+
+    await this.chunkedBulkWrite(Models.Lock, lockOps)
+    if (delegateOps.length > 0) await this.chunkedBulkWrite(Models.Lock, delegateOps)
+  }
+
+  async processWithdraws(): Promise<void> {
+    const events = this.byEvent('Withdraw')
+    if (events.length === 0) return
+
+    const ops = events.map(({ parsed, info }) => ({
+      updateOne: {
+        filter: { escrowAddress: info.address, network: info.network, tokenId: parsed.args.tokenId.toString() },
+        update: {
+          $set: {
+            memberAddress: parsed.args.depositor,
+            delegateReceiverAddress: null,
+            lockWithdraw: {
+              status: true,
+              transactionHash: info.transactionHash,
+              blockNumber: info.blockNumber,
+              totalLocked: parsed.args.newTotalLocked.toString(),
+              amount: parsed.args.value.toString(),
+              epochEndAt: Number(parsed.args.ts),
+            },
+          },
+        },
+      },
+    }))
+
+    await this.chunkedBulkWrite(Models.Lock, ops)
+  }
+
+  async processExitQueued(): Promise<void> {
+    const events = this.byEvent('ExitQueuedV2')
+    if (events.length === 0) return
+
+    const ops = events.map(({ parsed, info }) => {
+      const exitDateAt =
+        parsed.args.exitDate || parsed.args.queuedAt ? Number(parsed.args.exitDate || parsed.args.queuedAt) : null
+      return {
+        updateOne: {
+          filter: { exitQueueAddress: info.address, network: info.network, tokenId: parsed.args.tokenId.toString() },
+          update: {
+            $set: {
+              memberAddress: parsed.args.holder,
+              lockExit: {
+                status: true,
+                transactionHash: info.transactionHash,
+                blockNumber: info.blockNumber,
+                exitDateAt,
+                holder: parsed.args.holder,
+                tokenId: parsed.args.tokenId.toString(),
+              },
+            },
+          },
+        },
+      }
+    })
+
+    await this.chunkedBulkWrite(Models.Lock, ops)
+  }
+
+  async processDelegations(action: 'delegate' | 'undelegate'): Promise<void> {
+    const events = this.byEvent(action === 'delegate' ? 'TokensDelegated' : 'TokensUndelegated')
+    if (events.length === 0) return
+
+    // Pre-fetch all block timestamps in parallel
+    const blockNumbers = [...new Set(events.map(e => e.info.blockNumber))]
+    const timestamps = new Map<number, number>()
+    await Promise.all(blockNumbers.map(async bn => timestamps.set(bn, await this.tickCtx.getBlockTimestamp(bn))))
+
+    const delegationOps: any[] = []
+    const lockOps: any[] = []
+    const isDelegating = action === 'delegate'
+
+    for (const { parsed, info } of events) {
+      const from = parsed.args.sender
+      const to = parsed.args.delegatee
+      const tokenIds = parsed.args.tokenIds.map((id: any) => id.toString())
+      const id = `${info.network}-${info.transactionHash}-${info.transactionIndex}-${info.logIndex}`
+
+      delegationOps.push({
+        updateOne: {
+          filter: { id },
+          update: {
+            $setOnInsert: {
+              id,
+              network: info.network,
+              contractAddress: info.address,
+              delegator: from,
+              delegate: to,
+              tokenIds,
+              action,
+              blockNumber: info.blockNumber,
+              blockTimestamp: timestamps.get(info.blockNumber),
+              transactionHash: info.transactionHash,
+              transactionIndex: info.transactionIndex,
+              logIndex: info.logIndex,
+            },
+          },
+          upsert: true,
+        },
+      })
+
+      lockOps.push({
+        updateMany: {
+          filter: { network: info.network, tokenAddress: info.address, tokenId: { $in: tokenIds } },
+          update: { $set: { delegateReceiverAddress: isDelegating ? to : null } },
+        },
+      })
+    }
+
+    await this.chunkedBulkWrite(Models.TokenDelegation, delegationOps)
+    if (lockOps.length > 0) await this.chunkedBulkWrite(Models.Lock, lockOps)
+  }
+
+  async processSplits(): Promise<void> {
+    for (const { parsed, info, plugins } of this.byEvent('Split')) {
+      const sender = parsed.args._sender
+      const fromTokenId = parsed.args._from.toString()
+      const newTokenId = parsed.args.newTokenId.toString()
+      const { nftLockAddress, exitQueueAddress } = plugins[0].votingEscrow!
+
+      const original = await Models.Lock.findOne({
+        network: info.network,
+        escrowAddress: info.address,
+        tokenId: fromTokenId,
+      })
+      if (!original) {
+        logger.warn('Lock not found for split', llo({ fromTokenId, info }))
+        continue
+      }
+
+      const id = `${info.network}-${info.transactionHash}-${info.transactionIndex}-${info.logIndex}-${plugins[0].tokenAddress}-${info.address}-${sender}-${newTokenId}`
+
+      await Models.Lock.bulkWrite(
+        [
+          {
+            updateOne: {
+              filter: { id },
+              update: {
+                $setOnInsert: {
+                  id,
+                  network: info.network,
+                  escrowAddress: info.address,
+                  transactionHash: info.transactionHash,
+                  transactionIndex: info.transactionIndex,
+                  logIndex: info.logIndex,
+                  blockNumber: info.blockNumber,
+                  memberAddress: sender,
+                  nftAddress: nftLockAddress,
+                  tokenAddress: plugins[0].tokenAddress,
+                  exitQueueAddress,
+                  tokenId: newTokenId,
+                  amount: parsed.args._splitAmount2.toString(),
+                  epochStartAt: original.epochStartAt,
+                  splitFromTokenId: fromTokenId,
+                },
+              },
+              upsert: true,
+            },
+          },
+          {
+            updateOne: {
+              filter: { network: info.network, escrowAddress: info.address, tokenId: fromTokenId },
+              update: { $set: { memberAddress: sender, amount: parsed.args._splitAmount1.toString() } },
+            },
+          },
+        ],
+        { ordered: true },
+      )
+    }
+  }
+
+  async processMerges(): Promise<void> {
+    const events = this.byEvent('Merged')
+    if (events.length === 0) return
+
+    // Batch fetch all fromLock amounts in one query
+    const fromTokenIds = events.map(e => e.parsed.args._from.toString())
+    const fromLocks = await Models.Lock.find({
+      network: this.network,
+      tokenId: { $in: fromTokenIds },
+    }).lean()
+    const lockAmountMap = new Map<string, string>()
+    for (const lock of fromLocks) lockAmountMap.set(lock.tokenId, lock.amount)
+
+    const ops: any[] = []
+    for (const { parsed, info } of events) {
+      const sender = parsed.args._sender
+      const fromTokenId = parsed.args._from.toString()
+      const toTokenId = parsed.args._to.toString()
+      const fromAmount = lockAmountMap.get(fromTokenId)
+
+      if (!fromAmount) {
+        logger.warn('Lock not found for merge', llo({ fromTokenId, info }))
+        continue
+      }
+
+      ops.push(
+        {
+          updateOne: {
+            filter: { network: info.network, escrowAddress: info.address, tokenId: fromTokenId },
+            update: {
+              $set: {
+                memberAddress: sender,
+                amount: '0',
+                lockWithdraw: {
+                  status: true,
+                  transactionHash: info.transactionHash,
+                  blockNumber: info.blockNumber,
+                  amount: fromAmount,
+                },
+              },
+            },
+          },
+        },
+        {
+          updateOne: {
+            filter: { network: info.network, escrowAddress: info.address, tokenId: toTokenId },
+            update: { $set: { memberAddress: sender, amount: parsed.args._newTotalAmount.toString() } },
+          },
+        },
+      )
+    }
+
+    await this.chunkedBulkWrite(Models.Lock, ops)
+  }
+
+  async processMetrics(): Promise<void> {
+    // Collect unique member:plugin pairs with their max blockNumber
+    const metricsMap = new Map<string, { member: string; plugin: Plugin; blockNumber: number }>()
+
+    for (const { parsed, info, plugins, eventName } of this.events) {
+      const addMetric = (member: string) => {
+        const addr = ethers.getAddress(member)
+        for (const plugin of plugins) {
+          const key = `${addr}:${plugin.address}`
+          const existing = metricsMap.get(key)
+          if (!existing || info.blockNumber > existing.blockNumber) {
+            metricsMap.set(key, { member: addr, plugin, blockNumber: info.blockNumber })
+          }
+        }
+      }
+
+      const member = parsed.args.depositor || parsed.args._sender || parsed.args.sender || parsed.args.holder
+      if (member) addMetric(member)
+      if (eventName === 'TokensDelegated' && parsed.args.sender !== parsed.args.delegatee) {
+        addMetric(parsed.args.delegatee)
+      }
+    }
+
+    if (metricsMap.size === 0) return
+
+    // Bulk upsert PluginMetrics — no proposal/vote counting needed for VE events
+    const ops = [...metricsMap.values()].map(({ member, plugin, blockNumber }) => {
+      const id = `${this.network}-${member}-${plugin.address}`
+      return {
+        updateOne: {
+          filter: { id },
+          update: {
+            $setOnInsert: {
+              id,
+              network: this.network,
+              memberAddress: member,
+              pluginAddress: plugin.address,
+              daoAddress: plugin.daoAddress,
+              proposalCount: 0,
+              voteCount: 0,
+            },
+            $max: { lastActivity: blockNumber },
+          },
+          upsert: true,
+        },
+      }
+    })
+
+    await this.chunkedBulkWrite(Models.PluginMetrics, ops)
+  }
+
+  // -- Helpers --------------------------------------------------------------
+
+  private static readonly BULK_CHUNK_SIZE = 500
+
+  private async chunkedBulkWrite(model: any, ops: any[], ordered = false): Promise<void> {
+    if (ops.length === 0) return
+    if (ops.length <= VeBatchProcessor.BULK_CHUNK_SIZE) {
+      await model.bulkWrite(ops, { ordered })
+      return
+    }
+    for (let i = 0; i < ops.length; i += VeBatchProcessor.BULK_CHUNK_SIZE) {
+      const chunk = ops.slice(i, i + VeBatchProcessor.BULK_CHUNK_SIZE)
+      await model.bulkWrite(chunk, { ordered })
+    }
+  }
+
+  private byEvent(...names: string[]): VeEvent[] {
+    return this.events.filter(e => names.includes(e.eventName))
+  }
+
+  private buildDelegationLookup(): Map<string, Map<string, string>> {
+    const lookup = new Map<string, Map<string, string>>()
+    for (const e of this.byEvent('TokensDelegated')) {
+      const tokenIds = e.parsed.args.tokenIds.map((id: any) => id.toString())
+      if (!lookup.has(e.info.transactionHash)) lookup.set(e.info.transactionHash, new Map())
+      const txMap = lookup.get(e.info.transactionHash)!
+      for (const tid of tokenIds) txMap.set(tid, e.parsed.args.delegatee)
+    }
+    return lookup
+  }
+
+  async updateDaoMetrics(): Promise<void> {
+    const seen = new Set<string>()
+    for (const { info, plugins } of this.events) {
+      const escrow = plugins[0].votingEscrow?.escrowAddress
+      if (!escrow || seen.has(escrow)) continue
+      seen.add(escrow)
+      const gov = MemberGovernanceFactory.create({
+        address: escrow,
+        network: info.network,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenType: ITokenType.escrowAdapter,
+        extraParams: { escrowAdapterAddress: info.address },
+      })
+      await gov.updateDaoMetrics()
+    }
+  }
+
+  private async fetchPluginMaps(): Promise<PluginMaps> {
+    const escrowAddrs = new Set<string>()
+    const exitQueueAddrs = new Set<string>()
+    const tokenAddrs = new Set<string>()
+
+    for (const { eventName, info } of this.events) {
+      if (ESCROW_EVENTS.has(eventName)) escrowAddrs.add(info.address)
+      else if (EXIT_QUEUE_EVENTS.has(eventName)) exitQueueAddrs.add(info.address)
+      else if (TOKEN_EVENTS.has(eventName)) tokenAddrs.add(info.address)
+    }
+
+    const [byEscrow, byExitQueue, byToken] = await Promise.all([
+      escrowAddrs.size > 0
+        ? Models.Plugin.find({ 'votingEscrow.escrowAddress': { $in: [...escrowAddrs] }, network: this.network }).lean()
+        : [],
+      exitQueueAddrs.size > 0
+        ? Models.Plugin.find({
+            'votingEscrow.exitQueueAddress': { $in: [...exitQueueAddrs] },
+            network: this.network,
+          }).lean()
+        : [],
+      tokenAddrs.size > 0
+        ? Models.Plugin.find({
+            tokenAddress: { $in: [...tokenAddrs] },
+            network: this.network,
+            interfaceType: { $in: [IPluginInterfaceType.tokenVoting, IPluginInterfaceType.gauge] },
+          }).lean()
+        : [],
+    ])
+
+    const toMap = (items: any[], keyFn: (p: any) => string | undefined) => {
+      const map = new Map<string, Plugin[]>()
+      for (const p of items) {
+        const key = keyFn(p)
+        if (!key) continue
+        if (!map.has(key)) map.set(key, [])
+        map.get(key)!.push(p as Plugin)
+      }
+      return map
+    }
+
+    return {
+      escrowMap: toMap(byEscrow, p => p.votingEscrow?.escrowAddress),
+      exitQueueMap: toMap(byExitQueue, p => p.votingEscrow?.exitQueueAddress),
+      tokenMap: toMap(byToken, p => p.tokenAddress),
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API (used by PoolingCrawler)
+// ---------------------------------------------------------------------------
+
+export const GovernanceVeBatchHandler = {
+  async processVeEventsBatch(logs: Log[], network: NetworksEnum): Promise<void> {
+    if (logs.length === 0) return
+
+    logs.sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex || a.index - b.index)
+
+    const tickCtx = new TickContext(network, logs)
+    await tickCtx.init()
+
+    try {
+      const startTime = Date.now()
+      const processor = new VeBatchProcessor(network, tickCtx)
+
+      processor.parseLogs(logs)
+      await processor.resolvePlugins()
+      await processor.createMembers()
+
+      // Order matters: deposit creates locks, delegation references them,
+      // split/merge mutate them, exit/withdraw finalize them
+      const timings: Record<string, number> = {}
+      const time = async (name: string, fn: () => Promise<void>) => {
+        const t = Date.now()
+        await fn()
+        timings[name] = Date.now() - t
+      }
+
+      await time('deposits', () => processor.processDeposits())
+      await time('delegations', () => processor.processDelegations('delegate'))
+      await time('undelegations', () => processor.processDelegations('undelegate'))
+      await time('splits', () => processor.processSplits())
+      await time('merges', () => processor.processMerges())
+      await time('exitQueued', () => processor.processExitQueued())
+      await time('withdraws', () => processor.processWithdraws())
+      await time('metrics', () => processor.processMetrics())
+      await time('daoMetrics', () => processor.updateDaoMetrics())
+
+      logger.info(
+        'VeBatch processed',
+        llo({ network, total: logs.length, duration: `${Date.now() - startTime}ms`, timings }),
+      )
+    } finally {
+      tickCtx.clear()
+    }
+  },
+}

--- a/src/handlers/governanceVeBatchHandler.ts
+++ b/src/handlers/governanceVeBatchHandler.ts
@@ -61,6 +61,10 @@ export class VeBatchProcessor {
   private readonly tickCtx: TickContext
   private events: VeEvent[] = []
 
+  get eventCount(): number {
+    return this.events.length
+  }
+
   constructor(network: NetworksEnum, tickCtx: TickContext) {
     this.network = network
     this.tickCtx = tickCtx
@@ -315,17 +319,29 @@ export class VeBatchProcessor {
   }
 
   async processSplits(): Promise<void> {
-    for (const { parsed, info, plugins } of this.byEvent('Split')) {
+    const events = this.byEvent('Split')
+    if (events.length === 0) return
+
+    const fromTokenIds = events.map(e => e.parsed.args._from.toString())
+    const escrowAddresses = [...new Set(events.map(e => e.info.address))]
+    const fromLocks = await Models.Lock.find({
+      network: this.network,
+      escrowAddress: { $in: escrowAddresses },
+      tokenId: { $in: fromTokenIds },
+    }).lean()
+    const lockMap = new Map<string, { epochStartAt: number }>()
+    fromLocks.forEach((lock: any) =>
+      lockMap.set(`${lock.escrowAddress}:${lock.tokenId}`, { epochStartAt: lock.epochStartAt }),
+    )
+
+    const ops: any[] = []
+    for (const { parsed, info, plugins } of events) {
       const sender = parsed.args._sender
       const fromTokenId = parsed.args._from.toString()
       const newTokenId = parsed.args.newTokenId.toString()
       const { nftLockAddress, exitQueueAddress } = plugins[0].votingEscrow!
 
-      const original = await Models.Lock.findOne({
-        network: info.network,
-        escrowAddress: info.address,
-        tokenId: fromTokenId,
-      })
+      const original = lockMap.get(`${info.address}:${fromTokenId}`)
       if (!original) {
         logger.warn('Lock not found for split', llo({ fromTokenId, info }))
         continue
@@ -333,43 +349,42 @@ export class VeBatchProcessor {
 
       const id = `${info.network}-${info.transactionHash}-${info.transactionIndex}-${info.logIndex}-${plugins[0].tokenAddress}-${info.address}-${sender}-${newTokenId}`
 
-      await Models.Lock.bulkWrite(
-        [
-          {
-            updateOne: {
-              filter: { id },
-              update: {
-                $setOnInsert: {
-                  id,
-                  network: info.network,
-                  escrowAddress: info.address,
-                  transactionHash: info.transactionHash,
-                  transactionIndex: info.transactionIndex,
-                  logIndex: info.logIndex,
-                  blockNumber: info.blockNumber,
-                  memberAddress: sender,
-                  nftAddress: nftLockAddress,
-                  tokenAddress: plugins[0].tokenAddress,
-                  exitQueueAddress,
-                  tokenId: newTokenId,
-                  amount: parsed.args._splitAmount2.toString(),
-                  epochStartAt: original.epochStartAt,
-                  splitFromTokenId: fromTokenId,
-                },
+      ops.push(
+        {
+          updateOne: {
+            filter: { id },
+            update: {
+              $setOnInsert: {
+                id,
+                network: info.network,
+                escrowAddress: info.address,
+                transactionHash: info.transactionHash,
+                transactionIndex: info.transactionIndex,
+                logIndex: info.logIndex,
+                blockNumber: info.blockNumber,
+                memberAddress: sender,
+                nftAddress: nftLockAddress,
+                tokenAddress: plugins[0].tokenAddress,
+                exitQueueAddress,
+                tokenId: newTokenId,
+                amount: parsed.args._splitAmount2.toString(),
+                epochStartAt: original.epochStartAt,
+                splitFromTokenId: fromTokenId,
               },
-              upsert: true,
             },
+            upsert: true,
           },
-          {
-            updateOne: {
-              filter: { network: info.network, escrowAddress: info.address, tokenId: fromTokenId },
-              update: { $set: { memberAddress: sender, amount: parsed.args._splitAmount1.toString() } },
-            },
+        },
+        {
+          updateOne: {
+            filter: { network: info.network, escrowAddress: info.address, tokenId: fromTokenId },
+            update: { $set: { memberAddress: sender, amount: parsed.args._splitAmount1.toString() } },
           },
-        ],
-        { ordered: true },
+        },
       )
     }
+
+    await this.chunkedBulkWrite(Models.Lock, ops)
   }
 
   async processMerges(): Promise<void> {
@@ -377,19 +392,21 @@ export class VeBatchProcessor {
     if (events.length === 0) return
 
     const fromTokenIds = events.map(e => e.parsed.args._from.toString())
+    const escrowAddresses = [...new Set(events.map(e => e.info.address))]
     const fromLocks = await Models.Lock.find({
       network: this.network,
+      escrowAddress: { $in: escrowAddresses },
       tokenId: { $in: fromTokenIds },
     }).lean()
     const lockAmountMap = new Map<string, string>()
-    for (const lock of fromLocks) lockAmountMap.set(lock.tokenId, lock.amount)
+    for (const lock of fromLocks) lockAmountMap.set(`${lock.escrowAddress}:${lock.tokenId}`, lock.amount)
 
     const ops: any[] = []
     for (const { parsed, info } of events) {
       const sender = parsed.args._sender
       const fromTokenId = parsed.args._from.toString()
       const toTokenId = parsed.args._to.toString()
-      const fromAmount = lockAmountMap.get(fromTokenId)
+      const fromAmount = lockAmountMap.get(`${info.address}:${fromTokenId}`)
 
       if (!fromAmount) {
         logger.warn('Lock not found for merge', llo({ fromTokenId, info }))
@@ -571,8 +588,8 @@ export class VeBatchProcessor {
 }
 
 export const GovernanceVeBatchHandler = {
-  async processVeEventsBatch(logs: Log[], network: NetworksEnum): Promise<void> {
-    if (logs.length === 0) return
+  async processVeEventsBatch(logs: Log[], network: NetworksEnum): Promise<number> {
+    if (logs.length === 0) return 0
 
     logs.sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex || a.index - b.index)
 
@@ -585,6 +602,10 @@ export const GovernanceVeBatchHandler = {
 
       processor.parseLogs(logs)
       await processor.resolvePlugins()
+
+      const handledCount = processor.eventCount
+      if (handledCount === 0) return 0
+
       await processor.createMembers()
 
       const timings: Record<string, number> = {}
@@ -606,8 +627,10 @@ export const GovernanceVeBatchHandler = {
 
       logger.info(
         'VeBatch processed',
-        llo({ network, total: logs.length, duration: `${Date.now() - startTime}ms`, timings }),
+        llo({ network, total: logs.length, handled: handledCount, duration: `${Date.now() - startTime}ms`, timings }),
       )
+
+      return handledCount
     } finally {
       tickCtx.clear()
     }

--- a/src/handlers/governanceVeHandler.ts
+++ b/src/handlers/governanceVeHandler.ts
@@ -41,9 +41,7 @@ export const GovernanceVeHandler = {
           tokenIds,
           action: 'delegate',
           blockNumber: info.blockNumber,
-          blockTimestamp: info.context
-            ? await info.context.getBlockTimestamp(info.blockNumber)
-            : await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
+          blockTimestamp: await info.context!.getBlockTimestamp(info.blockNumber),
           transactionHash: info.transactionHash,
           transactionIndex: info.transactionIndex,
           logIndex: info.logIndex,
@@ -137,9 +135,7 @@ export const GovernanceVeHandler = {
           tokenIds,
           action: 'undelegate',
           blockNumber: info.blockNumber,
-          blockTimestamp: info.context
-            ? await info.context.getBlockTimestamp(info.blockNumber)
-            : await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
+          blockTimestamp: await info.context!.getBlockTimestamp(info.blockNumber),
           transactionHash: info.transactionHash,
           transactionIndex: info.transactionIndex,
           logIndex: info.logIndex,

--- a/src/handlers/governanceVeHandler.ts
+++ b/src/handlers/governanceVeHandler.ts
@@ -41,7 +41,9 @@ export const GovernanceVeHandler = {
           tokenIds,
           action: 'delegate',
           blockNumber: info.blockNumber,
-          blockTimestamp: await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
+          blockTimestamp: info.context
+            ? await info.context.getBlockTimestamp(info.blockNumber)
+            : await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
           transactionHash: info.transactionHash,
           transactionIndex: info.transactionIndex,
           logIndex: info.logIndex,
@@ -55,7 +57,9 @@ export const GovernanceVeHandler = {
         await MemberGovernanceFactory.createBaseMember(toAddress, info.blockNumber)
       }
 
-      const escrowAddress = await GovernanceVeHelper.getEscrowAddress(info.address, info.network)
+      const escrowAddress =
+        plugins[0].votingEscrow?.escrowAddress ??
+        (await GovernanceVeHelper.getEscrowAddress(info.address, info.network))
       if (escrowAddress) {
         const governance = MemberGovernanceFactory.create({
           address: escrowAddress,
@@ -133,7 +137,9 @@ export const GovernanceVeHandler = {
           tokenIds,
           action: 'undelegate',
           blockNumber: info.blockNumber,
-          blockTimestamp: await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
+          blockTimestamp: info.context
+            ? await info.context.getBlockTimestamp(info.blockNumber)
+            : await Web3Helper.getBlockTimestamp(info.blockNumber, info.network),
           transactionHash: info.transactionHash,
           transactionIndex: info.transactionIndex,
           logIndex: info.logIndex,
@@ -142,7 +148,9 @@ export const GovernanceVeHandler = {
 
       await MemberGovernanceFactory.createBaseMember(fromAddress, info.blockNumber)
 
-      const escrowAddress = await GovernanceVeHelper.getEscrowAddress(info.address, info.network)
+      const escrowAddress =
+        plugins[0].votingEscrow?.escrowAddress ??
+        (await GovernanceVeHelper.getEscrowAddress(info.address, info.network))
       if (escrowAddress) {
         const governance = MemberGovernanceFactory.create({
           address: escrowAddress,

--- a/src/modules/crawlers/blockchainLogCrawler.ts
+++ b/src/modules/crawlers/blockchainLogCrawler.ts
@@ -199,7 +199,12 @@ class BlockchainLogCrawler {
 
           if (parallelConfig.enable) {
             parallelConfig.useBatch
-              ? await this.logProcessingEngine.processLogsParallelBatch(sortedLogs, context, parallelConfig)
+              ? await this.logProcessingEngine.processLogsParallelBatch(
+                  sortedLogs,
+                  context,
+                  parallelConfig,
+                  this.crawlParams.strategy,
+                )
               : await this.logProcessingEngine.processLogsParallel(
                   sortedLogs,
                   context,
@@ -842,7 +847,12 @@ class BlockchainLogCrawler {
       latestBlock: latestBlock || 0,
     }
     const parallelConfig = this.getParallelConfig(logs?.length || 0)
-    const result = await this.logProcessingEngine.processLogsParallelBatch(logs, context, parallelConfig)
+    const result = await this.logProcessingEngine.processLogsParallelBatch(
+      logs,
+      context,
+      parallelConfig,
+      this.crawlParams.strategy,
+    )
 
     const stats = this.logProcessingEngine.getProcessingStats()
     this.crawlSetting.nbSuccess = stats.nbSuccess

--- a/src/modules/crawlers/logProcessingEngine.ts
+++ b/src/modules/crawlers/logProcessingEngine.ts
@@ -175,7 +175,7 @@ export class LogProcessingEngine {
     }
   }
 
-  private static readonly BATCH_THRESHOLD = 5
+  private static readonly BATCH_THRESHOLD = 10
 
   /**
    * Process logs sequentially, with adaptive batch handler support.

--- a/src/modules/crawlers/logProcessingEngine.ts
+++ b/src/modules/crawlers/logProcessingEngine.ts
@@ -7,11 +7,13 @@ import {
   type IParallelConfig,
   type IProcessingContext,
   type IProcessingStats,
+  ICrawStrategy,
   type NetworksEnum,
 } from '@types'
 import async from 'async'
 import { Interface, type Log, type LogDescription } from 'ethers'
 import { CrawlerErrorHandler } from './crawlerErrorHandler'
+import { TickContext } from './tickContext'
 
 const llo = logger.logMeta.bind(null, { service: 'LogProcessingEngine' })
 
@@ -57,6 +59,10 @@ export class LogProcessingEngine {
     this.errorHandler = new CrawlerErrorHandler({
       stopOnError: this.stopOnError,
     })
+  }
+
+  private isRealtimeStrategy(strategy?: string): boolean {
+    return strategy === ICrawStrategy.getBlockReceipts || strategy === ICrawStrategy.getLogsWithoutTopics
   }
 
   /**
@@ -128,6 +134,7 @@ export class LogProcessingEngine {
     const { config } = eventSetting
     let parsedEvent: LogDescription | null = null
     let matchingHandler: any = null
+    let matchingBatchHandler: any = null
 
     for (const configItem of config) {
       const abiFragment = configItem.abi.find((item: any) => item.name === eventSetting?.event && item.type === 'event')
@@ -137,6 +144,7 @@ export class LogProcessingEngine {
         parsedEvent = Web3Utils.parseLog(log, iFace)
         if (parsedEvent) {
           matchingHandler = configItem.handler
+          matchingBatchHandler = configItem.batchHandler
           break
         }
       } catch (_) {
@@ -162,12 +170,17 @@ export class LogProcessingEngine {
     return {
       event: parsedEvent!,
       handler: matchingHandler,
+      batchHandler: matchingBatchHandler,
       info,
     }
   }
 
+  private static readonly BATCH_THRESHOLD = 5
+
   /**
-   * Process logs sequentially
+   * Process logs sequentially, with adaptive batch handler support.
+   * Events with a `batchHandler` in config are grouped — if volume exceeds threshold,
+   * the batch handler is used; otherwise falls back to the individual handler.
    */
   async processLogs(
     logs: Log[],
@@ -177,26 +190,107 @@ export class LogProcessingEngine {
     logService?: string,
   ): Promise<number> {
     let highestBlockNumber = 0
-    let logIndex = 0
 
-    for (const log of logs) {
-      logIndex++
+    const parsed: Array<{ log: Log; formatted: IFormattedLog; index: number }> = []
+    for (let i = 0; i < logs.length; i++) {
+      const formatted = this.formatLog(logs[i])
+      if (formatted.event) {
+        parsed.push({ log: logs[i], formatted, index: i + 1 })
+      } else {
+        highestBlockNumber = Math.max(highestBlockNumber, logs[i].blockNumber)
+      }
+    }
+
+    if (parsed.length === 0) return highestBlockNumber
+
+    const tickCtx = new TickContext(this.network, logs)
+    if (this.isRealtimeStrategy(strategy)) {
+      await tickCtx.init()
+    }
+
+    try {
+      const { individualEvents, batchQueues } = this.partitionByBatchSupport(parsed, tickCtx)
+
+      highestBlockNumber = await this.runIndividualHandlers(individualEvents, tickCtx, highestBlockNumber, {
+        context,
+        strategy,
+        address,
+        logService,
+        totalLogs: logs.length,
+      })
+
+      highestBlockNumber = await this.runBatchHandlers(batchQueues, highestBlockNumber)
+    } finally {
+      tickCtx.clear()
+    }
+
+    return highestBlockNumber
+  }
+
+  /**
+   * Partition parsed events into individual and batch queues.
+   * Events with a batchHandler are grouped by handler name — if the group
+   * exceeds BATCH_THRESHOLD they go to batchQueues, otherwise fall back to individual.
+   */
+  private partitionByBatchSupport(
+    parsed: Array<{ log: Log; formatted: IFormattedLog; index: number }>,
+    tickCtx: TickContext,
+  ) {
+    type ParsedItem = (typeof parsed)[0]
+    type BatchQueue = { handler: any; events: Array<{ parsedEvent: any; info: any; log: Log }> }
+
+    const candidates = new Map<string, ParsedItem[]>()
+    const individualEvents: ParsedItem[] = []
+
+    for (const item of parsed) {
+      if (item.formatted.batchHandler) {
+        const key = item.formatted.batchHandler.name || 'batch'
+        if (!candidates.has(key)) candidates.set(key, [])
+        candidates.get(key)!.push(item)
+      } else {
+        individualEvents.push(item)
+      }
+    }
+
+    const batchQueues = new Map<string, BatchQueue>()
+
+    for (const [key, items] of candidates) {
+      if (items.length >= LogProcessingEngine.BATCH_THRESHOLD) {
+        batchQueues.set(key, {
+          handler: items[0].formatted.batchHandler,
+          events: items.map(item => {
+            item.formatted.info.context = tickCtx
+            return { parsedEvent: item.formatted.event, info: item.formatted.info, log: item.log }
+          }),
+        })
+      } else {
+        individualEvents.push(...items)
+      }
+    }
+
+    return { individualEvents, batchQueues }
+  }
+
+  /**
+   * Run individual event handlers sequentially.
+   */
+  private async runIndividualHandlers(
+    events: Array<{ log: Log; formatted: IFormattedLog; index: number }>,
+    tickCtx: TickContext,
+    highestBlockNumber: number,
+    meta: { context: IProcessingContext; strategy?: string; address?: string; logService?: string; totalLogs: number },
+  ): Promise<number> {
+    for (const { log, formatted, index } of events) {
       try {
         const startTime = Date.now()
-        const { handler, event, info } = this.formatLog(log)
-
-        if (!event) {
-          highestBlockNumber = Math.max(highestBlockNumber, log.blockNumber)
-          continue
-        }
+        const { handler, event, info } = formatted
+        info.context = tickCtx
 
         await handler(event, info, this.onlyHistorical)
 
         if (log.blockNumber) {
           highestBlockNumber = Math.max(highestBlockNumber, log.blockNumber)
-          if (log.blockNumber > this.stats.lastSync) {
-            this.stats.lastSync = log.blockNumber
-          }
+          if (log.blockNumber > this.stats.lastSync) this.stats.lastSync = log.blockNumber
         }
 
         this.stats.nbSuccess++
@@ -205,27 +299,58 @@ export class LogProcessingEngine {
           'Processing Event',
           llo({
             network: this.network,
-            address,
-            logService,
+            address: meta.address,
+            logService: meta.logService,
             blockNumber: Number(log.blockNumber),
-            logsLen: logs.length,
-            logIndex,
+            logsLen: meta.totalLogs,
+            logIndex: index,
             event: event.name,
-            strategy,
-            fromBlock: context.fromBlock,
+            strategy: meta.strategy,
+            fromBlock: meta.context.fromBlock,
             processedTime: Date.now() - startTime,
-            toBlock: context.toBlock,
-            latestBlock: context.latestBlock,
+            toBlock: meta.context.toBlock,
+            latestBlock: meta.context.latestBlock,
             transactionHash: log.transactionHash,
           }),
         )
       } catch (error: any) {
         this.stats.nbError++
         this.onError?.(this.errorHandler.toError(error), log)
+        if (this.stopOnError) throw error
+      }
+    }
 
-        if (this.stopOnError) {
-          throw error
+    return highestBlockNumber
+  }
+
+  /**
+   * Run batch handlers — one call per handler with all collected events.
+   */
+  private async runBatchHandlers(
+    batchQueues: Map<string, { handler: any; events: Array<{ parsedEvent: any; info: any; log: Log }> }>,
+    highestBlockNumber: number,
+  ): Promise<number> {
+    for (const [handlerName, { handler, events }] of batchQueues) {
+      try {
+        const startTime = Date.now()
+        await handler(events)
+
+        for (const { log } of events) {
+          if (log.blockNumber) {
+            highestBlockNumber = Math.max(highestBlockNumber, log.blockNumber)
+            if (log.blockNumber > this.stats.lastSync) this.stats.lastSync = log.blockNumber
+          }
+          this.stats.nbSuccess++
         }
+
+        logger.verbose(
+          'Processing Batch Event',
+          llo({ network: this.network, handlerName, count: events.length, processedTime: Date.now() - startTime }),
+        )
+      } catch (error: any) {
+        this.stats.nbError += events.length
+        this.onError?.(this.errorHandler.toError(error), events[0]?.log)
+        if (this.stopOnError) throw error
       }
     }
 
@@ -245,6 +370,11 @@ export class LogProcessingEngine {
   ): Promise<number> {
     if (!logs || logs.length === 0) {
       return 0
+    }
+
+    const tickCtx = new TickContext(this.network, logs)
+    if (this.isRealtimeStrategy(strategy)) {
+      await tickCtx.init()
     }
 
     const concurrency = parallelConfig.concurrency || 10
@@ -275,6 +405,7 @@ export class LogProcessingEngine {
             return
           }
 
+          info.context = tickCtx
           await handler(event, info, this.onlyHistorical)
 
           this.stats.nbSuccess++
@@ -329,6 +460,7 @@ export class LogProcessingEngine {
       // Handle completion
       queue.drain(() => {
         if (processedCount >= totalLogs) {
+          tickCtx.clear()
           resolve(highestBlockNumber)
         }
       })
@@ -348,12 +480,14 @@ export class LogProcessingEngine {
         )
         if (this.stopOnError) {
           queue.kill()
+          tickCtx.clear()
           reject(error)
         }
       })
 
       // If queue is empty, resolve immediately
       if (queue.length() === 0 && queue.running() === 0) {
+        tickCtx.clear()
         resolve(highestBlockNumber)
       }
     })
@@ -367,6 +501,7 @@ export class LogProcessingEngine {
     logs: Log[],
     context: IProcessingContext,
     parallelConfig: IParallelConfig,
+    strategy?: string,
   ): Promise<number> {
     if (!logs || logs.length === 0) {
       return 0
@@ -405,87 +540,58 @@ export class LogProcessingEngine {
       eventBatches.get(handlerKey)!.logs.push({ log, formatted })
     }
 
-    // Process each event type's batches
-    for (const [handlerKey, eventData] of eventBatches) {
-      const { logs: eventLogs, handler, eventName } = eventData
+    if (eventBatches.size === 0) return highestBlockNumber
 
-      // Check if this handler is a batch handler
-      const isBatchHandler = handler.name?.endsWith('Batch')
+    const tickCtx = new TickContext(this.network, logs)
+    if (this.isRealtimeStrategy(strategy)) {
+      await tickCtx.init()
+    }
 
-      if (isBatchHandler) {
-        // For batch handlers, split into chunks and call with arrays
-        for (let i = 0; i < eventLogs.length; i += batchSize) {
-          const chunk = eventLogs.slice(i, Math.min(i + batchSize, eventLogs.length))
+    try {
+      // Process each event type's batches
+      for (const [handlerKey, eventData] of eventBatches) {
+        const { logs: eventLogs, handler, eventName } = eventData
 
-          // Prepare array of events for batch handler
-          const eventsArray = chunk.map(item => ({
-            parsedEvent: item.formatted.event,
-            info: item.formatted.info,
-          }))
+        // Check if this handler is a batch handler
+        const isBatchHandler = handler.name?.endsWith('Batch')
 
-          try {
-            // Call batch handler with array of events
-            await handler(eventsArray)
+        if (isBatchHandler) {
+          // For batch handlers, split into chunks and call with arrays
+          for (let i = 0; i < eventLogs.length; i += batchSize) {
+            const chunk = eventLogs.slice(i, Math.min(i + batchSize, eventLogs.length))
 
-            // Update stats and block number
-            for (const item of chunk) {
-              if (item.log.blockNumber) {
-                highestBlockNumber = Math.max(highestBlockNumber, item.log.blockNumber)
-                if (item.log.blockNumber > this.stats.lastSync) {
-                  this.stats.lastSync = item.log.blockNumber
-                }
+            // Prepare array of events for batch handler
+            const eventsArray = chunk.map(item => {
+              item.formatted.info.context = tickCtx
+              return {
+                parsedEvent: item.formatted.event,
+                info: item.formatted.info,
               }
-              this.stats.nbSuccess++
-            }
-          } catch (error: any) {
-            this.stats.nbError += chunk.length
-            this.onError?.(this.errorHandler.toError(error), chunk[0]?.log)
+            })
 
-            logger.error(
-              'Batch handler processing error',
-              llo({
-                error,
-                handlerKey,
-                eventName,
-                batchSize: chunk.length,
-              }),
-            )
-
-            if (this.stopOnError) {
-              throw error
-            }
-          }
-        }
-      } else {
-        // For regular handlers, process individually but in parallel chunks
-        const chunks: (typeof eventLogs)[] = []
-        for (let i = 0; i < eventLogs.length; i += batchSize) {
-          chunks.push(eventLogs.slice(i, Math.min(i + batchSize, eventLogs.length)))
-        }
-
-        await async.eachLimit(chunks, concurrency, async chunk => {
-          for (const item of chunk) {
             try {
-              await handler(item.formatted.event, item.formatted.info, this.onlyHistorical)
+              await handler(eventsArray)
 
-              if (item.log.blockNumber) {
-                highestBlockNumber = Math.max(highestBlockNumber, item.log.blockNumber)
-                if (item.log.blockNumber > this.stats.lastSync) {
-                  this.stats.lastSync = item.log.blockNumber
+              for (const item of chunk) {
+                if (item.log.blockNumber) {
+                  highestBlockNumber = Math.max(highestBlockNumber, item.log.blockNumber)
+                  if (item.log.blockNumber > this.stats.lastSync) {
+                    this.stats.lastSync = item.log.blockNumber
+                  }
                 }
+                this.stats.nbSuccess++
               }
-
-              this.stats.nbSuccess++
             } catch (error: any) {
-              this.stats.nbError++
-              this.onError?.(this.errorHandler.toError(error), item.log)
+              this.stats.nbError += chunk.length
+              this.onError?.(this.errorHandler.toError(error), chunk[0]?.log)
 
               logger.error(
-                'Individual processing error',
+                'Batch handler processing error',
                 llo({
                   error,
+                  handlerKey,
                   eventName,
-                  blockNumber: item.log.blockNumber,
+                  batchSize: chunk.length,
                 }),
               )
 
@@ -494,12 +600,52 @@ export class LogProcessingEngine {
               }
             }
           }
-        })
-      }
-    }
+        } else {
+          // For regular handlers, process individually but in parallel chunks
+          const chunks: (typeof eventLogs)[] = []
+          for (let i = 0; i < eventLogs.length; i += batchSize) {
+            chunks.push(eventLogs.slice(i, Math.min(i + batchSize, eventLogs.length)))
+          }
 
-    // Clear event batches from memory
-    eventBatches.clear()
+          await async.eachLimit(chunks, concurrency, async chunk => {
+            for (const item of chunk) {
+              try {
+                item.formatted.info.context = tickCtx
+                await handler(item.formatted.event, item.formatted.info, this.onlyHistorical)
+
+                if (item.log.blockNumber) {
+                  highestBlockNumber = Math.max(highestBlockNumber, item.log.blockNumber)
+                  if (item.log.blockNumber > this.stats.lastSync) {
+                    this.stats.lastSync = item.log.blockNumber
+                  }
+                }
+
+                this.stats.nbSuccess++
+              } catch (error: any) {
+                this.stats.nbError++
+                this.onError?.(this.errorHandler.toError(error), item.log)
+
+                logger.error(
+                  'Individual processing error',
+                  llo({
+                    error,
+                    eventName,
+                    blockNumber: item.log.blockNumber,
+                  }),
+                )
+
+                if (this.stopOnError) {
+                  throw error
+                }
+              }
+            }
+          })
+        }
+      }
+    } finally {
+      eventBatches.clear()
+      tickCtx.clear()
+    }
 
     return highestBlockNumber
   }

--- a/src/modules/crawlers/tickContext.ts
+++ b/src/modules/crawlers/tickContext.ts
@@ -1,0 +1,101 @@
+import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
+import logger from '@logger'
+import type { NetworksEnum } from '@types'
+import type { Log } from 'ethers'
+
+const llo = logger.logMeta.bind(null, { service: 'modules:TickContext' })
+
+export class TickContext {
+  private readonly network: NetworksEnum
+  private readonly rawLogs: Log[]
+  private logsByBlock = new Map<number, Log[]>()
+  private logsByTxHash = new Map<string, Log[]>()
+  private blockTimestamps = new Map<number, number>()
+  private cache = new Map<string, any>()
+  private initialized = false
+
+  constructor(network: NetworksEnum, logs: Log[]) {
+    this.network = network
+    this.rawLogs = logs
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return
+
+    for (const log of this.rawLogs) {
+      const blockLogs = this.logsByBlock.get(log.blockNumber) || []
+      blockLogs.push(log)
+      this.logsByBlock.set(log.blockNumber, blockLogs)
+
+      const txLogs = this.logsByTxHash.get(log.transactionHash) || []
+      txLogs.push(log)
+      this.logsByTxHash.set(log.transactionHash, txLogs)
+    }
+
+    await this.prefetchBlockTimestamps()
+    this.initialized = true
+  }
+
+  private async prefetchBlockTimestamps(): Promise<void> {
+    const blockNumbers = [...this.logsByBlock.keys()]
+    if (blockNumbers.length === 0) return
+
+    const from = Math.min(...blockNumbers)
+    const to = Math.max(...blockNumbers)
+
+    try {
+      const timestamps = await Web3BatchHelper.getBlocksTimestamps(from, to, this.network)
+      for (const [key, ts] of Object.entries(timestamps)) {
+        const blockNumber = Number(key.split('-').pop())
+        this.blockTimestamps.set(blockNumber, ts)
+      }
+    } catch (error) {
+      logger.error('Error prefetching block timestamps', llo({ from, to, network: this.network, error }))
+    }
+  }
+
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const cached = this.blockTimestamps.get(blockNumber)
+    if (cached !== undefined) return cached
+
+    const ts = await Web3Helper.getBlockTimestamp(blockNumber, this.network)
+    this.blockTimestamps.set(blockNumber, ts)
+    return ts
+  }
+
+  getLogsByBlock(blockNumber: number): Log[] {
+    return this.logsByBlock.get(blockNumber) || []
+  }
+
+  async getLogsByTxHash(txHash: string): Promise<Log[]> {
+    const cached = this.logsByTxHash.get(txHash)
+    if (cached) return cached
+
+    const receipt = await Web3Helper.getTransactionReceipt(txHash, this.network)
+    if (receipt) {
+      this.logsByTxHash.set(txHash, receipt.logs as unknown as Log[])
+      return receipt.logs as unknown as Log[]
+    }
+    return []
+  }
+
+  async getOrFetch<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+    if (this.cache.has(key)) return this.cache.get(key) as T
+    const value = await fetcher()
+    this.cache.set(key, value)
+    return value
+  }
+
+  toJSON() {
+    return { initialized: this.initialized, network: this.network, logs: this.rawLogs.length }
+  }
+
+  clear(): void {
+    this.logsByBlock.clear()
+    this.logsByTxHash.clear()
+    this.blockTimestamps.clear()
+    this.cache.clear()
+    this.initialized = false
+  }
+}

--- a/src/modules/poolingCrawler.ts
+++ b/src/modules/poolingCrawler.ts
@@ -207,7 +207,14 @@ const PoolingCrawler = {
     if (veLogs.length === 0) return logs
 
     try {
-      await GovernanceVeBatchHandler.processVeEventsBatch(veLogs, network)
+      const handled = await GovernanceVeBatchHandler.processVeEventsBatch(veLogs, network)
+      if (handled === 0) {
+        logger.warn(
+          'VeBatch processed 0 events, falling back to individual handlers',
+          llo({ network, veLogCount: veLogs.length }),
+        )
+        return logs
+      }
     } catch (error) {
       logger.error('VeBatch processing failed, falling back to individual handlers', llo({ network, error }))
       return logs

--- a/src/modules/poolingCrawler.ts
+++ b/src/modules/poolingCrawler.ts
@@ -3,6 +3,7 @@ import { GovernanceERC20 } from '@artifacts/GovernanceERC20'
 import config from '@config'
 import { Models } from '@dbModels'
 import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
+import { GovernanceVeBatchHandler, VE_TOPICS } from '@handlers/governanceVeBatchHandler'
 import utils from '@helpers/utils'
 import configIndexer from '@indexer/configIndexer'
 import logger from '@logger'
@@ -79,7 +80,8 @@ const PoolingCrawler = {
       if (includeTransfer) {
         return await PoolingCrawler._filterTransferLogs(logs, network)
       } else {
-        return await PoolingCrawler._filterDelegateVotesLogs(logs, network)
+        const filtered = await PoolingCrawler._filterDelegateVotesLogs(logs, network)
+        return await PoolingCrawler._filterVeLogs(filtered, network)
       }
     } catch (error) {
       logger.error('PoolingCrawler filterLogs', llo({ network, error }))
@@ -188,6 +190,31 @@ const PoolingCrawler = {
       if (log.topics[0] !== delegateVotesChangedTopic) return true
       return log.topics[0] === delegateVotesChangedTopic && tokenAddressesSet.has(ethers.getAddress(log.address))
     })
+  },
+
+  async _filterVeLogs(logs: Log[], network: NetworksEnum) {
+    const veLogs: Log[] = []
+    const remainingLogs: Log[] = []
+
+    for (const log of logs) {
+      if (log.topics.length > 0 && VE_TOPICS.has(log.topics[0])) {
+        veLogs.push(log)
+      } else {
+        remainingLogs.push(log)
+      }
+    }
+
+    if (veLogs.length === 0) return logs
+
+    try {
+      await GovernanceVeBatchHandler.processVeEventsBatch(veLogs, network)
+    } catch (error) {
+      logger.error('VeBatch processing failed, falling back to individual handlers', llo({ network, error }))
+      return logs
+    }
+
+    // VE logs handled — remove them from normal flow
+    return remainingLogs
   },
 
   _getReceiverAddress: (log: Log) => {

--- a/src/services/aragon-indexer/configIndexer.ts
+++ b/src/services/aragon-indexer/configIndexer.ts
@@ -500,6 +500,7 @@ const IndexerEventConfig: IIndexerConfig[] = [
       {
         abi: VotingEscrow.abi,
         handler: GovernanceErc20Handler.delegateChanged,
+        batchHandler: GovernanceErc20Handler.delegateChangedBatch,
       },
     ],
   },
@@ -601,6 +602,7 @@ const IndexerEventConfig: IIndexerConfig[] = [
       {
         abi: CapitalDistributor.abi,
         handler: CapitalDistributorHandler.payoutClaimed,
+        batchHandler: CapitalDistributorHandler.payoutClaimedBatch,
       },
     ],
   },

--- a/src/types/crawler.ts
+++ b/src/types/crawler.ts
@@ -199,6 +199,7 @@ export interface IIndexerConfigHandler {
   handler:
     | ((event: LogDescription, info: ILogInfo, isHistorical?: boolean) => Promise<any>)
     | ((events: Array<{ parsedEvent: LogDescription; info: ILogInfo }>) => Promise<any>)
+  batchHandler?: (events: Array<{ parsedEvent: LogDescription; info: ILogInfo }>) => Promise<any>
 }
 
 export interface IIndexerConfig {

--- a/src/types/eventLogs.ts
+++ b/src/types/eventLogs.ts
@@ -1,4 +1,5 @@
 import { type HexAddress, type NetworksEnum } from '@src/types/networks'
+import type { TickContext } from '@src/modules/crawlers/tickContext'
 import type { LogDescription } from 'ethers'
 
 export interface ILogInfo {
@@ -10,10 +11,12 @@ export interface ILogInfo {
   address: HexAddress
   eventName: string
   interfaceType?: string
+  context?: TickContext
 }
 
 export interface IFormattedLog {
   event: LogDescription
   info: ILogInfo
   handler: any
+  batchHandler?: any
 }

--- a/test/unit-dep/batchVeHandler.spec.ts
+++ b/test/unit-dep/batchVeHandler.spec.ts
@@ -216,7 +216,7 @@ describe.only('Integ: VE Batch Handler — Full DAO Simulation', () => {
       provider.getLogs({
         address: gaugePluginAddress,
         topics: [gaugeTopics],
-        fromBlock: 24244432,
+        fromBlock: 23387484,
         toBlock: startBlock,
       }),
     )) as any[]

--- a/test/unit-dep/batchVeHandler.spec.ts
+++ b/test/unit-dep/batchVeHandler.spec.ts
@@ -1,0 +1,321 @@
+import { GaugeVoter } from '@artifacts/GaugeVoter'
+import { Models } from '@dbModels'
+import ConfigIndexerHelper from '@helpers/configIndexer'
+import RabbitMQHelper from '@helpers/rabbitMQ'
+import Web3Helper from '@helpers/web3'
+import configIndexer from '@indexer/configIndexer'
+import logger from '@logger'
+import { BlockchainLogCrawler } from '@modules/crawlers'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+import PoolingCrawler from '@modules/poolingCrawler'
+import { LibUtils } from '@test/lib/unit-dep/lib'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { Interface } from 'ethers'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+describe.only('Integ: VE Batch Handler — Full DAO Simulation', () => {
+  let sandbox: SinonSandbox
+
+  const network = NetworksEnum.katanaMainnet
+  const daoAddress = '0xb72291652f15cF73651357383c0A86FBba29B675'
+  const startBlock = 27092715
+  const endBlock = 27093780
+  const logService = ConfigIndexerHelper.builders.indexer(network)
+
+  beforeEach(async function () {
+    this.timeout(10000000)
+
+    sandbox = sinon.createSandbox()
+    sandbox.stub(RabbitMQHelper, 'sendMessage').resolves()
+
+    // --- DAO ---
+    await Models.Dao.create({
+      id: `${network}-${daoAddress}`,
+      isActive: true,
+      isHidden: false,
+      network,
+      transactionHash: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304',
+      blockNumber: 23368834,
+      blockTimestamp: 1770111645,
+      address: daoAddress,
+      implementationAddress: '0x8E241da6591d07a9f2480117b5d94dE4A63c4B3f',
+      creatorAddress: '0xCe77fFD992001995B2079000111DA07F75606042',
+      subdomain: null,
+      metadataIpfs: 'ipfs://QmaNwP3uNWvvKopVsTDX4dG5Df9erS9CgAT2RHnsVuWPPv',
+      name: 'Katana vKAT Management DAO',
+      version: '1.4.0',
+      metrics: {},
+    })
+
+    // --- Plugins ---
+
+    // Gauge plugin (VE)
+    await Models.Plugin.create({
+      id: `${network}-0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304-0x5e755A3C5dc81A79DE7a7cEF192FFA60964c9352`,
+      transactionHash: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304',
+      blockNumber: 23368834,
+      blockTimestamp: 1770111645,
+      network,
+      address: '0x5e755A3C5dc81A79DE7a7cEF192FFA60964c9352',
+      implementationAddress: '0x25FCd22Bf758E5eac96D392cebeBDff83a2282a9',
+      interfaceType: 'gauge',
+      status: 'installed',
+      isSupported: true,
+      daoAddress,
+      tokenAddress: '0xB67Ac05e2C1d8592692a90BF61712274b988f25A',
+      pluginSetupRepoAddress: '0x6E00fC9cF62c2c78A850cf13e1dA1Ae48d940D01',
+      sender: '0xCe77fFD992001995B2079000111DA07F75606042',
+      release: '1',
+      build: '1',
+      subdomain: 'katanagaugevoter',
+      uninstalled: { status: false },
+      hasTarget: false,
+      isProcess: false,
+      isBody: false,
+      isSubPlugin: false,
+      votingEscrow: {
+        curveAddress: '0x38b8B74330b2F918C22F7936aCf773C6D963C73c',
+        exitQueueAddress: '0x6dE9cAAb658C744aD337Ca5d92D084c97ffF578d',
+        escrowAddress: '0x4d6fC15Ca6258b168225D283262743C623c13Ead',
+        clockAddress: '0x000000000000000000000000000000006981C2AF',
+        nftLockAddress: '0x106F7D67Ea25Cb9eFf5064CF604ebf6259Ff296d',
+        underlying: '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d',
+      },
+    })
+
+    // Multisig plugin
+    await Models.Plugin.create({
+      id: `${network}-0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304-0x69f9105DCc43bAaa78089Fcf811aaaD2C156D269`,
+      transactionHash: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304',
+      blockNumber: 23368834,
+      blockTimestamp: 1770111645,
+      network,
+      address: '0x69f9105DCc43bAaa78089Fcf811aaaD2C156D269',
+      implementationAddress: '0x9A09363C4b886025F9182E10B1081690B0B498D0',
+      interfaceType: 'multisig',
+      status: 'installed',
+      isSupported: true,
+      daoAddress,
+      tokenAddress: null,
+      pluginSetupRepoAddress: '0x5596451d7eDeA4cba96a181c5B8A31B93A62F7dF',
+      sender: '0xCe77fFD992001995B2079000111DA07F75606042',
+      release: '1',
+      build: '3',
+      subdomain: 'multisig',
+      uninstalled: { status: false },
+      hasTarget: false,
+      isProcess: true,
+      isBody: true,
+      isSubPlugin: false,
+    })
+
+    // Capital distributor plugin
+    await Models.Plugin.create({
+      id: `${network}-0x59f438871555d331dcd97dbe861767a6683e3ed6dbe8149414cd9a8c5191c753-0x290503854c95Bfa44173d68f2E3e5AaFe073e220`,
+      transactionHash: '0x59f438871555d331dcd97dbe861767a6683e3ed6dbe8149414cd9a8c5191c753',
+      blockNumber: 23620252,
+      blockTimestamp: 1770363063,
+      network,
+      address: '0x290503854c95Bfa44173d68f2E3e5AaFe073e220',
+      implementationAddress: '0xB5aFc75D15Bd5077C331aBDFa2f704693E9bbB2D',
+      interfaceType: 'capitalDistributor',
+      status: 'installed',
+      isSupported: true,
+      daoAddress,
+      tokenAddress: null,
+      pluginSetupRepoAddress: '0x5a75f0C2c82747ac69f39d1450FF581B15358759',
+      sender: '0x6DfAAEe5fA1d4B0EF453EC3E08883bC58966B503',
+      release: '1',
+      build: '1',
+      subdomain: 'capital-distributor',
+      uninstalled: { status: false },
+      hasTarget: false,
+      isProcess: false,
+      isBody: false,
+      isSubPlugin: false,
+    })
+
+    // --- Settings ---
+
+    // Gauge setting
+    await Models.Setting.create({
+      id: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304-0x5e755A3C5dc81A79DE7a7cEF192FFA60964c9352',
+      transactionHash: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304',
+      blockNumber: 23368834,
+      blockTimestamp: 1770111645,
+      network,
+      status: 'active',
+      daoAddress,
+      pluginAddress: '0x5e755A3C5dc81A79DE7a7cEF192FFA60964c9352',
+      pluginSubdomain: 'katanagaugevoter',
+      votingEscrow: {
+        minDeposit: '500000000000000000',
+        minLockTime: 1,
+        maxTime: 0,
+        slope: '0',
+        bias: '1000000000000000000',
+        cooldown: 3888000,
+        feePercent: '8000',
+        minFeePercent: '250',
+        minCooldown: 1,
+        feeType: 2,
+      },
+    })
+
+    // Multisig setting
+    await Models.Setting.create({
+      id: '0x407c6594a27133826fd0d281ddcecca3d1a585c08f35962604ec234ab6eb5ad1-0x69f9105DCc43bAaa78089Fcf811aaaD2C156D269',
+      transactionHash: '0x407c6594a27133826fd0d281ddcecca3d1a585c08f35962604ec234ab6eb5ad1',
+      blockNumber: 27518813,
+      blockTimestamp: 1774261624,
+      network,
+      status: 'active',
+      daoAddress,
+      pluginAddress: '0x69f9105DCc43bAaa78089Fcf811aaaD2C156D269',
+      pluginSubdomain: 'multisig',
+    })
+
+    // --- Token ---
+    await Models.Token.create({
+      id: '0xB67Ac05e2C1d8592692a90BF61712274b988f25A-katana-mainnet',
+      network,
+      address: '0xB67Ac05e2C1d8592692a90BF61712274b988f25A',
+      type: 'escrowAdapter',
+      name: 'Katana Network Token',
+      symbol: 'KAT',
+      decimals: 18,
+      isGovernance: true,
+      hasDelegate: true,
+      transactionHash: '0x905c5b075c4626cf08e4016ef1d64694d1995cf272dfd385b3b4f3437656f304',
+      blockNumber: 23368834,
+    })
+
+    // --- ConfigIndexer ---
+    await Models.ConfigIndexer.create({
+      id: `${network}-${logService}`,
+      network,
+      service: logService,
+      lastSync: startBlock,
+    })
+
+    // --- Fetch and process GaugeCreated/Activated events from gaugePlugin ---
+    const gaugePluginAddress = '0x5e755A3C5dc81A79DE7a7cEF192FFA60964c9352'
+    const gaugeIface = new Interface(GaugeVoter.abi)
+    const gaugeTopics = [
+      gaugeIface.getEvent('GaugeCreated')!.topicHash,
+      gaugeIface.getEvent('GaugeActivated')!.topicHash,
+    ]
+
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    const limiter = BottleneckModule.getNodeLimiter(network)
+
+    const gaugeLogs = (await limiter.schedule(() =>
+      provider.getLogs({
+        address: gaugePluginAddress,
+        topics: [gaugeTopics],
+        fromBlock: 24244432,
+        toBlock: startBlock,
+      }),
+    )) as any[]
+
+    if (gaugeLogs.length > 0) {
+      // Get unique tx hashes sorted by block
+      const txMap = new Map<string, number>()
+      for (const log of gaugeLogs) {
+        if (!txMap.has(log.transactionHash) || log.blockNumber < txMap.get(log.transactionHash)!) {
+          txMap.set(log.transactionHash, log.blockNumber)
+        }
+      }
+      const sortedTxHashes = [...txMap.entries()].sort((a, b) => a[1] - b[1]).map(([hash]) => hash)
+
+      logger.info('Processing gauge setup events', { txCount: sortedTxHashes.length, gaugeLogs: gaugeLogs.length })
+      await LibUtils.handleEventsFromTxHashes(sortedTxHashes, network)
+    }
+  })
+
+  afterEach(() => {
+    PoolingCrawler.instances.clear()
+    sandbox?.restore()
+  })
+
+  it('should simulate realtime ticks with all events', async function () {
+    this.timeout(10000000)
+
+    // Phase 1: Small ticks (50 blocks) through the VE burst range
+    // Phase 2: Switch to real latest and catch up
+    const tickSize = 50
+    let tickCount = 0
+    let useRealLatest = false
+
+    const getBlockNumberStub = sandbox.stub(Web3Helper, 'getBlockNumber')
+    getBlockNumberStub.callsFake(async (blockOrTag: any, net: NetworksEnum) => {
+      if (blockOrTag === 'latest' && net === network && !useRealLatest) {
+        tickCount++
+        const simulated = startBlock + tickSize * tickCount
+        if (simulated > endBlock) useRealLatest = true
+        return simulated
+      }
+      return (getBlockNumberStub.wrappedMethod as any).call(Web3Helper, blockOrTag, net)
+    })
+
+    // Full configIndexer — all event types + filterLogs routes VE events to batch handler
+    const crawler = new BlockchainLogCrawler({
+      network,
+      events: configIndexer,
+      filterLogs: async (logs: any) => PoolingCrawler.filterLogs(logs, network),
+      onError: async (error: any) => logger.error('Crawler error', { error }),
+      logService,
+      stopOnError: true,
+      batchSize: 0.05,
+    })
+
+    const startTime = Date.now()
+    let tick = 0
+
+    while (true) {
+      tick++
+      const tickStart = Date.now()
+
+      await crawler.crawl()
+
+      const tickDuration = Date.now() - tickStart
+      const ci = await Models.ConfigIndexer.findOne({ service: logService, network })
+      const realLatest = await (getBlockNumberStub.wrappedMethod as any).call(Web3Helper, 'latest', network)
+
+      logger.info(`Tick ${tick}`, {
+        lastSync: ci?.lastSync,
+        realLatest,
+        tickDuration: `${tickDuration}ms`,
+        isRealtime: useRealLatest,
+      })
+
+      if (useRealLatest && ci?.lastSync && ci.lastSync >= realLatest - 5) {
+        logger.info('Caught up to realtime, stopping')
+        break
+      }
+    }
+
+    const totalDuration = Date.now() - startTime
+
+    const locks = await Models.Lock.countDocuments({ network })
+    const delegations = await Models.TokenDelegation.countDocuments({ network })
+    const members = await Models.Member.countDocuments({})
+    const votes = await Models.VoteGauge.countDocuments({ network })
+
+    logger.info('Simulation complete', {
+      totalDuration: `${totalDuration}ms`,
+      ticks: tick,
+      locks,
+      delegations,
+      members,
+      votes,
+    })
+
+    expect(locks).to.be.greaterThan(0)
+    expect(delegations).to.be.greaterThan(0)
+    expect(members).to.be.greaterThan(0)
+  })
+})

--- a/test/unit-dep/batchVeHandler.spec.ts
+++ b/test/unit-dep/batchVeHandler.spec.ts
@@ -16,7 +16,7 @@ import { Interface } from 'ethers'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 
-describe.only('Integ: VE Batch Handler — Full DAO Simulation', () => {
+describe.skip('Integ: VE Batch Handler — Full DAO Simulation', () => {
   let sandbox: SinonSandbox
 
   const network = NetworksEnum.katanaMainnet

--- a/test/unit/governance/veGovernance.spec.ts
+++ b/test/unit/governance/veGovernance.spec.ts
@@ -692,6 +692,160 @@ describe('Governance:VeGovernance', () => {
     })
   })
 
+  describe('exitCancelled', () => {
+    beforeEach(async () => {
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      await Models.Lock.create({
+        network: testNetwork,
+        escrowAddress: testEscrowAddress,
+        transactionHash: '0xlocktx',
+        transactionIndex: 0,
+        logIndex: 0,
+        blockNumber: 100,
+        memberAddress: parsedAddress,
+        nftAddress: '0xnftaddress',
+        tokenAddress: testTokenAddress,
+        exitQueueAddress: '0xexitqueueaddress',
+        tokenId: '555',
+        amount: '1000000000000000000',
+        epochStartAt: 1680000000,
+        totalLocked: '1000000000000000000',
+        lockExit: {
+          status: true,
+          transactionHash: '0xexittx',
+          blockNumber: 150,
+          exitDateAt: 1680004000,
+          holder: memberAddress,
+          tokenId: '555',
+        },
+      })
+    })
+
+    it('should cancel exit and clear lockExit', async () => {
+      const result = await veGovernance.exitCancelled(memberAddress, {
+        info: {
+          transactionHash: '0xcanceltx',
+          blockNumber: 300,
+          address: '0xexitqueueaddress',
+        },
+        parsedEvent: {
+          args: {
+            holder: memberAddress,
+            tokenId: 555,
+          },
+        },
+      } as any)
+
+      expect(result).to.exist
+      expect(result?.tokenId).to.equal('555')
+
+      const updatedLock = await Models.Lock.findOne({
+        tokenId: '555',
+        exitQueueAddress: '0xexitqueueaddress',
+      })
+      expect(updatedLock?.lockExit).to.be.null
+
+      expect(loggerVerboseStub.calledWith('Exit cancelled processed in VeGovernance')).to.be.true
+    })
+
+    it('should return null if address parsing fails', async () => {
+      const result = await veGovernance.exitCancelled(
+        'invalid' as HexAddress,
+        {
+          info: { transactionHash: '0xtx', blockNumber: 300, address: '0xexitqueueaddress' },
+          parsedEvent: { args: {} },
+        } as any,
+      )
+
+      expect(result).to.be.null
+    })
+
+    it('should return null if info or parsedEvent is missing', async () => {
+      const result = await veGovernance.exitCancelled(memberAddress, {} as any)
+
+      expect(result).to.be.null
+      expect(loggerErrorStub.calledWith('Missing info or parsedEvent for exitCancelled')).to.be.true
+    })
+
+    it('should return existing lock if not in exit queue', async () => {
+      // Create a lock without lockExit
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      await Models.Lock.create({
+        network: testNetwork,
+        escrowAddress: testEscrowAddress,
+        transactionHash: '0xlocktx2',
+        transactionIndex: 0,
+        logIndex: 0,
+        blockNumber: 101,
+        memberAddress: parsedAddress,
+        nftAddress: '0xnftaddress',
+        tokenAddress: testTokenAddress,
+        exitQueueAddress: '0xexitqueueaddress2',
+        tokenId: '556',
+        amount: '1000000000000000000',
+        epochStartAt: 1680000000,
+        totalLocked: '1000000000000000000',
+      })
+
+      const result = await veGovernance.exitCancelled(memberAddress, {
+        info: {
+          transactionHash: '0xcanceltx',
+          blockNumber: 300,
+          address: '0xexitqueueaddress2',
+        },
+        parsedEvent: {
+          args: {
+            holder: memberAddress,
+            tokenId: 556,
+          },
+        },
+      } as any)
+
+      expect(result).to.exist
+      expect(loggerWarnStub.calledWith('Lock not in exit queue')).to.be.true
+    })
+
+    it('should return null if lock not found', async () => {
+      const result = await veGovernance.exitCancelled(memberAddress, {
+        info: {
+          transactionHash: '0xcanceltx',
+          blockNumber: 300,
+          address: '0xexitqueueaddress',
+        },
+        parsedEvent: {
+          args: {
+            holder: memberAddress,
+            tokenId: 999,
+          },
+        },
+      } as any)
+
+      expect(result).to.be.null
+      expect(loggerErrorStub.calledWith('Lock not found for exitCancelled')).to.be.true
+    })
+
+    it('should handle database error and return null', async () => {
+      sandbox.stub(Models.Lock, 'findOne').rejects(new Error('Database error'))
+
+      const result = await veGovernance.exitCancelled(memberAddress, {
+        info: {
+          transactionHash: '0xcanceltx',
+          blockNumber: 300,
+          address: '0xexitqueueaddress',
+        },
+        parsedEvent: {
+          args: {
+            holder: memberAddress,
+            tokenId: 555,
+          },
+        },
+      } as any)
+
+      expect(result).to.be.null
+      expect(loggerErrorStub.calledWith('Error in exitCancelled')).to.be.true
+    })
+  })
+
   describe('delete', () => {
     it('should throw not implemented error', async () => {
       try {
@@ -1011,6 +1165,29 @@ describe('Governance:VeGovernance', () => {
       expect(result).to.be.null
       expect(loggerErrorStub.calledWith('No plugins found for split')).to.be.true
     })
+
+    it('should handle database error during split and return null', async () => {
+      sandbox.stub(Models.Lock, 'findOne').rejects(new Error('Database error'))
+
+      const result = await veGovernance.lockSplit({
+        fromTokenId: '100',
+        newTokenId: '101',
+        splitAmount1: '6000000000000000000',
+        splitAmount2: '4000000000000000000',
+        info: {
+          transactionHash: '0xsplittx',
+          transactionIndex: 1,
+          logIndex: 2,
+          blockNumber: 200,
+          network: testNetwork,
+          address: testEscrowAddress,
+          eventName: 'Split',
+        },
+      })
+
+      expect(result).to.be.null
+      expect(loggerErrorStub.calledWith('Error in lockSplit')).to.be.true
+    })
   })
 
   describe('lockMerge', () => {
@@ -1192,6 +1369,28 @@ describe('Governance:VeGovernance', () => {
       expect(result).to.exist
       expect(result?.tokenId).to.equal('202')
       expect(loggerVerboseStub.calledWith('Merge processed in VeGovernance')).to.be.true
+    })
+
+    it('should handle database error during merge and return null', async () => {
+      sandbox.stub(Models.Lock, 'findOne').rejects(new Error('Database error'))
+
+      const result = await veGovernance.lockMerge({
+        fromTokenId: '200',
+        toTokenId: '201',
+        newTotalAmount: '10000000000000000000',
+        info: {
+          transactionHash: '0xmergetx',
+          transactionIndex: 1,
+          logIndex: 2,
+          blockNumber: 300,
+          network: testNetwork,
+          address: testEscrowAddress,
+          eventName: 'Merged',
+        },
+      })
+
+      expect(result).to.be.null
+      expect(loggerErrorStub.calledWith('Error in lockMerge')).to.be.true
     })
   })
 })

--- a/test/unit/handlers/capitalDistributorHandler.spec.ts
+++ b/test/unit/handlers/capitalDistributorHandler.spec.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import { CapitalDistributorHandler } from '@handlers/capitalDistributorHandler'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import IPFSModule from '@modules/ipfs'
@@ -940,6 +941,174 @@ describe('Handler: CapitalDistributor', () => {
       expect(updatedCampaign?.active).to.be.false
       expect(updatedCampaign?.ended).to.be.true
       expect(loggerInfoStub.calledWith('Campaign status updated' as any)).to.be.true
+    })
+  })
+
+  describe('payoutClaimedBatch', () => {
+    const pluginAddress = '0xCapitalDistributor123456789012345678901234' as any
+    const batchNetwork = NetworksEnum.ethereumMainnet
+
+    beforeEach(async () => {
+      await Models.Plugin.create({
+        id: `${batchNetwork}-${pluginAddress}-batch`,
+        address: pluginAddress,
+        network: batchNetwork,
+        transactionHash: '0xbatchtx1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        blockNumber: 100,
+        status: IPluginStatus.installed,
+        interfaceType: IPluginInterfaceType.capitalDistributor,
+        daoAddress: '0xdao1234567890123456789012345678901234567890' as HexAddress,
+        pluginSetupRepoAddress: '0xrepo123456789012345678901234567890123456' as HexAddress,
+        name: 'Capital Distributor',
+        build: '1',
+        release: '1',
+      })
+    })
+
+    const makeClaimEvent = (overrides: any = {}) => ({
+      parsedEvent: {
+        args: {
+          campaignId: overrides.campaignId || BigInt(1),
+          recipient: overrides.recipient || ('0xuser1234567890123456789012345678901234567890' as HexAddress),
+          amount: overrides.amount || BigInt('1000000000000000000'),
+        },
+      } as any,
+      info: {
+        address: overrides.address || pluginAddress,
+        network: batchNetwork,
+        blockNumber: overrides.blockNumber || 12345678,
+        transactionHash:
+          overrides.transactionHash ||
+          ('0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as HexAddress),
+        transactionIndex: overrides.transactionIndex || 0,
+        logIndex: overrides.logIndex || 0,
+      } as any,
+    })
+
+    it('should skip when events array is empty', async () => {
+      const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite')
+
+      await CapitalDistributorHandler.payoutClaimedBatch([])
+
+      expect(rewardBulkWriteStub.notCalled).to.be.true
+    })
+
+    it('should skip when no plugins found', async () => {
+      const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite')
+
+      const events = [
+        makeClaimEvent({
+          address: '0x9999999999999999999999999999999999999999' as HexAddress,
+        }),
+      ]
+
+      await CapitalDistributorHandler.payoutClaimedBatch(events)
+
+      expect(rewardBulkWriteStub.notCalled).to.be.true
+    })
+
+    it('should upsert rewards and push claims via bulkWrite', async () => {
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
+
+      const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
+      sandbox.stub(Models.CampaignReward, 'find').returns({ lean: sinon.stub().resolves([]) } as any)
+      sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        totalClaimed: '0',
+        save: sandbox.stub().resolves(),
+      } as any)
+
+      await CapitalDistributorHandler.payoutClaimedBatch([makeClaimEvent()])
+
+      expect(rewardBulkWriteStub.calledOnce).to.be.true
+      const ops = rewardBulkWriteStub.getCall(0).args[0] as any[]
+      expect(ops).to.have.lengthOf(1)
+      expect(ops[0].updateOne.update.$setOnInsert.userAddress).to.equal(
+        '0xuser1234567890123456789012345678901234567890',
+      )
+      expect(ops[0].updateOne.update.$push.claims.claimedAmount).to.equal('1000000000000000000')
+      expect(ops[0].updateOne.upsert).to.be.true
+    })
+
+    it('should update campaign claimCount and totalClaimed', async () => {
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
+      sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
+      sandbox.stub(Models.CampaignReward, 'find').returns({ lean: sinon.stub().resolves([]) } as any)
+
+      const campaignBulkWriteStub = sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
+      const saveSpy = sandbox.stub().resolves()
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        totalClaimed: '500000000000000000',
+        save: saveSpy,
+      } as any)
+
+      const events = [
+        makeClaimEvent({ logIndex: 0 }),
+        makeClaimEvent({
+          logIndex: 1,
+          recipient: '0xuser2234567890123456789012345678901234567890' as HexAddress,
+          transactionHash: '0xbbbbbb1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as HexAddress,
+        }),
+      ]
+
+      await CapitalDistributorHandler.payoutClaimedBatch(events)
+
+      expect(campaignBulkWriteStub.calledOnce).to.be.true
+      const campaignOps = campaignBulkWriteStub.getCall(0).args[0] as any[]
+      expect(campaignOps).to.have.lengthOf(1)
+      expect(campaignOps[0].updateOne.update.$inc.claimCount).to.equal(2)
+
+      expect(saveSpy.calledOnce).to.be.true
+    })
+
+    it('should skip duplicate claims (same txHash)', async () => {
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
+
+      const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
+      sandbox.stub(Models.CampaignReward, 'find').returns({ lean: sinon.stub().resolves([]) } as any)
+      sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        totalClaimed: '0',
+        save: sandbox.stub().resolves(),
+      } as any)
+
+      await CapitalDistributorHandler.payoutClaimedBatch([makeClaimEvent()])
+
+      expect(rewardBulkWriteStub.calledOnce).to.be.true
+      const ops = rewardBulkWriteStub.getCall(0).args[0] as any[]
+      // The filter includes $ne check on claims.transactionHash to skip duplicates
+      expect(ops[0].updateOne.filter['claims.transactionHash'].$ne).to.equal(
+        '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      )
+    })
+
+    it('should fetch timestamps via Web3BatchHelper.getBlocksTimestamps', async () => {
+      const getTimestampsStub = sandbox
+        .stub(Web3BatchHelper, 'getBlocksTimestamps')
+        .resolves({ '100': 1630425600, '200': 1630425700 })
+      sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
+      sandbox.stub(Models.CampaignReward, 'find').returns({ lean: sinon.stub().resolves([]) } as any)
+      sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        totalClaimed: '0',
+        save: sandbox.stub().resolves(),
+      } as any)
+
+      const events = [
+        makeClaimEvent({ blockNumber: 100, logIndex: 0 }),
+        makeClaimEvent({
+          blockNumber: 200,
+          logIndex: 1,
+          transactionHash: '0xcccccc1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as HexAddress,
+        }),
+      ]
+
+      await CapitalDistributorHandler.payoutClaimedBatch(events)
+
+      expect(getTimestampsStub.calledOnce).to.be.true
+      expect(getTimestampsStub.getCall(0).args[0]).to.equal(100)
+      expect(getTimestampsStub.getCall(0).args[1]).to.equal(200)
+      expect(getTimestampsStub.getCall(0).args[2]).to.equal(batchNetwork)
     })
   })
 })

--- a/test/unit/handlers/capitalDistributorHandler.spec.ts
+++ b/test/unit/handlers/capitalDistributorHandler.spec.ts
@@ -1026,7 +1026,7 @@ describe('Handler: CapitalDistributor', () => {
       expect(ops[0].updateOne.update.$setOnInsert.userAddress).to.equal(
         '0xuser1234567890123456789012345678901234567890',
       )
-      expect(ops[0].updateOne.update.$push.claims.claimedAmount).to.equal('1000000000000000000')
+      expect(ops[0].updateOne.update.$addToSet.claims.claimedAmount).to.equal('1000000000000000000')
       expect(ops[0].updateOne.upsert).to.be.true
     })
 
@@ -1061,7 +1061,7 @@ describe('Handler: CapitalDistributor', () => {
       expect(saveSpy.calledOnce).to.be.true
     })
 
-    it('should skip duplicate claims (same txHash)', async () => {
+    it('should deduplicate claims via $addToSet', async () => {
       sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
 
       const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
@@ -1076,10 +1076,13 @@ describe('Handler: CapitalDistributor', () => {
 
       expect(rewardBulkWriteStub.calledOnce).to.be.true
       const ops = rewardBulkWriteStub.getCall(0).args[0] as any[]
-      // The filter includes $ne check on claims.transactionHash to skip duplicates
-      expect(ops[0].updateOne.filter['claims.transactionHash'].$ne).to.equal(
+      // Uses $addToSet instead of $push + $ne filter for dedup
+      expect(ops[0].updateOne.update.$addToSet).to.exist
+      expect(ops[0].updateOne.update.$addToSet.claims.transactionHash).to.equal(
         '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
       )
+      // Filter should be simple id-only (no $ne)
+      expect(ops[0].updateOne.filter['claims.transactionHash']).to.be.undefined
     })
 
     it('should fetch timestamps via Web3BatchHelper.getBlocksTimestamps', async () => {
@@ -1111,14 +1114,22 @@ describe('Handler: CapitalDistributor', () => {
       expect(getTimestampsStub.getCall(0).args[2]).to.equal(batchNetwork)
     })
 
-    it('should recalculate totalClaimed for existing rewards after bulkWrite', async () => {
+    it('should recalculate totalClaimed from actual claims array after bulkWrite', async () => {
       sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
 
       const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
       const rewardId = `${batchNetwork}-${pluginAddress}-1-0xuser1234567890123456789012345678901234567890`
 
       sandbox.stub(Models.CampaignReward, 'find').returns({
-        lean: sinon.stub().resolves([{ id: rewardId, totalClaimed: '500000000000000000' }]),
+        lean: sinon.stub().resolves([
+          {
+            id: rewardId,
+            claims: [
+              { claimedAmount: '500000000000000000', transactionHash: '0xold' },
+              { claimedAmount: '1000000000000000000', transactionHash: '0xnew' },
+            ],
+          },
+        ]),
       } as any)
       sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
       sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
@@ -1128,14 +1139,14 @@ describe('Handler: CapitalDistributor', () => {
 
       await CapitalDistributorHandler.payoutClaimedBatch([makeClaimEvent()])
 
-      // First call: reward upserts with claims push
-      // Second call: totalClaimed recalculation
+      // First call: reward upserts with $addToSet claims
+      // Second call: totalClaimed recalculation from actual claims
       expect(rewardBulkWriteStub.calledTwice).to.be.true
 
       const updateOps = rewardBulkWriteStub.getCall(1).args[0] as any[]
       expect(updateOps).to.have.lengthOf(1)
       expect(updateOps[0].updateOne.filter.id).to.equal(rewardId)
-      // 500000000000000000 (existing) + 1000000000000000000 (new claim)
+      // Sum of actual claims in DB: 500000000000000000 + 1000000000000000000
       expect(updateOps[0].updateOne.update.$set.totalClaimed).to.equal('1500000000000000000')
     })
 

--- a/test/unit/handlers/capitalDistributorHandler.spec.ts
+++ b/test/unit/handlers/capitalDistributorHandler.spec.ts
@@ -1110,5 +1110,47 @@ describe('Handler: CapitalDistributor', () => {
       expect(getTimestampsStub.getCall(0).args[1]).to.equal(200)
       expect(getTimestampsStub.getCall(0).args[2]).to.equal(batchNetwork)
     })
+
+    it('should recalculate totalClaimed for existing rewards after bulkWrite', async () => {
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '12345678': 1640995200 })
+
+      const rewardBulkWriteStub = sandbox.stub(Models.CampaignReward, 'bulkWrite').resolves()
+      const rewardId = `${batchNetwork}-${pluginAddress}-1-0xuser1234567890123456789012345678901234567890`
+
+      sandbox.stub(Models.CampaignReward, 'find').returns({
+        lean: sinon.stub().resolves([{ id: rewardId, totalClaimed: '500000000000000000' }]),
+      } as any)
+      sandbox.stub(Models.Campaign, 'bulkWrite').resolves()
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        totalClaimed: '0',
+        save: sandbox.stub().resolves(),
+      } as any)
+
+      await CapitalDistributorHandler.payoutClaimedBatch([makeClaimEvent()])
+
+      // First call: reward upserts with claims push
+      // Second call: totalClaimed recalculation
+      expect(rewardBulkWriteStub.calledTwice).to.be.true
+
+      const updateOps = rewardBulkWriteStub.getCall(1).args[0] as any[]
+      expect(updateOps).to.have.lengthOf(1)
+      expect(updateOps[0].updateOne.filter.id).to.equal(rewardId)
+      // 500000000000000000 (existing) + 1000000000000000000 (new claim)
+      expect(updateOps[0].updateOne.update.$set.totalClaimed).to.equal('1500000000000000000')
+    })
+
+    it('should throw when an error occurs in payoutClaimedBatch', async () => {
+      sandbox.stub(logger, 'error')
+      sandbox
+        .stub(Models.Plugin, 'find')
+        .returns({ lean: sinon.stub().rejects(new Error('DB connection lost')) } as any)
+
+      try {
+        await CapitalDistributorHandler.payoutClaimedBatch([makeClaimEvent()])
+        expect.fail('Expected an error to be thrown')
+      } catch (error: any) {
+        expect(error.message).to.equal('DB connection lost')
+      }
+    })
   })
 })

--- a/test/unit/handlers/gaugeHandler.spec.ts
+++ b/test/unit/handlers/gaugeHandler.spec.ts
@@ -60,6 +60,9 @@ describe('Handler: gaugeHandler', () => {
       transactionIndex: 0,
       logIndex: 0,
       blockNumber: 12346,
+      context: {
+        getBlockTimestamp: sandbox.stub().resolves(1620000000),
+      },
     }
 
     // Stub external dependencies
@@ -517,17 +520,20 @@ describe('Handler: gaugeHandler', () => {
         },
       } as any
 
-      getBlockTimestampStub.resolves(1620000001)
+      const voteInfo = {
+        ...mockInfo,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1620000001) },
+      }
       const verboseStub = sandbox.stub(logger, 'verbose')
 
-      await GaugeHandler.gaugeVoted(parsedEvent, mockInfo)
+      await GaugeHandler.gaugeVoted(parsedEvent, voteInfo)
 
       // Verify VoteGauge was created
       const voteGauge = await Models.VoteGauge.findOne({
-        network: mockInfo.network,
-        transactionHash: mockInfo.transactionHash,
-        transactionIndex: mockInfo.transactionIndex,
-        logIndex: mockInfo.logIndex,
+        network: voteInfo.network,
+        transactionHash: voteInfo.transactionHash,
+        transactionIndex: voteInfo.transactionIndex,
+        logIndex: voteInfo.logIndex,
         pluginAddress: mockPlugin.address,
       })
 
@@ -537,7 +543,7 @@ describe('Handler: gaugeHandler', () => {
       expect(voteGauge.memberAddress).to.equal('0xVoter11111111111111111111111111111111111')
       expect(voteGauge.epochId).to.equal('1')
       expect(voteGauge.votingPower).to.equal('1000000000000000000')
-      expect(voteGauge.blockNumber).to.equal(mockInfo.blockNumber)
+      expect(voteGauge.blockNumber).to.equal(voteInfo.blockNumber)
       expect(voteGauge.blockTimestamp).to.equal(1620000001)
 
       expect(verboseStub.calledOnce).to.be.true
@@ -647,10 +653,13 @@ describe('Handler: gaugeHandler', () => {
         },
       } as any
 
-      getBlockTimestampStub.rejects(new Error('Web3 error'))
+      const errorInfo = {
+        ...mockInfo,
+        context: { getBlockTimestamp: sandbox.stub().rejects(new Error('Web3 error')) },
+      }
       const errorStub = sandbox.stub(logger, 'error')
 
-      await GaugeHandler.gaugeVoted(parsedEvent, mockInfo)
+      await GaugeHandler.gaugeVoted(parsedEvent, errorInfo)
 
       expect(errorStub.calledOnce).to.be.true
       expect(errorStub.args[0][0]).to.equal('Error gaugeVoted')
@@ -681,13 +690,13 @@ describe('Handler: gaugeHandler', () => {
         },
       } as any
 
-      getBlockTimestampStub.resolves(null)
       sandbox.stub(logger, 'verbose')
 
       const voteInfo = {
         ...mockInfo,
         transactionHash: '0xNullTsTx1111111111111111111111111111111111111111111111111111111111',
         logIndex: 99,
+        context: { getBlockTimestamp: sandbox.stub().resolves(null) },
       }
 
       await GaugeHandler.gaugeVoted(parsedEvent, voteInfo)
@@ -773,9 +782,9 @@ describe('Handler: gaugeHandler', () => {
         ...mockInfo,
         transactionHash: resetTxHash,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1620000002) },
       }
 
-      getBlockTimestampStub.resolves(1620000002)
       const verboseStub = sandbox.stub(logger, 'verbose')
 
       await GaugeHandler.gaugeReset(parsedEvent, resetInfo)
@@ -853,9 +862,9 @@ describe('Handler: gaugeHandler', () => {
         ...mockInfo,
         transactionHash: '0xNullTsResetTx1111111111111111111111111111111111111111111111111111',
         logIndex: 98,
+        context: { getBlockTimestamp: sandbox.stub().resolves(null) },
       }
 
-      getBlockTimestampStub.resolves(null)
       sandbox.stub(logger, 'verbose')
 
       await GaugeHandler.gaugeReset(parsedEvent, resetInfo)
@@ -1009,13 +1018,12 @@ describe('Handler: gaugeHandler', () => {
         },
       } as any
 
-      getBlockTimestampStub.resolves(1620000002)
-
       const voteInfo = {
         ...mockInfo,
         transactionHash: '0xVoteTx1111111111111111111111111111111111111111111111111111111111',
         transactionIndex: 1,
         logIndex: 5,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1620000002) },
       }
 
       await GaugeHandler.gaugeVoted(voteEvent, voteInfo)
@@ -1045,6 +1053,7 @@ describe('Handler: gaugeHandler', () => {
         ...voteInfo,
         transactionHash: '0xResetTx22222222222222222222222222222222222222222222222222222222',
         logIndex: 10,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1620000003) },
       }
 
       await GaugeHandler.gaugeReset(resetEvent, resetInfo)
@@ -1081,8 +1090,6 @@ describe('Handler: gaugeHandler', () => {
         '0xVoterC3333333333333333333333333333333333',
       ]
 
-      getBlockTimestampStub.resolves(1620000003)
-
       // Cast votes from multiple voters
       for (let i = 0; i < voters.length; i++) {
         const voteEvent = {
@@ -1101,6 +1108,7 @@ describe('Handler: gaugeHandler', () => {
           transactionHash: `0xVoteTx${i}111111111111111111111111111111111111111111111111111111`,
           transactionIndex: i,
           logIndex: i * 2,
+          context: { getBlockTimestamp: sandbox.stub().resolves(1620000003) },
         }
 
         await GaugeHandler.gaugeVoted(voteEvent, voteInfo)

--- a/test/unit/handlers/governanceErc20Handler.spec.ts
+++ b/test/unit/handlers/governanceErc20Handler.spec.ts
@@ -7,6 +7,7 @@ import GovernanceErc20Helper from '@helpers/governanceErc20'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import utils from '@helpers/utils'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import { ProxyToken } from '@modules/proxyToken'
@@ -1043,6 +1044,7 @@ describe('GovernanceErc20Handler', () => {
       transactionIndex: 1,
       logIndex: 1,
       address: '0xTokenAddress',
+      context: { getBlockTimestamp: sinon.stub().resolves(1630425600) },
     }
 
     it('should skip if no plugins found for token address', async () => {
@@ -1131,6 +1133,154 @@ describe('GovernanceErc20Handler', () => {
 
       expect(loggerErrorStub.calledOnce).to.be.true
       expect(loggerErrorStub.args[0][0]).to.equal('DelegateChanged - error')
+    })
+  })
+
+  describe('delegateChangedBatch', () => {
+    const tokenAddress = '0xTokenBatch'
+    const makeEvent = (overrides: any = {}) => ({
+      parsedEvent: {
+        args: {
+          delegator: overrides.delegator || '0xDelegator1',
+          fromDelegate: overrides.fromDelegate || '0xFrom1',
+          toDelegate: overrides.toDelegate || '0xTo1',
+        },
+      } as any,
+      info: {
+        network,
+        blockNumber: overrides.blockNumber || 100,
+        transactionHash: overrides.transactionHash || '0xtx1',
+        transactionIndex: overrides.transactionIndex || 0,
+        logIndex: overrides.logIndex || 0,
+        address: overrides.address || tokenAddress,
+      } as any,
+    })
+
+    it('should skip when events array is empty', async () => {
+      const bulkWriteStub = sandbox.stub(Models.LogDelegateChanged, 'bulkWrite')
+
+      await GovernanceErc20Handler.delegateChangedBatch([])
+
+      expect(bulkWriteStub.notCalled).to.be.true
+    })
+
+    it('should skip when no plugins found', async () => {
+      const bulkWriteStub = sandbox.stub(Models.LogDelegateChanged, 'bulkWrite')
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({})
+
+      await GovernanceErc20Handler.delegateChangedBatch([makeEvent()])
+
+      expect(bulkWriteStub.notCalled).to.be.true
+    })
+
+    it('should bulk create LogDelegateChanged records', async () => {
+      await Models.Plugin.create({
+        id: `${network}-0xPluginBatch-0`,
+        transactionHash: '0xplugintx',
+        blockNumber: 50,
+        network,
+        address: '0xPluginBatch',
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: IPluginStatus.installed,
+        tokenAddress,
+        daoAddress: '0xDaoBatch',
+        isSupported: true,
+      })
+
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '100': 1630425600 })
+      const bulkWriteStub = sandbox.stub(Models.LogDelegateChanged, 'bulkWrite').resolves()
+
+      const events = [
+        makeEvent({ logIndex: 0, transactionIndex: 0 }),
+        makeEvent({ delegator: '0xDelegator2', logIndex: 1, transactionIndex: 0 }),
+      ]
+
+      await GovernanceErc20Handler.delegateChangedBatch(events)
+
+      expect(bulkWriteStub.calledOnce).to.be.true
+      const ops = bulkWriteStub.getCall(0).args[0] as any[]
+      expect(ops).to.have.lengthOf(2)
+      expect(ops[0].updateOne.update.$setOnInsert.delegator).to.equal('0xDelegator1')
+      expect(ops[1].updateOne.update.$setOnInsert.delegator).to.equal('0xDelegator2')
+    })
+
+    it('should fetch timestamps via Web3BatchHelper.getBlocksTimestamps', async () => {
+      await Models.Plugin.create({
+        id: `${network}-0xPluginBatch-0`,
+        transactionHash: '0xplugintx',
+        blockNumber: 50,
+        network,
+        address: '0xPluginBatch',
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: IPluginStatus.installed,
+        tokenAddress,
+        daoAddress: '0xDaoBatch',
+        isSupported: true,
+      })
+
+      const getTimestampsStub = sandbox
+        .stub(Web3BatchHelper, 'getBlocksTimestamps')
+        .resolves({ '100': 1630425600, '200': 1630425700 })
+      sandbox.stub(Models.LogDelegateChanged, 'bulkWrite').resolves()
+
+      const events = [makeEvent({ blockNumber: 100 }), makeEvent({ blockNumber: 200, logIndex: 1 })]
+
+      await GovernanceErc20Handler.delegateChangedBatch(events)
+
+      expect(getTimestampsStub.calledOnce).to.be.true
+      expect(getTimestampsStub.getCall(0).args[0]).to.equal(100)
+      expect(getTimestampsStub.getCall(0).args[1]).to.equal(200)
+      expect(getTimestampsStub.getCall(0).args[2]).to.equal(network)
+    })
+
+    it('should filter events by valid token addresses', async () => {
+      await Models.Plugin.create({
+        id: `${network}-0xPluginBatch-0`,
+        transactionHash: '0xplugintx',
+        blockNumber: 50,
+        network,
+        address: '0xPluginBatch',
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: IPluginStatus.installed,
+        tokenAddress,
+        daoAddress: '0xDaoBatch',
+        isSupported: true,
+      })
+
+      sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({ '100': 1630425600 })
+      const bulkWriteStub = sandbox.stub(Models.LogDelegateChanged, 'bulkWrite').resolves()
+
+      const events = [
+        makeEvent({ address: tokenAddress, logIndex: 0 }),
+        makeEvent({ address: '0xUnknownToken', logIndex: 1 }),
+      ]
+
+      await GovernanceErc20Handler.delegateChangedBatch(events)
+
+      expect(bulkWriteStub.calledOnce).to.be.true
+      const ops = bulkWriteStub.getCall(0).args[0] as any[]
+      expect(ops).to.have.lengthOf(1)
+      expect(ops[0].updateOne.update.$setOnInsert.tokenAddress).to.equal(tokenAddress)
+    })
+
+    it('should handle errors and re-throw', async () => {
+      const loggerErrorStub = sandbox.stub(logger, 'error')
+
+      const badEvents = {
+        length: 1,
+        map: () => {
+          throw new Error('Batch error')
+        },
+        0: makeEvent(),
+      } as any
+
+      try {
+        await GovernanceErc20Handler.delegateChangedBatch(badEvents)
+        expect.fail('Should have thrown')
+      } catch (err) {
+        expect(loggerErrorStub.calledWith('DelegateChangedBatch - error' as any)).to.be.true
+        expect((err as Error).message).to.equal('Batch error')
+      }
     })
   })
 })

--- a/test/unit/handlers/governanceVeBatchHandler.spec.ts
+++ b/test/unit/handlers/governanceVeBatchHandler.spec.ts
@@ -469,7 +469,7 @@ describe('Handler: GovernanceVeBatchHandler', () => {
         ;(processor as any).events[0].plugins = [plugin]
 
         sandbox.stub(Models.Lock, 'find').returns({
-          lean: sandbox.stub().resolves([{ tokenId: '1', amount: '100' }]),
+          lean: sandbox.stub().resolves([{ tokenId: '1', escrowAddress: ESCROW_ADDRESS, amount: '100' }]),
         } as any)
         const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
 
@@ -648,10 +648,15 @@ describe('Handler: GovernanceVeBatchHandler', () => {
         processor.parseLogs([splitLog])
         ;(processor as any).events[0].plugins = [plugin]
 
-        sandbox.stub(Models.Lock, 'findOne').resolves({
-          tokenId: '1',
-          epochStartAt: 1000,
-          amount: '500',
+        sandbox.stub(Models.Lock, 'find').returns({
+          lean: sandbox.stub().resolves([
+            {
+              tokenId: '1',
+              escrowAddress: ESCROW_ADDRESS,
+              epochStartAt: 1000,
+              amount: '500',
+            },
+          ]),
         } as any)
 
         const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
@@ -892,7 +897,7 @@ describe('Handler: GovernanceVeBatchHandler', () => {
         processor.parseLogs([splitLog])
         ;(processor as any).events[0].plugins = [plugin]
 
-        sandbox.stub(Models.Lock, 'findOne').resolves(null)
+        sandbox.stub(Models.Lock, 'find').returns({ lean: sandbox.stub().resolves([]) } as any)
         const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
 
         await processor.processSplits()

--- a/test/unit/handlers/governanceVeBatchHandler.spec.ts
+++ b/test/unit/handlers/governanceVeBatchHandler.spec.ts
@@ -677,6 +677,108 @@ describe('Handler: GovernanceVeBatchHandler', () => {
     })
   })
 
+  describe('resolvePlugins with ExitQueuedV2 events', () => {
+    it('should attach plugins to ExitQueuedV2 events via exitQueueAddress', async () => {
+      const exitLog = encodeExitQueuedV2Log(1n, DEPOSITOR, 1700000000n)
+      const plugin = createPlugin()
+
+      tickCtx = makeTickCtx([exitLog])
+      const processor = new VeBatchProcessor(NETWORK, tickCtx)
+      processor.parseLogs([exitLog])
+
+      const events = (processor as any).events
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].eventName).to.equal('ExitQueuedV2')
+
+      // Plugin.find should be called with exitQueueAddress filter
+      const findStub = sandbox.stub(Models.Plugin, 'find')
+      findStub.returns({ lean: sandbox.stub().resolves([plugin]) } as any)
+
+      await processor.resolvePlugins()
+
+      const resolvedEvents = (processor as any).events
+      expect(resolvedEvents).to.have.lengthOf(1)
+      expect(resolvedEvents[0].plugins).to.deep.include(plugin)
+    })
+  })
+
+  describe('processExitQueued with lock update ops', () => {
+    it('should create lock update ops for ExitQueuedV2 events', async () => {
+      const exitLog = encodeExitQueuedV2Log(1n, DEPOSITOR, 1234567890n)
+      const plugin = createPlugin()
+
+      tickCtx = makeTickCtx([exitLog])
+      const processor = new VeBatchProcessor(NETWORK, tickCtx)
+      processor.parseLogs([exitLog])
+      ;(processor as any).events[0].plugins = [plugin]
+
+      const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+      await processor.processExitQueued()
+
+      expect(bulkWriteStub.calledOnce).to.be.true
+      const ops = bulkWriteStub.firstCall.args[0]
+      expect(ops).to.have.lengthOf(1)
+
+      const filter = ops[0].updateOne.filter
+      expect(filter.exitQueueAddress).to.equal(EXIT_QUEUE_ADDRESS)
+      expect(filter.tokenId).to.equal('1')
+
+      const update = ops[0].updateOne.update.$set
+      expect(update.memberAddress).to.equal(DEPOSITOR)
+      expect(update.lockExit.status).to.be.true
+      expect(update.lockExit.tokenId).to.equal('1')
+      expect(update.lockExit.holder).to.equal(DEPOSITOR)
+      expect(update.lockExit.exitDateAt).to.equal(1234567890)
+    })
+  })
+
+  describe('updateDaoMetrics', () => {
+    it('should call MemberGovernanceFactory.create and gov.updateDaoMetrics for unique escrow addresses', async () => {
+      const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+      const plugin = createPlugin()
+
+      tickCtx = makeTickCtx([depositLog])
+      const processor = new VeBatchProcessor(NETWORK, tickCtx)
+      processor.parseLogs([depositLog])
+      ;(processor as any).events[0].plugins = [plugin]
+
+      const updateDaoMetricsStub = sandbox.stub().resolves()
+      const factoryStub = sandbox.stub(MemberGovernanceFactory, 'create').returns({
+        updateDaoMetrics: updateDaoMetricsStub,
+      } as any)
+
+      await processor.updateDaoMetrics()
+
+      expect(factoryStub.calledOnce).to.be.true
+      expect(factoryStub.firstCall.args[0].address).to.equal(ESCROW_ADDRESS)
+      expect(factoryStub.firstCall.args[0].network).to.equal(NETWORK)
+      expect(updateDaoMetricsStub.calledOnce).to.be.true
+    })
+
+    it('should deduplicate by escrow address', async () => {
+      const depositLog1 = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+      const depositLog2 = encodeDepositLog(DEPOSITOR, 2n, 2000n, 300n, 800n)
+      const plugin = createPlugin()
+
+      tickCtx = makeTickCtx([depositLog1, depositLog2])
+      const processor = new VeBatchProcessor(NETWORK, tickCtx)
+      processor.parseLogs([depositLog1, depositLog2])
+      ;(processor as any).events[0].plugins = [plugin]
+      ;(processor as any).events[1].plugins = [plugin]
+
+      const updateDaoMetricsStub = sandbox.stub().resolves()
+      sandbox.stub(MemberGovernanceFactory, 'create').returns({
+        updateDaoMetrics: updateDaoMetricsStub,
+      } as any)
+
+      await processor.updateDaoMetrics()
+
+      // Only called once despite two events with the same escrow address
+      expect(updateDaoMetricsStub.calledOnce).to.be.true
+    })
+  })
+
   describe('GovernanceVeBatchHandler.processVeEventsBatch', () => {
     it('should return immediately for empty logs', async () => {
       const pluginFindStub = sandbox.stub(Models.Plugin, 'find')

--- a/test/unit/handlers/governanceVeBatchHandler.spec.ts
+++ b/test/unit/handlers/governanceVeBatchHandler.spec.ts
@@ -819,5 +819,107 @@ describe('Handler: GovernanceVeBatchHandler', () => {
       // Verify PluginMetrics.bulkWrite was called (metrics processed)
       expect((Models.PluginMetrics.bulkWrite as sinon.SinonStub).calledOnce).to.be.true
     })
+
+    it('should sort logs by blockNumber, transactionIndex, and index', async () => {
+      const log1 = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+      const log2 = encodeDepositLog(DEPOSITOR, 2n, 2000n, 300n, 800n)
+      // Make log2 appear before log1 in block order
+      ;(log1 as any).blockNumber = 200
+      ;(log1 as any).transactionIndex = 1
+      ;(log1 as any).index = 0
+      ;(log2 as any).blockNumber = 100
+      ;(log2 as any).transactionIndex = 0
+      ;(log2 as any).index = 0
+
+      const plugin = createPlugin()
+
+      sandbox.stub(Models.Plugin, 'find').returns({
+        lean: sandbox.stub().resolves([plugin]),
+      } as any)
+      sandbox.stub(Models.Member, 'bulkWrite').resolves()
+      sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+      sandbox.stub(Models.Lock, 'find').returns({ lean: sandbox.stub().resolves([]) } as any)
+      sandbox.stub(Models.Lock, 'findOne').resolves(null)
+      sandbox.stub(Models.TokenDelegation, 'bulkWrite').resolves()
+      sandbox.stub(Models.PluginMetrics, 'bulkWrite').resolves()
+      sandbox.stub(MemberGovernanceFactory, 'create').returns({
+        updateDaoMetrics: sandbox.stub().resolves(),
+      } as any)
+
+      await GovernanceVeBatchHandler.processVeEventsBatch([log1, log2], NETWORK)
+
+      // If sort works, log2 (block 100) should be before log1 (block 200)
+      expect((Models.Member.bulkWrite as sinon.SinonStub).calledOnce).to.be.true
+    })
+  })
+
+  describe('VeBatchProcessor edge cases', () => {
+    describe('createMembers with duplicate addresses', () => {
+      it('should merge min/max blockNumbers for same address across events', async () => {
+        const log1 = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const log2 = encodeWithdrawLog(DEPOSITOR, 1n, 300n, 2000n, 200n)
+        ;(log1 as any).blockNumber = 100
+        ;(log2 as any).blockNumber = 200
+
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([log1, log2])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([log1, log2])
+        ;(processor as any).events[0].plugins = [plugin]
+        ;(processor as any).events[1].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Member, 'bulkWrite').resolves()
+
+        await processor.createMembers()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        // Same address should be deduplicated into one op
+        expect(ops).to.have.lengthOf(1)
+        expect(ops[0].updateOne.update.$setOnInsert.firstActivity).to.equal(100)
+        expect(ops[0].updateOne.update.$max.lastActivity).to.equal(200)
+      })
+    })
+
+    describe('processSplits when lock not found', () => {
+      it('should skip split and continue when original lock not found', async () => {
+        const splitLog = encodeSplitLog(1n, 2n, DEPOSITOR, 300n, 200n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([splitLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([splitLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        sandbox.stub(Models.Lock, 'findOne').resolves(null)
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processSplits()
+
+        expect(bulkWriteStub.called).to.be.false
+      })
+    })
+
+    describe('resolvePlugins with TOKEN_EVENTS', () => {
+      it('should resolve TokensDelegated events via tokenMap', async () => {
+        const delegateLog = encodeTokensDelegatedLog(DEPOSITOR, DELEGATEE, [1n])
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([delegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([delegateLog])
+
+        sandbox.stub(Models.Plugin, 'find').returns({
+          lean: sandbox.stub().resolves([plugin]),
+        } as any)
+
+        await processor.resolvePlugins()
+
+        const events = (processor as any).events
+        expect(events).to.have.lengthOf(1)
+        expect(events[0].plugins).to.deep.include(plugin)
+      })
+    })
   })
 })

--- a/test/unit/handlers/governanceVeBatchHandler.spec.ts
+++ b/test/unit/handlers/governanceVeBatchHandler.spec.ts
@@ -29,17 +29,18 @@ const NETWORK = NetworksEnum.ethereumMainnet
 const coder = AbiCoder.defaultAbiCoder()
 
 function makeLog(overrides: Partial<Log> & { topics: string[]; data: string; address: string }): Log {
+  const { address, data, topics, ...rest } = overrides
   return {
     blockNumber: 100,
     blockHash: '0x' + '00'.repeat(32),
     transactionIndex: 0,
     removed: false,
-    address: overrides.address,
-    data: overrides.data,
-    topics: overrides.topics,
+    address,
+    data,
+    topics,
     transactionHash: '0x' + 'ab'.repeat(32),
-    index: overrides.index ?? 0,
-    ...overrides,
+    index: rest.index ?? 0,
+    ...rest,
   } as unknown as Log
 }
 

--- a/test/unit/handlers/governanceVeBatchHandler.spec.ts
+++ b/test/unit/handlers/governanceVeBatchHandler.spec.ts
@@ -1,0 +1,720 @@
+import { VotingEscrowIncreasing } from '@artifacts/VotingEscrowIncreasing'
+import { VotingEscrow } from '@artifacts/VotingEscrow'
+import { ExitQueue } from '@artifacts/ExitQueue'
+import { Models } from '@dbModels'
+import { MemberGovernanceFactory } from '@src/governance'
+import { IPluginInterfaceType, IPluginStatus, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { AbiCoder, ethers, Interface, type Log } from 'ethers'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+import { GovernanceVeBatchHandler, VE_TOPICS, VeBatchProcessor } from '@handlers/governanceVeBatchHandler'
+import { TickContext } from '@modules/crawlers/tickContext'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
+
+const veIncreasingIface = new Interface(VotingEscrowIncreasing.abi)
+const exitQueueIface = new Interface(ExitQueue.abi)
+const votingEscrowIface = new Interface(VotingEscrow.abi)
+
+const ESCROW_ADDRESS = ethers.getAddress('0x641DdEdc2139d9948e8dcC936C1Ab2314D9181E6')
+const EXIT_QUEUE_ADDRESS = ethers.getAddress('0x0000000000000000000000000000000000000EE1')
+const TOKEN_ADDRESS = ethers.getAddress('0x0000000000000000000000000000000000000AA1')
+const NFT_LOCK_ADDRESS = ethers.getAddress('0x0000000000000000000000000000000000000BB1')
+const DAO_ADDRESS = ethers.getAddress('0x0000000000000000000000000000000000000DD1')
+const DEPOSITOR = ethers.getAddress('0x65D9d3887aa9a9ee78901E96819B574160E4EAC5')
+const DELEGATEE = ethers.getAddress('0x0000000000000000000000000000000000000CC1')
+const NETWORK = NetworksEnum.ethereumMainnet
+
+const coder = AbiCoder.defaultAbiCoder()
+
+function makeLog(overrides: Partial<Log> & { topics: string[]; data: string; address: string }): Log {
+  return {
+    blockNumber: 100,
+    blockHash: '0x' + '00'.repeat(32),
+    transactionIndex: 0,
+    removed: false,
+    address: overrides.address,
+    data: overrides.data,
+    topics: overrides.topics,
+    transactionHash: '0x' + 'ab'.repeat(32),
+    index: overrides.index ?? 0,
+    ...overrides,
+  } as unknown as Log
+}
+
+function encodeDepositLog(
+  depositor: string,
+  tokenId: bigint,
+  startTs: bigint,
+  value: bigint,
+  newTotalLocked: bigint,
+): Log {
+  const fragment = veIncreasingIface.getEvent('Deposit')!
+  const topics = [
+    fragment.topicHash,
+    coder.encode(['address'], [depositor]),
+    coder.encode(['uint256'], [tokenId]),
+    coder.encode(['uint256'], [startTs]),
+  ]
+  const data = coder.encode(['uint256', 'uint256'], [value, newTotalLocked])
+  return makeLog({ topics, data, address: ESCROW_ADDRESS })
+}
+
+function encodeWithdrawLog(depositor: string, tokenId: bigint, value: bigint, ts: bigint, newTotalLocked: bigint): Log {
+  const fragment = veIncreasingIface.getEvent('Withdraw')!
+  const topics = [fragment.topicHash, coder.encode(['address'], [depositor]), coder.encode(['uint256'], [tokenId])]
+  const data = coder.encode(['uint256', 'uint256', 'uint256'], [value, ts, newTotalLocked])
+  return makeLog({ topics, data, address: ESCROW_ADDRESS })
+}
+
+function encodeMergedLog(
+  sender: string,
+  from: bigint,
+  to: bigint,
+  fromAmount: bigint,
+  toAmount: bigint,
+  newTotalAmount: bigint,
+): Log {
+  const fragment = veIncreasingIface.getEvent('Merged')!
+  const topics = [
+    fragment.topicHash,
+    coder.encode(['address'], [sender]),
+    coder.encode(['uint256'], [from]),
+    coder.encode(['uint256'], [to]),
+  ]
+  const data = coder.encode(['uint208', 'uint208', 'uint208'], [fromAmount, toAmount, newTotalAmount])
+  return makeLog({ topics, data, address: ESCROW_ADDRESS })
+}
+
+function encodeTokensDelegatedLog(sender: string, delegatee: string, tokenIds: bigint[]): Log {
+  const fragment = votingEscrowIface.getEvent('TokensDelegated')!
+  const topics = [fragment.topicHash, coder.encode(['address'], [sender]), coder.encode(['address'], [delegatee])]
+  const data = coder.encode(['uint256[]'], [tokenIds])
+  return makeLog({ topics, data, address: TOKEN_ADDRESS })
+}
+
+function encodeTokensUndelegatedLog(sender: string, delegatee: string, tokenIds: bigint[]): Log {
+  const fragment = votingEscrowIface.getEvent('TokensUndelegated')!
+  const topics = [fragment.topicHash, coder.encode(['address'], [sender]), coder.encode(['address'], [delegatee])]
+  const data = coder.encode(['uint256[]'], [tokenIds])
+  return makeLog({ topics, data, address: TOKEN_ADDRESS })
+}
+
+function encodeExitQueuedV2Log(tokenId: bigint, holder: string, queuedAt: bigint): Log {
+  const fragment = exitQueueIface.getEvent('ExitQueuedV2')!
+  const topics = [fragment.topicHash, coder.encode(['uint256'], [tokenId]), coder.encode(['address'], [holder])]
+  const data = coder.encode(['uint256'], [queuedAt])
+  return makeLog({ topics, data, address: EXIT_QUEUE_ADDRESS })
+}
+
+function encodeSplitLog(from: bigint, newTokenId: bigint, sender: string, amt1: bigint, amt2: bigint): Log {
+  const fragment = veIncreasingIface.getEvent('Split')!
+  const topics = [fragment.topicHash, coder.encode(['uint256'], [from]), coder.encode(['uint256'], [newTokenId])]
+  const data = coder.encode(['address', 'uint208', 'uint208'], [sender, amt1, amt2])
+  return makeLog({ topics, data, address: ESCROW_ADDRESS })
+}
+
+function createPlugin(overrides: any = {}) {
+  return {
+    id: 'test-plugin-1',
+    address: TOKEN_ADDRESS,
+    daoAddress: DAO_ADDRESS,
+    tokenAddress: TOKEN_ADDRESS,
+    network: NETWORK,
+    interfaceType: IPluginInterfaceType.tokenVoting,
+    status: IPluginStatus.installed,
+    votingEscrow: {
+      escrowAddress: ESCROW_ADDRESS,
+      nftLockAddress: NFT_LOCK_ADDRESS,
+      exitQueueAddress: EXIT_QUEUE_ADDRESS,
+    },
+    ...overrides,
+  }
+}
+
+describe('Handler: GovernanceVeBatchHandler', () => {
+  let sandbox: SinonSandbox
+  let tickCtx: TickContext
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({})
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  function makeTickCtx(logs: Log[]): TickContext {
+    const ctx = new TickContext(NETWORK, logs)
+    // Stub the init to avoid actual web3 calls (timestamps already stubbed)
+    sandbox.stub(ctx, 'getBlockTimestamp').resolves(1700000000)
+    return ctx
+  }
+
+  describe('VE_TOPICS', () => {
+    it('should contain topic hashes for all 7 registered events', () => {
+      const expectedEvents = [
+        { iface: veIncreasingIface, name: 'Deposit' },
+        { iface: veIncreasingIface, name: 'Withdraw' },
+        { iface: veIncreasingIface, name: 'Split' },
+        { iface: veIncreasingIface, name: 'Merged' },
+        { iface: exitQueueIface, name: 'ExitQueuedV2' },
+        { iface: votingEscrowIface, name: 'TokensDelegated' },
+        { iface: votingEscrowIface, name: 'TokensUndelegated' },
+      ]
+
+      expect(VE_TOPICS.size).to.equal(7)
+
+      for (const { iface, name } of expectedEvents) {
+        const topicHash = iface.getEvent(name)!.topicHash
+        expect(VE_TOPICS.has(topicHash), `missing topic for ${name}`).to.be.true
+      }
+    })
+  })
+
+  describe('VeBatchProcessor', () => {
+    describe('parseLogs', () => {
+      it('should parse valid logs and populate events', () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const withdrawLog = encodeWithdrawLog(DEPOSITOR, 2n, 300n, 2000n, 200n)
+        const logs = [depositLog, withdrawLog]
+
+        tickCtx = makeTickCtx(logs)
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        const result = processor.parseLogs(logs)
+
+        expect(result).to.equal(processor)
+        // Access private events via casting to check count
+        const events = (processor as any).events
+        expect(events).to.have.lengthOf(2)
+        expect(events[0].eventName).to.equal('Deposit')
+        expect(events[1].eventName).to.equal('Withdraw')
+      })
+
+      it('should skip logs with unknown topics', () => {
+        const unknownLog = makeLog({
+          topics: ['0x' + 'ff'.repeat(32)],
+          data: '0x',
+          address: ESCROW_ADDRESS,
+        })
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+
+        tickCtx = makeTickCtx([unknownLog, depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([unknownLog, depositLog])
+
+        const events = (processor as any).events
+        expect(events).to.have.lengthOf(1)
+        expect(events[0].eventName).to.equal('Deposit')
+      })
+
+      it('should preserve order of logs', () => {
+        const log1 = encodeDepositLog(DEPOSITOR, 1n, 1000n, 100n, 100n)
+        const log2 = encodeMergedLog(DEPOSITOR, 1n, 2n, 50n, 50n, 100n)
+        const log3 = encodeWithdrawLog(DEPOSITOR, 3n, 200n, 3000n, 0n)
+
+        tickCtx = makeTickCtx([log1, log2, log3])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([log1, log2, log3])
+
+        const events = (processor as any).events
+        expect(events[0].eventName).to.equal('Deposit')
+        expect(events[1].eventName).to.equal('Merged')
+        expect(events[2].eventName).to.equal('Withdraw')
+      })
+    })
+
+    describe('resolvePlugins', () => {
+      it('should filter out events without matching plugins', async () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+
+        tickCtx = makeTickCtx([depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog])
+
+        // No plugins in DB => all events should be filtered out
+        sandbox.stub(Models.Plugin, 'find').returns({ lean: sandbox.stub().resolves([]) } as any)
+
+        await processor.resolvePlugins()
+
+        const events = (processor as any).events
+        expect(events).to.have.lengthOf(0)
+      })
+
+      it('should attach plugins to matching events', async () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog])
+
+        const findStub = sandbox.stub(Models.Plugin, 'find')
+        findStub.returns({ lean: sandbox.stub().resolves([plugin]) } as any)
+
+        await processor.resolvePlugins()
+
+        const events = (processor as any).events
+        expect(events).to.have.lengthOf(1)
+        expect(events[0].plugins).to.deep.include(plugin)
+      })
+    })
+
+    describe('createMembers', () => {
+      it('should bulk create members from event addresses', async () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog])
+
+        // Manually inject plugins on events
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Member, 'bulkWrite').resolves()
+
+        await processor.createMembers()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(1)
+        expect(ops[0].updateOne.filter.id).to.equal(ethers.getAddress(DEPOSITOR))
+        expect(ops[0].updateOne.update.$setOnInsert.address).to.equal(ethers.getAddress(DEPOSITOR))
+        expect(ops[0].updateOne.upsert).to.be.true
+      })
+
+      it('should track delegatee address from TokensDelegated events', async () => {
+        const delegateLog = encodeTokensDelegatedLog(DEPOSITOR, DELEGATEE, [1n])
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([delegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([delegateLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Member, 'bulkWrite').resolves()
+
+        await processor.createMembers()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        // Both sender and delegatee should be tracked
+        const ids = ops.map((op: any) => op.updateOne.filter.id)
+        expect(ids).to.include(ethers.getAddress(DEPOSITOR))
+        expect(ids).to.include(ethers.getAddress(DELEGATEE))
+      })
+
+      it('should not call bulkWrite when there are no events', async () => {
+        tickCtx = makeTickCtx([])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+
+        const bulkWriteStub = sandbox.stub(Models.Member, 'bulkWrite').resolves()
+
+        await processor.createMembers()
+
+        expect(bulkWriteStub.called).to.be.false
+      })
+    })
+
+    describe('processDeposits', () => {
+      it('should create lock records via bulkWrite', async () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processDeposits()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(1)
+
+        const setOnInsert = ops[0].updateOne.update.$setOnInsert
+        expect(setOnInsert.memberAddress).to.equal(DEPOSITOR)
+        expect(setOnInsert.tokenId).to.equal('1')
+        expect(setOnInsert.amount).to.equal('500')
+        expect(setOnInsert.totalLocked).to.equal('500')
+        expect(setOnInsert.nftAddress).to.equal(NFT_LOCK_ADDRESS)
+        expect(setOnInsert.tokenAddress).to.equal(TOKEN_ADDRESS)
+        expect(setOnInsert.exitQueueAddress).to.equal(EXIT_QUEUE_ADDRESS)
+      })
+
+      it('should handle same-tx delegation by updating lock with delegatee', async () => {
+        const txHash = '0x' + 'ab'.repeat(32)
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const delegateLog = encodeTokensDelegatedLog(DEPOSITOR, DELEGATEE, [1n])
+        // Make them share the same tx hash
+        ;(delegateLog as any).transactionHash = txHash
+        ;(depositLog as any).transactionHash = txHash
+
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([depositLog, delegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog, delegateLog])
+        ;(processor as any).events[0].plugins = [plugin]
+        ;(processor as any).events[1].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processDeposits()
+
+        // Should have been called twice: once for lock creation, once for delegate update
+        expect(bulkWriteStub.calledTwice).to.be.true
+        const delegateOps = bulkWriteStub.secondCall.args[0]
+        expect(delegateOps).to.have.lengthOf(1)
+        expect(delegateOps[0].updateOne.update.$set.delegateReceiverAddress).to.equal(DELEGATEE)
+      })
+
+      it('should skip when no deposit events exist', async () => {
+        const withdrawLog = encodeWithdrawLog(DEPOSITOR, 1n, 300n, 2000n, 200n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([withdrawLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([withdrawLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processDeposits()
+
+        expect(bulkWriteStub.called).to.be.false
+      })
+    })
+
+    describe('processDelegations', () => {
+      it('should create TokenDelegation records and update locks for delegate', async () => {
+        const delegateLog = encodeTokensDelegatedLog(DEPOSITOR, DELEGATEE, [1n, 2n])
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([delegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([delegateLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const tokenDelegationBulkWrite = sandbox.stub(Models.TokenDelegation, 'bulkWrite').resolves()
+        const lockBulkWrite = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processDelegations('delegate')
+
+        expect(tokenDelegationBulkWrite.calledOnce).to.be.true
+        const delegationOps = tokenDelegationBulkWrite.firstCall.args[0]
+        expect(delegationOps).to.have.lengthOf(1)
+
+        const setOnInsert = delegationOps[0].updateOne.update.$setOnInsert
+        expect(setOnInsert.delegator).to.equal(DEPOSITOR)
+        expect(setOnInsert.delegate).to.equal(DELEGATEE)
+        expect(setOnInsert.tokenIds).to.deep.equal(['1', '2'])
+        expect(setOnInsert.action).to.equal('delegate')
+        expect(setOnInsert.blockTimestamp).to.equal(1700000000)
+
+        expect(lockBulkWrite.calledOnce).to.be.true
+        const lockOps = lockBulkWrite.firstCall.args[0]
+        expect(lockOps[0].updateMany.update.$set.delegateReceiverAddress).to.equal(DELEGATEE)
+      })
+
+      it('should set delegateReceiverAddress to null for undelegate', async () => {
+        const undelegateLog = encodeTokensUndelegatedLog(DEPOSITOR, DELEGATEE, [1n])
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([undelegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([undelegateLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const tokenDelegationBulkWrite = sandbox.stub(Models.TokenDelegation, 'bulkWrite').resolves()
+        const lockBulkWrite = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processDelegations('undelegate')
+
+        expect(tokenDelegationBulkWrite.calledOnce).to.be.true
+        const setOnInsert = tokenDelegationBulkWrite.firstCall.args[0][0].updateOne.update.$setOnInsert
+        expect(setOnInsert.action).to.equal('undelegate')
+
+        expect(lockBulkWrite.calledOnce).to.be.true
+        const lockOps = lockBulkWrite.firstCall.args[0]
+        expect(lockOps[0].updateMany.update.$set.delegateReceiverAddress).to.be.null
+      })
+
+      it('should skip when no delegation events exist', async () => {
+        tickCtx = makeTickCtx([])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+
+        const bulkWriteStub = sandbox.stub(Models.TokenDelegation, 'bulkWrite').resolves()
+
+        await processor.processDelegations('delegate')
+
+        expect(bulkWriteStub.called).to.be.false
+      })
+    })
+
+    describe('processMerges', () => {
+      it('should batch fetch lock amounts and update via bulkWrite', async () => {
+        const mergeLog = encodeMergedLog(DEPOSITOR, 1n, 2n, 100n, 200n, 300n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([mergeLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([mergeLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        sandbox.stub(Models.Lock, 'find').returns({
+          lean: sandbox.stub().resolves([{ tokenId: '1', amount: '100' }]),
+        } as any)
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processMerges()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        // Two ops: one to zero out the from lock, one to update the to lock
+        expect(ops).to.have.lengthOf(2)
+
+        // From lock set to 0 with withdraw info
+        const fromOp = ops[0].updateOne
+        expect(fromOp.update.$set.amount).to.equal('0')
+        expect(fromOp.update.$set.lockWithdraw.status).to.be.true
+        expect(fromOp.update.$set.lockWithdraw.amount).to.equal('100')
+
+        // To lock updated with new total
+        const toOp = ops[1].updateOne
+        expect(toOp.update.$set.amount).to.equal('300')
+        expect(toOp.update.$set.memberAddress).to.equal(DEPOSITOR)
+      })
+
+      it('should skip merge if source lock not found', async () => {
+        const mergeLog = encodeMergedLog(DEPOSITOR, 99n, 2n, 100n, 200n, 300n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([mergeLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([mergeLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        sandbox.stub(Models.Lock, 'find').returns({
+          lean: sandbox.stub().resolves([]),
+        } as any)
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processMerges()
+
+        // No ops should be created since source lock was not found
+        expect(bulkWriteStub.called).to.be.false
+      })
+
+      it('should skip when no merge events exist', async () => {
+        tickCtx = makeTickCtx([])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+
+        const findStub = sandbox.stub(Models.Lock, 'find')
+
+        await processor.processMerges()
+
+        expect(findStub.called).to.be.false
+      })
+    })
+
+    describe('processMetrics', () => {
+      it('should bulk upsert PluginMetrics for event participants', async () => {
+        const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([depositLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([depositLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.PluginMetrics, 'bulkWrite').resolves()
+
+        await processor.processMetrics()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(1)
+
+        const setOnInsert = ops[0].updateOne.update.$setOnInsert
+        expect(setOnInsert.memberAddress).to.equal(ethers.getAddress(DEPOSITOR))
+        expect(setOnInsert.pluginAddress).to.equal(TOKEN_ADDRESS)
+        expect(setOnInsert.daoAddress).to.equal(DAO_ADDRESS)
+        expect(setOnInsert.proposalCount).to.equal(0)
+        expect(setOnInsert.voteCount).to.equal(0)
+      })
+
+      it('should add metrics for both sender and delegatee on TokensDelegated', async () => {
+        const delegateLog = encodeTokensDelegatedLog(DEPOSITOR, DELEGATEE, [1n])
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([delegateLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([delegateLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.PluginMetrics, 'bulkWrite').resolves()
+
+        await processor.processMetrics()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(2)
+
+        const members = ops.map((op: any) => op.updateOne.update.$setOnInsert.memberAddress)
+        expect(members).to.include(ethers.getAddress(DEPOSITOR))
+        expect(members).to.include(ethers.getAddress(DELEGATEE))
+      })
+
+      it('should not call bulkWrite when no events', async () => {
+        tickCtx = makeTickCtx([])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+
+        const bulkWriteStub = sandbox.stub(Models.PluginMetrics, 'bulkWrite').resolves()
+
+        await processor.processMetrics()
+
+        expect(bulkWriteStub.called).to.be.false
+      })
+    })
+
+    describe('processWithdraws', () => {
+      it('should update locks with withdraw info', async () => {
+        const withdrawLog = encodeWithdrawLog(DEPOSITOR, 1n, 300n, 2000n, 200n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([withdrawLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([withdrawLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processWithdraws()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(1)
+
+        const update = ops[0].updateOne.update.$set
+        expect(update.memberAddress).to.equal(DEPOSITOR)
+        expect(update.delegateReceiverAddress).to.be.null
+        expect(update.lockWithdraw.status).to.be.true
+        expect(update.lockWithdraw.amount).to.equal('300')
+        expect(update.lockWithdraw.totalLocked).to.equal('200')
+      })
+    })
+
+    describe('processExitQueued', () => {
+      it('should update locks with exit queue info', async () => {
+        const exitLog = encodeExitQueuedV2Log(1n, DEPOSITOR, 1700000000n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([exitLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([exitLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processExitQueued()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(1)
+
+        const update = ops[0].updateOne.update.$set
+        expect(update.memberAddress).to.equal(DEPOSITOR)
+        expect(update.lockExit.status).to.be.true
+        expect(update.lockExit.tokenId).to.equal('1')
+        expect(update.lockExit.holder).to.equal(DEPOSITOR)
+        expect(update.lockExit.exitDateAt).to.equal(1700000000)
+      })
+    })
+
+    describe('processSplits', () => {
+      it('should create new lock and update original via bulkWrite', async () => {
+        const splitLog = encodeSplitLog(1n, 2n, DEPOSITOR, 300n, 200n)
+        const plugin = createPlugin()
+
+        tickCtx = makeTickCtx([splitLog])
+        const processor = new VeBatchProcessor(NETWORK, tickCtx)
+        processor.parseLogs([splitLog])
+        ;(processor as any).events[0].plugins = [plugin]
+
+        sandbox.stub(Models.Lock, 'findOne').resolves({
+          tokenId: '1',
+          epochStartAt: 1000,
+          amount: '500',
+        } as any)
+
+        const bulkWriteStub = sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+
+        await processor.processSplits()
+
+        expect(bulkWriteStub.calledOnce).to.be.true
+        const ops = bulkWriteStub.firstCall.args[0]
+        expect(ops).to.have.lengthOf(2)
+
+        // New lock from split
+        const newLock = ops[0].updateOne.update.$setOnInsert
+        expect(newLock.tokenId).to.equal('2')
+        expect(newLock.amount).to.equal('200')
+        expect(newLock.splitFromTokenId).to.equal('1')
+        expect(newLock.epochStartAt).to.equal(1000)
+
+        // Original lock amount updated
+        const originalUpdate = ops[1].updateOne.update.$set
+        expect(originalUpdate.amount).to.equal('300')
+        expect(originalUpdate.memberAddress).to.equal(DEPOSITOR)
+      })
+    })
+  })
+
+  describe('GovernanceVeBatchHandler.processVeEventsBatch', () => {
+    it('should return immediately for empty logs', async () => {
+      const pluginFindStub = sandbox.stub(Models.Plugin, 'find')
+
+      await GovernanceVeBatchHandler.processVeEventsBatch([], NETWORK)
+
+      expect(pluginFindStub.called).to.be.false
+    })
+
+    it('should orchestrate the full flow', async () => {
+      const depositLog = encodeDepositLog(DEPOSITOR, 1n, 1000n, 500n, 500n)
+      const plugin = createPlugin()
+
+      // Stub Plugin.find for resolvePlugins
+      sandbox.stub(Models.Plugin, 'find').returns({
+        lean: sandbox.stub().resolves([plugin]),
+      } as any)
+
+      // Stub all model writes
+      sandbox.stub(Models.Member, 'bulkWrite').resolves()
+      sandbox.stub(Models.Lock, 'bulkWrite').resolves()
+      sandbox.stub(Models.Lock, 'find').returns({ lean: sandbox.stub().resolves([]) } as any)
+      sandbox.stub(Models.Lock, 'findOne').resolves(null)
+      sandbox.stub(Models.TokenDelegation, 'bulkWrite').resolves()
+      sandbox.stub(Models.PluginMetrics, 'bulkWrite').resolves()
+
+      // Stub MemberGovernanceFactory
+      sandbox.stub(MemberGovernanceFactory, 'create').returns({
+        updateDaoMetrics: sandbox.stub().resolves(),
+      } as any)
+
+      await GovernanceVeBatchHandler.processVeEventsBatch([depositLog], NETWORK)
+
+      // Verify Member.bulkWrite was called (members created)
+      expect((Models.Member.bulkWrite as sinon.SinonStub).calledOnce).to.be.true
+      // Verify Lock.bulkWrite was called (deposits processed)
+      expect((Models.Lock.bulkWrite as sinon.SinonStub).called).to.be.true
+      // Verify PluginMetrics.bulkWrite was called (metrics processed)
+      expect((Models.PluginMetrics.bulkWrite as sinon.SinonStub).calledOnce).to.be.true
+    })
+  })
+})

--- a/test/unit/handlers/governanceVeHandler.spec.ts
+++ b/test/unit/handlers/governanceVeHandler.spec.ts
@@ -2585,6 +2585,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xselfdelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.delegateTokens(mockParsedEvent, mockInfo)
@@ -2695,6 +2696,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xmultidelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.delegateTokens(mockParsedEvent, mockInfo)
@@ -2819,6 +2821,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xerrordelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       // Handler should not throw but log the error
@@ -2852,7 +2855,6 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xabcG',
         blockNumber: 1,
         votingEscrow: {
-          escrowAddress: '0xEscrowG',
           nftLockAddress: '0xNftG',
           exitQueueAddress: '0xExitQueueG',
         },
@@ -2890,6 +2892,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xnoescrowtx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.delegateTokens(mockParsedEvent, mockInfo)
@@ -2991,6 +2994,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xundelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.unDelegateTokens(mockParsedEvent, mockInfo)
@@ -3113,6 +3117,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xmultiundelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.unDelegateTokens(mockParsedEvent, mockInfo)
@@ -3223,6 +3228,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xemptyundelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.unDelegateTokens(mockParsedEvent, mockInfo)
@@ -3290,6 +3296,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xerrorundelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       // Handler should not throw but log the error
@@ -3323,7 +3330,6 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xabcH',
         blockNumber: 1,
         votingEscrow: {
-          escrowAddress: '0xEscrowH',
           nftLockAddress: '0xNftH',
           exitQueueAddress: '0xExitQueueH',
         },
@@ -3361,6 +3367,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xnoescrowundelegatetx',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.unDelegateTokens(mockParsedEvent, mockInfo)
@@ -3412,6 +3419,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xhash',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.delegateTokens(mockParsedEvent, mockInfo)
@@ -3457,6 +3465,7 @@ describe('Handler:GovernanceVeHandler', () => {
         transactionHash: '0xhash',
         transactionIndex: 1,
         logIndex: 1,
+        context: { getBlockTimestamp: sandbox.stub().resolves(1640995200) },
       } as any
 
       await GovernanceVeHandler.delegateTokens(mockParsedEvent, mockInfo)

--- a/test/unit/handlers/governanceVeHandler.spec.ts
+++ b/test/unit/handlers/governanceVeHandler.spec.ts
@@ -1,3 +1,4 @@
+import { VotingEscrow } from '@artifacts/VotingEscrow'
 import { Models } from '@dbModels'
 import { GovernanceVeHandler } from '@handlers/governanceVeHandler'
 import GovernanceVeHelper from '@helpers/governanceVe'
@@ -9,6 +10,7 @@ import { PluginSetting } from '@models/schema/setting'
 import { MemberGovernanceFactory } from '@src/governance'
 import { IPluginInterfaceType, IPluginStatus, ISettingStatus, NetworksEnum } from '@types'
 import { expect } from 'chai'
+import { AbiCoder, Interface } from 'ethers'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 
@@ -3813,6 +3815,76 @@ describe('Handler:GovernanceVeHandler', () => {
       expect(stubLoggerError.calledOnce).to.be.true
       expect(stubLoggerError.calledWith('Merge error' as any)).to.be.true
       expect(stubLoggerVerbose.notCalled).to.be.true
+    })
+  })
+
+  describe('checkSameTxDelegation', () => {
+    const coder = AbiCoder.defaultAbiCoder()
+    const iface = new Interface(VotingEscrow.abi)
+
+    function encodeTokensDelegatedLog(sender: string, delegatee: string, tokenIds: bigint[]) {
+      const fragment = iface.getEvent('TokensDelegated')!
+      const topics = [fragment.topicHash, coder.encode(['address'], [sender]), coder.encode(['address'], [delegatee])]
+      const data = coder.encode(['uint256[]'], [tokenIds])
+      return { topics, data }
+    }
+
+    it('should return undefined if txReceipt is null', async () => {
+      sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves(null)
+
+      const result = await GovernanceVeHandler.checkSameTxDelegation(
+        { tokenId: '1' } as any,
+        { transactionHash: '0xtx', network: NetworksEnum.ethereumMainnet } as any,
+      )
+
+      expect(result).to.be.undefined
+    })
+
+    it('should return delegatee when matching TokensDelegated log found', async () => {
+      const delegatee = '0x65D9d3887aa9a9ee78901E96819B574160E4EAC5'
+      const sender = '0x0000000000000000000000000000000000000001'
+      const { topics, data } = encodeTokensDelegatedLog(sender, delegatee, [42n])
+
+      sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves({
+        logs: [{ topics, data }],
+      } as any)
+
+      const result = await GovernanceVeHandler.checkSameTxDelegation(
+        { tokenId: '42' } as any,
+        { transactionHash: '0xtx', network: NetworksEnum.ethereumMainnet } as any,
+      )
+
+      expect(result).to.equal(delegatee)
+    })
+
+    it('should skip logs that do not match tokenId', async () => {
+      const delegatee = '0x65D9d3887aa9a9ee78901E96819B574160E4EAC5'
+      const sender = '0x0000000000000000000000000000000000000001'
+      const { topics, data } = encodeTokensDelegatedLog(sender, delegatee, [99n])
+
+      sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves({
+        logs: [{ topics, data }],
+      } as any)
+
+      const result = await GovernanceVeHandler.checkSameTxDelegation(
+        { tokenId: '42' } as any,
+        { transactionHash: '0xtx', network: NetworksEnum.ethereumMainnet } as any,
+      )
+
+      expect(result).to.be.undefined
+    })
+
+    it('should skip non-TokensDelegated logs gracefully', async () => {
+      sandbox.stub(Web3Helper, 'getTransactionReceipt').resolves({
+        logs: [{ topics: ['0xdeadbeef'], data: '0x' }],
+      } as any)
+
+      const result = await GovernanceVeHandler.checkSameTxDelegation(
+        { tokenId: '1' } as any,
+        { transactionHash: '0xtx', network: NetworksEnum.ethereumMainnet } as any,
+      )
+
+      expect(result).to.be.undefined
     })
   })
 })

--- a/test/unit/modules/crawlers/logProcessingEngine.spec.ts
+++ b/test/unit/modules/crawlers/logProcessingEngine.spec.ts
@@ -1106,4 +1106,223 @@ describe('Module: LogProcessingEngine', () => {
       expect(engine.getProcessingStats().nbSuccess).to.equal(1)
     })
   })
+
+  describe('processLogs - batch handler support', () => {
+    let parseLogStub: SinonStub
+    let parseInfoLogStub: SinonStub
+    let mockBatchHandler: SinonStub
+
+    const BATCH_THRESHOLD = 10
+
+    const batchTopic = '0xbatch_topic_hash'
+
+    beforeEach(() => {
+      mockBatchHandler = sandbox.stub().resolves()
+      Object.defineProperty(mockBatchHandler, 'name', { value: 'veBatchHandler', writable: false })
+
+      parseInfoLogStub = sandbox.stub(Web3Utils, 'parseInfoLog').returns({
+        address: '0xcontract',
+        blockNumber: 1000,
+        network: NetworksEnum.ethereumMainnet,
+        transactionIndex: 0,
+        logIndex: 0,
+        transactionHash: '0xtx',
+        eventName: 'Transfer',
+      })
+    })
+
+    it('should use batchHandler when event count >= BATCH_THRESHOLD', async () => {
+      const parseLogStub = sandbox.stub(Web3Utils, 'parseLog').returns({
+        name: 'Transfer',
+        args: [] as any,
+      } as any)
+
+      const batchEvent: IIndexerConfig = {
+        ...mockEvent,
+        config: [
+          {
+            ...mockEvent.config[0],
+            handler: mockHandler,
+            batchHandler: mockBatchHandler,
+          },
+        ],
+      }
+
+      const batchEngine = new LogProcessingEngine({
+        events: [batchEvent],
+        isTopicObject: false,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      const logs = Array.from({ length: BATCH_THRESHOLD }, (_, i) =>
+        createMockLog({ blockNumber: 1000 + i, transactionHash: `0xtx${i}` }),
+      )
+
+      await batchEngine.processLogs(logs, createContext())
+
+      expect(mockBatchHandler.calledOnce).to.be.true
+      expect(mockHandler.called).to.be.false
+      const callArg = mockBatchHandler.firstCall.args[0]
+      expect(callArg).to.be.an('array').with.lengthOf(BATCH_THRESHOLD)
+    })
+
+    it('should fall back to individual handler when event count < BATCH_THRESHOLD', async () => {
+      sandbox.stub(Web3Utils, 'parseLog').returns({
+        name: 'Transfer',
+        args: [] as any,
+      } as any)
+
+      const batchEvent: IIndexerConfig = {
+        ...mockEvent,
+        config: [
+          {
+            ...mockEvent.config[0],
+            handler: mockHandler,
+            batchHandler: mockBatchHandler,
+          },
+        ],
+      }
+
+      const batchEngine = new LogProcessingEngine({
+        events: [batchEvent],
+        isTopicObject: false,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      const logs = Array.from({ length: BATCH_THRESHOLD - 1 }, (_, i) =>
+        createMockLog({ blockNumber: 1000 + i, transactionHash: `0xtx${i}` }),
+      )
+
+      await batchEngine.processLogs(logs, createContext())
+
+      expect(mockBatchHandler.called).to.be.false
+      expect(mockHandler.callCount).to.equal(BATCH_THRESHOLD - 1)
+    })
+
+    it('should process both individual and batch handlers in same tick', async () => {
+      const individualHandler = sandbox.stub().resolves()
+      sandbox.stub(Web3Utils, 'parseLog').returns({
+        name: 'Transfer',
+        args: [] as any,
+      } as any)
+
+      const individualTopic = '0xindividual_topic'
+
+      const batchEvent: IIndexerConfig = {
+        topic: mockEvent.topic,
+        event: 'Transfer',
+        config: [
+          {
+            ...mockEvent.config[0],
+            handler: mockHandler,
+            batchHandler: mockBatchHandler,
+          },
+        ],
+      }
+
+      const individualEvent: IIndexerConfig = {
+        topic: individualTopic,
+        event: 'Transfer',
+        config: [
+          {
+            abi: mockEvent.config[0].abi,
+            handler: individualHandler,
+          },
+        ],
+      }
+
+      const mixedEngine = new LogProcessingEngine({
+        events: [batchEvent, individualEvent],
+        isTopicObject: false,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      const batchLogs = Array.from({ length: BATCH_THRESHOLD }, (_, i) =>
+        createMockLog({ blockNumber: 1000 + i, transactionHash: `0xbatch${i}`, topics: [mockEvent.topic] }),
+      )
+      const individualLogs = Array.from({ length: 3 }, (_, i) =>
+        createMockLog({ blockNumber: 2000 + i, transactionHash: `0xind${i}`, topics: [individualTopic] }),
+      )
+
+      const allLogs = [...batchLogs, ...individualLogs]
+
+      await mixedEngine.processLogs(allLogs, createContext())
+
+      expect(mockBatchHandler.calledOnce).to.be.true
+      expect(individualHandler.callCount).to.equal(3)
+      expect(mockHandler.called).to.be.false
+    })
+
+    it('should handle errors in batch handler', async () => {
+      sandbox.stub(Web3Utils, 'parseLog').returns({
+        name: 'Transfer',
+        args: [] as any,
+      } as any)
+
+      const failingBatchHandler = sandbox.stub().rejects(new Error('Batch processing failed'))
+      Object.defineProperty(failingBatchHandler, 'name', { value: 'failBatchHandler', writable: false })
+
+      const batchEvent: IIndexerConfig = {
+        ...mockEvent,
+        config: [
+          {
+            ...mockEvent.config[0],
+            handler: mockHandler,
+            batchHandler: failingBatchHandler,
+          },
+        ],
+      }
+
+      const batchEngine = new LogProcessingEngine({
+        events: [batchEvent],
+        isTopicObject: false,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      const logs = Array.from({ length: BATCH_THRESHOLD }, (_, i) =>
+        createMockLog({ blockNumber: 1000 + i, transactionHash: `0xtx${i}` }),
+      )
+
+      await batchEngine.processLogs(logs, createContext())
+
+      expect(batchEngine.getProcessingStats().nbError).to.equal(BATCH_THRESHOLD)
+    })
+
+    it('should pass TickContext to batch handler events', async () => {
+      sandbox.stub(Web3Utils, 'parseLog').returns({
+        name: 'Transfer',
+        args: [] as any,
+      } as any)
+
+      const batchEvent: IIndexerConfig = {
+        ...mockEvent,
+        config: [
+          {
+            ...mockEvent.config[0],
+            handler: mockHandler,
+            batchHandler: mockBatchHandler,
+          },
+        ],
+      }
+
+      const batchEngine = new LogProcessingEngine({
+        events: [batchEvent],
+        isTopicObject: false,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      const logs = Array.from({ length: BATCH_THRESHOLD }, (_, i) =>
+        createMockLog({ blockNumber: 1000 + i, transactionHash: `0xtx${i}` }),
+      )
+
+      await batchEngine.processLogs(logs, createContext())
+
+      expect(mockBatchHandler.calledOnce).to.be.true
+      const batchEvents = mockBatchHandler.firstCall.args[0]
+      for (const evt of batchEvents) {
+        expect(evt.info).to.have.property('context')
+        expect(evt.info.context).to.not.be.undefined
+      }
+    })
+  })
 })

--- a/test/unit/modules/crawlers/logProcessingEngine.spec.ts
+++ b/test/unit/modules/crawlers/logProcessingEngine.spec.ts
@@ -1108,13 +1108,10 @@ describe('Module: LogProcessingEngine', () => {
   })
 
   describe('processLogs - batch handler support', () => {
-    let parseLogStub: SinonStub
     let parseInfoLogStub: SinonStub
     let mockBatchHandler: SinonStub
 
     const BATCH_THRESHOLD = 10
-
-    const batchTopic = '0xbatch_topic_hash'
 
     beforeEach(() => {
       mockBatchHandler = sandbox.stub().resolves()
@@ -1132,7 +1129,7 @@ describe('Module: LogProcessingEngine', () => {
     })
 
     it('should use batchHandler when event count >= BATCH_THRESHOLD', async () => {
-      const parseLogStub = sandbox.stub(Web3Utils, 'parseLog').returns({
+      sandbox.stub(Web3Utils, 'parseLog').returns({
         name: 'Transfer',
         args: [] as any,
       } as any)

--- a/test/unit/modules/crawlers/tickContext.spec.ts
+++ b/test/unit/modules/crawlers/tickContext.spec.ts
@@ -1,0 +1,262 @@
+import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
+import logger from '@logger'
+import { TickContext } from '@modules/crawlers/tickContext'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import type { Log } from 'ethers'
+import sinon, { type SinonSandbox, type SinonStub } from 'sinon'
+
+const makeMockLog = (blockNumber: number, transactionHash: string, index: number): Log =>
+  ({
+    blockNumber,
+    transactionHash,
+    index,
+    blockHash: `0xblockhash${blockNumber}`,
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    data: '0x',
+    topics: [],
+    removed: false,
+    transactionIndex: 0,
+  }) as unknown as Log
+
+describe('Module: TickContext', () => {
+  let sandbox: SinonSandbox
+  let getBlocksTimestampsStub: SinonStub
+  let getBlockTimestampStub: SinonStub
+  let getTransactionReceiptStub: SinonStub
+  let logErrorStub: SinonStub
+
+  const network = NetworksEnum.ethereumMainnet
+
+  const mockLogs: Log[] = [
+    makeMockLog(100, '0xtx1', 0),
+    makeMockLog(100, '0xtx1', 1),
+    makeMockLog(101, '0xtx2', 0),
+    makeMockLog(102, '0xtx3', 0),
+  ]
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    logErrorStub = sandbox.stub(logger, 'error')
+
+    getBlocksTimestampsStub = sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves({
+      'eth-100': 1000,
+      'eth-101': 1010,
+      'eth-102': 1020,
+    })
+    getBlockTimestampStub = sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(9999)
+    getTransactionReceiptStub = sandbox.stub(Web3Helper, 'getTransactionReceipt')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('constructor', () => {
+    it('should create an instance with network and logs', () => {
+      const ctx = new TickContext(network, mockLogs)
+      const json = ctx.toJSON()
+      expect(json.network).to.equal(network)
+      expect(json.logs).to.equal(4)
+      expect(json.initialized).to.equal(false)
+    })
+  })
+
+  describe('init', () => {
+    it('should index logs by block and txHash and prefetch timestamps', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      expect(ctx.toJSON().initialized).to.equal(true)
+      expect(getBlocksTimestampsStub.calledOnce).to.be.true
+      expect(getBlocksTimestampsStub.calledWith(100, 102, network)).to.be.true
+    })
+
+    it('should be idempotent — second call is a no-op', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+      await ctx.init()
+
+      expect(getBlocksTimestampsStub.calledOnce).to.be.true
+    })
+
+    it('should handle empty logs without calling batch helper', async () => {
+      const ctx = new TickContext(network, [])
+      await ctx.init()
+
+      expect(getBlocksTimestampsStub.called).to.be.false
+      expect(ctx.toJSON().initialized).to.equal(true)
+    })
+  })
+
+  describe('getBlockTimestamp', () => {
+    it('should return cached timestamp from prefetch', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const ts = await ctx.getBlockTimestamp(100)
+      expect(ts).to.equal(1000)
+      expect(getBlockTimestampStub.called).to.be.false
+    })
+
+    it('should fallback to Web3Helper for uncached block', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const ts = await ctx.getBlockTimestamp(999)
+      expect(ts).to.equal(9999)
+      expect(getBlockTimestampStub.calledOnce).to.be.true
+      expect(getBlockTimestampStub.calledWith(999, network)).to.be.true
+    })
+
+    it('should cache the fallback result for subsequent calls', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      await ctx.getBlockTimestamp(999)
+      await ctx.getBlockTimestamp(999)
+
+      expect(getBlockTimestampStub.calledOnce).to.be.true
+    })
+  })
+
+  describe('getLogsByBlock', () => {
+    it('should return logs grouped by block number', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const logsFor100 = ctx.getLogsByBlock(100)
+      expect(logsFor100).to.have.length(2)
+      expect(logsFor100[0].transactionHash).to.equal('0xtx1')
+
+      const logsFor101 = ctx.getLogsByBlock(101)
+      expect(logsFor101).to.have.length(1)
+    })
+
+    it('should return empty array for unknown block', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      expect(ctx.getLogsByBlock(999)).to.deep.equal([])
+    })
+  })
+
+  describe('getLogsByTxHash', () => {
+    it('should return cached logs by txHash', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const logs = await ctx.getLogsByTxHash('0xtx1')
+      expect(logs).to.have.length(2)
+      expect(getTransactionReceiptStub.called).to.be.false
+    })
+
+    it('should fallback to Web3Helper for uncached txHash', async () => {
+      const receiptLogs = [makeMockLog(200, '0xtxUnknown', 0)]
+      getTransactionReceiptStub.resolves({ logs: receiptLogs })
+
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const logs = await ctx.getLogsByTxHash('0xtxUnknown')
+      expect(logs).to.have.length(1)
+      expect(getTransactionReceiptStub.calledOnce).to.be.true
+    })
+
+    it('should return empty array when receipt is null', async () => {
+      getTransactionReceiptStub.resolves(null)
+
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      const logs = await ctx.getLogsByTxHash('0xtxMissing')
+      expect(logs).to.deep.equal([])
+    })
+
+    it('should cache fetched receipt logs for subsequent calls', async () => {
+      const receiptLogs = [makeMockLog(200, '0xtxNew', 0)]
+      getTransactionReceiptStub.resolves({ logs: receiptLogs })
+
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      await ctx.getLogsByTxHash('0xtxNew')
+      await ctx.getLogsByTxHash('0xtxNew')
+
+      expect(getTransactionReceiptStub.calledOnce).to.be.true
+    })
+  })
+
+  describe('getOrFetch', () => {
+    it('should call fetcher on first access and cache the result', async () => {
+      const ctx = new TickContext(network, [])
+      const fetcher = sandbox.stub().resolves('hello')
+
+      const val1 = await ctx.getOrFetch('key1', fetcher)
+      const val2 = await ctx.getOrFetch('key1', fetcher)
+
+      expect(val1).to.equal('hello')
+      expect(val2).to.equal('hello')
+      expect(fetcher.calledOnce).to.be.true
+    })
+
+    it('should keep separate entries for different keys', async () => {
+      const ctx = new TickContext(network, [])
+
+      const val1 = await ctx.getOrFetch('a', async () => 1)
+      const val2 = await ctx.getOrFetch('b', async () => 2)
+
+      expect(val1).to.equal(1)
+      expect(val2).to.equal(2)
+    })
+  })
+
+  describe('clear', () => {
+    it('should reset all internal state', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      // Populate generic cache
+      await ctx.getOrFetch('foo', async () => 'bar')
+
+      ctx.clear()
+
+      const json = ctx.toJSON()
+      expect(json.initialized).to.equal(false)
+      expect(ctx.getLogsByBlock(100)).to.deep.equal([])
+    })
+  })
+
+  describe('toJSON', () => {
+    it('should return correct shape before init', () => {
+      const ctx = new TickContext(network, mockLogs)
+      const json = ctx.toJSON()
+
+      expect(json).to.deep.equal({
+        initialized: false,
+        network,
+        logs: 4,
+      })
+    })
+
+    it('should return initialized true after init', async () => {
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      expect(ctx.toJSON().initialized).to.equal(true)
+    })
+  })
+
+  describe('prefetchBlockTimestamps error handling', () => {
+    it('should log error and continue when batch fetch fails', async () => {
+      getBlocksTimestampsStub.rejects(new Error('batch failed'))
+
+      const ctx = new TickContext(network, mockLogs)
+      await ctx.init()
+
+      expect(logErrorStub.calledOnce).to.be.true
+      expect(ctx.toJSON().initialized).to.equal(true)
+    })
+  })
+})

--- a/test/unit/modules/poolingCrawler.spec.ts
+++ b/test/unit/modules/poolingCrawler.spec.ts
@@ -181,8 +181,6 @@ describe('Module: PoolingCrawler', () => {
     })
 
     it('should wait for peaqMainnet network', async () => {
-      const govTokenInterface = new Interface(GovernanceERC20.abi)
-      const transferTopic = govTokenInterface.getEvent('Transfer')?.topicHash!
       const daoInterface = new Interface(DAO.abi)
       const nativeTokenDepositedTopic = daoInterface.getEvent('NativeTokenDeposited')?.topicHash!
 

--- a/test/unit/modules/poolingCrawler.spec.ts
+++ b/test/unit/modules/poolingCrawler.spec.ts
@@ -10,7 +10,7 @@ import { PluginList } from '@test/mock/fakePlugins'
 import { FakeToken } from '@test/mock/fakeToken'
 import { IPluginInterfaceType, ITokenType, NetworksEnum } from '@types'
 import { expect } from 'chai'
-import { ethers, Interface } from 'ethers'
+import { ethers, Interface, type Log } from 'ethers'
 import * as sinon from 'sinon'
 import { type SinonSandbox } from 'sinon'
 
@@ -256,6 +256,86 @@ describe('Module: PoolingCrawler', () => {
       expect(loggerStub.calledOnce).to.be.true
       expect(loggerStub.firstCall.args[0]).to.equal('PoolingCrawler filterLogs')
       expect(result).to.equal(mockLogs)
+    })
+  })
+
+  describe('_filterVeLogs', () => {
+    let processVeStub: sinon.SinonStub
+
+    beforeEach(async () => {
+      const { GovernanceVeBatchHandler } = await import('@handlers/governanceVeBatchHandler')
+      processVeStub = sandbox.stub(GovernanceVeBatchHandler, 'processVeEventsBatch').resolves()
+    })
+
+    const getVeTopics = async () => {
+      const { VE_TOPICS } = await import('@handlers/governanceVeBatchHandler')
+      return [...VE_TOPICS]
+    }
+
+    const createMockLog = (topic: string, address = '0x1234567890abcdef1234567890abcdef12345678') =>
+      ({
+        topics: [topic],
+        address,
+        blockNumber: 100,
+        transactionHash: '0xtx',
+        transactionIndex: 0,
+        index: 0,
+        data: '0x',
+        removed: false,
+      }) as unknown as Log
+
+    it('should return logs unchanged when no VE topics present', async () => {
+      const logs = [createMockLog('0xnon_ve_topic_hash'), createMockLog('0xanother_non_ve_topic')]
+
+      const result = await PoolingCrawler._filterVeLogs(logs, NetworksEnum.ethereumMainnet)
+
+      expect(result).to.deep.equal(logs)
+      expect(processVeStub.called).to.be.false
+    })
+
+    it('should intercept VE logs and process via batch handler', async () => {
+      const veTopics = await getVeTopics()
+      const veTopic = veTopics[0]
+
+      const veLogs = [createMockLog(veTopic), createMockLog(veTopic)]
+
+      const result = await PoolingCrawler._filterVeLogs(veLogs, NetworksEnum.ethereumMainnet)
+
+      expect(processVeStub.calledOnce).to.be.true
+      expect(processVeStub.firstCall.args[0]).to.have.lengthOf(2)
+      expect(processVeStub.firstCall.args[1]).to.equal(NetworksEnum.ethereumMainnet)
+      expect(result).to.have.lengthOf(0)
+    })
+
+    it('should return remaining non-VE logs', async () => {
+      const veTopics = await getVeTopics()
+      const veTopic = veTopics[0]
+      const nonVeTopic = '0xnon_ve_topic_hash'
+
+      const logs = [createMockLog(veTopic), createMockLog(nonVeTopic), createMockLog(veTopic)]
+
+      const result = await PoolingCrawler._filterVeLogs(logs, NetworksEnum.ethereumMainnet)
+
+      expect(processVeStub.calledOnce).to.be.true
+      expect(result).to.have.lengthOf(1)
+      expect(result[0].topics[0]).to.equal(nonVeTopic)
+    })
+
+    it('should fall back to returning all logs on batch handler error', async () => {
+      const veTopics = await getVeTopics()
+      const veTopic = veTopics[0]
+
+      processVeStub.rejects(new Error('Batch processing failed'))
+
+      const loggerStub = sandbox.stub(logger, 'error')
+
+      const logs = [createMockLog(veTopic), createMockLog('0xother_topic')]
+
+      const result = await PoolingCrawler._filterVeLogs(logs, NetworksEnum.ethereumMainnet)
+
+      expect(result).to.deep.equal(logs)
+      expect(loggerStub.calledOnce).to.be.true
+      expect(loggerStub.firstCall.args[0]).to.include('VeBatch processing failed')
     })
   })
 


### PR DESCRIPTION
## 📝 Summary

Optimizes the real-time indexer to handle high-volume VE governance event batches (deposit, delegate, merge, split, etc.) that previously caused the Katana indexer to fall behind by ~10 minutes during bulk on-chain operations.

**Task:** [BE-183](https://linear.app/aragon/issue/BE-183/optimize-real-time-indexer-performance-for-high-volume-event-batches)

## 🔄 What Changed

### VE Batch Processor (`governanceVeBatchHandler.ts`)
- New `VeBatchProcessor` class that processes VE lifecycle events (Deposit, Withdraw, Delegation, Split, Merge, ExitQueued) using MongoDB `bulkWrite` instead of individual DB transactions
- Intercepts VE events in `PoolingCrawler._filterVeLogs` before the sequential handler path, processes them in bulk, and returns remaining events to the normal flow
- Falls back to individual handlers on error

### Adaptive Batch Handler Support (`logProcessingEngine.ts`)
- Extended `IIndexerConfigHandler` with optional `batchHandler` field — config can now declare both individual and batch handlers per event type
- `processLogs` automatically partitions events: if a handler has a `batchHandler` and event count exceeds `BATCH_THRESHOLD` (10), uses the batch path; otherwise falls back to individual handler
- Refactored `processLogs` into focused methods: `partitionByBatchSupport`, `runIndividualHandlers`, `runBatchHandlers`

### TickContext (`tickContext.ts`)
- Per-tick caching layer for block timestamps and transaction logs
- Batch-prefetches timestamps via `Web3BatchHelper.getBlocksTimestamps` during `init()`
- `toJSON()` prevents raw log array serialization in logger output

### Additional Batch Handlers
- `delegateChangedBatch` in `governanceErc20Handler.ts` — bulk upserts `LogDelegateChanged` records
- `payoutClaimedBatch` in `capitalDistributorHandler.ts` — bulk upserts reward claims and campaign updates

### Bug Fixes
- Fixed `escrowAddress` lookup in `governanceVeHandler.ts` — was always calling RPC, now reads from `plugin.votingEscrow.escrowAddress` first
- Fixed `logIndex: undefined` in batch handler log parsing — uses `log.index ?? log.logIndex` fallback

## 📊 Performance Impact

Processing 4,348 VE events in a single batch:
- **Before**: ~10 minutes (individual DB transactions + redundant RPC calls)  
- **After**: ~2-4 seconds (bulk DB operations, cached timestamps, zero redundant RPC)

## 🔍 Data Validation

Batch handler output validated against:
- Production database (exact match on all metrics)
- Envio-based indexer (exact match at same block height)
- On-chain event counts (72 withdraws, 5,816 deposits — exact)

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [x] Included integration tests for end-to-end scenarios (unit-dep)
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship**