### PR TITLE
feat(capitalDistributor): add fileUrl support for campaign member uploads

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "includes": [

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -5,7 +5,6 @@ import { type HexAddress, type IPermission, NetworksEnum } from '@types'
 import async from 'async'
 import { ethers } from 'ethers'
 import { IIndexerConfig } from '@src/types/crawler'
-import config from '@config'
 
 const Utils = {
   noop: (): number => 0,
@@ -537,17 +536,11 @@ const Utils = {
 
   async preflightFileUrl(rawUrl: string): Promise<boolean> {
     try {
-      const maxBytes: number = config.FILE_UPLOADS.MAX_FILE_SIZE_MB
       const head = await fetch(rawUrl, { method: 'HEAD' })
       if (!head.ok) return false
 
       const contentType = head.headers.get('content-type') ?? ''
-      if (!contentType.includes('application/json') && !contentType.includes('text/plain')) return false
-
-      const contentLength = head.headers.get('content-length')
-      if (contentLength && Number(contentLength) > maxBytes) return false
-
-      return true
+      return contentType.includes('application/json')
     } catch {
       return false
     }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -524,15 +524,30 @@ const Utils = {
   },
 
   /**
+   * Allowed hostname suffixes for fileUrl fetching.
+   * Only IPFS gateways, AWS S3, and Cloudflare R2 are permitted.
+   */
+
+  isAllowedFileUrlHost(hostname: string): boolean {
+    const FILE_URL_ALLOWED_HOSTS = [
+      '.ipfs.io',
+      '.pinata.cloud',
+      '.mypinata.cloud',
+      'dweb.link',
+      '.dweb.link',
+      'cloudflare-ipfs.com',
+      '.cloudflare-ipfs.com',
+      '.s3.amazonaws.com',
+      '.r2.dev',
+      '.r2.cloudflarestorage.com',
+    ]
+    return FILE_URL_ALLOWED_HOSTS.some(allowed => hostname === allowed.replace(/^\./, '') || hostname.endsWith(allowed))
+  },
+
+  /**
    * Fetches JSON from a user-supplied URL safely.
-   * Mitigations applied before any network call:
-   *   1. URL is parsed — protocol must be https
-   *   2. Hostname is checked against private/internal IP ranges (SSRF blocklist)
-   *   3. HEAD preflight verifies the endpoint is reachable and returns JSON content-type
-   *
-   * An allowlist is not used because callers legitimately fetch from arbitrary HTTPS hosts
-   * (IPFS gateways, S3, CDNs). The protocol + hostname blocklist is the appropriate control here.
-   * lgtm[js/request-forgery]
+   * Only URLs from known trusted hosts (IPFS gateways, S3, Cloudflare R2) are allowed.
+   * Protocol must be HTTPS, a HEAD preflight confirms reachability and JSON content-type.
    */
   async fetchSafeJsonFromUrl(rawUrl: string): Promise<unknown> {
     let url: URL
@@ -543,11 +558,9 @@ const Utils = {
     }
 
     if (url.protocol !== 'https:') throw new Error('Only HTTPS URLs are allowed')
+    if (!Utils.isAllowedFileUrlHost(url.hostname)) throw new Error('URL host is not allowed')
 
-    const isPrivate = /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(url.hostname)
-    if (isPrivate) throw new Error('Private/internal URLs are not allowed')
-
-    const head = await fetch(url.href, { method: 'HEAD' }) // lgtm[js/request-forgery]
+    const head = await fetch(url.href, { method: 'HEAD' })
     if (!head.ok) throw new Error('URL is not reachable')
 
     const contentType = head.headers.get('content-type') ?? ''
@@ -555,7 +568,7 @@ const Utils = {
       throw new Error('URL does not return JSON content')
     }
 
-    const response = await fetch(url.href) // lgtm[js/request-forgery]
+    const response = await fetch(url.href)
     if (!response.ok) throw new Error('Failed to fetch URL')
 
     return response.json()

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -523,27 +523,42 @@ const Utils = {
     return null
   },
 
-  isSafeHttpsUrl(rawUrl: string): boolean {
+  /**
+   * Fetches JSON from a user-supplied URL safely.
+   * Mitigations applied before any network call:
+   *   1. URL is parsed — protocol must be https
+   *   2. Hostname is checked against private/internal IP ranges (SSRF blocklist)
+   *   3. HEAD preflight verifies the endpoint is reachable and returns JSON content-type
+   *
+   * An allowlist is not used because callers legitimately fetch from arbitrary HTTPS hosts
+   * (IPFS gateways, S3, CDNs). The protocol + hostname blocklist is the appropriate control here.
+   * lgtm[js/request-forgery]
+   */
+  async fetchSafeJsonFromUrl(rawUrl: string): Promise<unknown> {
+    let url: URL
     try {
-      const parsed = new URL(rawUrl)
-      if (parsed.protocol !== 'https:') return false
-      const isPrivate = /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(parsed.hostname)
-      return !isPrivate
+      url = new URL(rawUrl)
     } catch {
-      return false
+      throw new Error('Invalid URL')
     }
-  },
 
-  async preflightFileUrl(rawUrl: string): Promise<boolean> {
-    try {
-      const head = await fetch(rawUrl, { method: 'HEAD' })
-      if (!head.ok) return false
+    if (url.protocol !== 'https:') throw new Error('Only HTTPS URLs are allowed')
 
-      const contentType = head.headers.get('content-type') ?? ''
-      return contentType.includes('application/json')
-    } catch {
-      return false
+    const isPrivate = /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(url.hostname)
+    if (isPrivate) throw new Error('Private/internal URLs are not allowed')
+
+    const head = await fetch(url.href, { method: 'HEAD' }) // lgtm[js/request-forgery]
+    if (!head.ok) throw new Error('URL is not reachable')
+
+    const contentType = head.headers.get('content-type') ?? ''
+    if (!contentType.includes('application/json') && !contentType.includes('text/plain')) {
+      throw new Error('URL does not return JSON content')
     }
+
+    const response = await fetch(url.href) // lgtm[js/request-forgery]
+    if (!response.ok) throw new Error('Failed to fetch URL')
+
+    return response.json()
   },
 }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -5,6 +5,7 @@ import { type HexAddress, type IPermission, NetworksEnum } from '@types'
 import async from 'async'
 import { ethers } from 'ethers'
 import { IIndexerConfig } from '@src/types/crawler'
+import config from '@config'
 
 const Utils = {
   noop: (): number => 0,
@@ -521,6 +522,35 @@ const Utils = {
     }
 
     return null
+  },
+
+  isSafeHttpsUrl(rawUrl: string): boolean {
+    try {
+      const parsed = new URL(rawUrl)
+      if (parsed.protocol !== 'https:') return false
+      const isPrivate = /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(parsed.hostname)
+      return !isPrivate
+    } catch {
+      return false
+    }
+  },
+
+  async preflightFileUrl(rawUrl: string): Promise<boolean> {
+    try {
+      const maxBytes: number = config.FILE_UPLOADS.MAX_FILE_SIZE_MB
+      const head = await fetch(rawUrl, { method: 'HEAD' })
+      if (!head.ok) return false
+
+      const contentType = head.headers.get('content-type') ?? ''
+      if (!contentType.includes('application/json') && !contentType.includes('text/plain')) return false
+
+      const contentLength = head.headers.get('content-length')
+      if (contentLength && Number(contentLength) > maxBytes) return false
+
+      return true
+    } catch {
+      return false
+    }
   },
 }
 

--- a/src/services/aragon-api/routers/schema/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/schema/capitalDistributor.ts
@@ -44,7 +44,9 @@ const CapitalDistributorSchema = {
     network: Joi.string()
       .valid(...Object.values(NetworksEnum))
       .required(),
-    fileUrl: Joi.string().uri().optional(),
+    fileUrl: Joi.string()
+      .uri({ scheme: ['https'] })
+      .optional(),
   }),
 
   uploadCampaignMembersBody: Joi.array()

--- a/src/services/aragon-api/routers/schema/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/schema/capitalDistributor.ts
@@ -44,6 +44,7 @@ const CapitalDistributorSchema = {
     network: Joi.string()
       .valid(...Object.values(NetworksEnum))
       .required(),
+    fileUrl: Joi.string().uri().optional(),
   }),
 
   uploadCampaignMembersBody: Joi.array()

--- a/src/services/aragon-api/routers/schema/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/schema/capitalDistributor.ts
@@ -1,3 +1,4 @@
+import Utils from '@helpers/utils'
 import ValidationSchema from '@helpers/validationSchema'
 import { NetworksEnum } from '@types'
 import Joi from 'joi'
@@ -46,6 +47,13 @@ const CapitalDistributorSchema = {
       .required(),
     fileUrl: Joi.string()
       .uri({ scheme: ['https'] })
+      .custom((value, helpers) => {
+        const { hostname } = new URL(value)
+        if (!Utils.isAllowedFileUrlHost(hostname)) {
+          return helpers.error('any.invalid')
+        }
+        return value
+      })
       .optional(),
   }),
 

--- a/src/services/aragon-api/routers/v1/contract.ts
+++ b/src/services/aragon-api/routers/v1/contract.ts
@@ -17,9 +17,9 @@ const ContractRouter = {
     const params = {
       network: ctx.params.network,
       to: ctx.params.address,
-      from: (ctx.request.body as any).from,
-      data: (ctx.request.body as any).data,
-      value: (ctx.request.body as any).value,
+      from: (ctx.request as any).body.from,
+      data: (ctx.request as any).body.data,
+      value: (ctx.request as any).body.value,
     }
     const formattedValues = await ValidationSchema.validateParams(ContractDetailsSchema.decodeActionData, params)
     ctx.body = await ContractController.decodeContractData(formattedValues)

--- a/src/services/aragon-api/routers/v2/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/v2/capitalDistributor.ts
@@ -90,15 +90,9 @@ const CapitalDistributorRouter = {
 
       rewards = fileData
     } else if (body.fileUrl) {
-      assertExposable(Utils.isSafeHttpsUrl(body.fileUrl), ErrorKeyEnum.badParams)
-      assertExposable(await Utils.preflightFileUrl(body.fileUrl), ErrorKeyEnum.badParams)
-
-      const response = await fetch(body.fileUrl)
-      assertExposable(response.ok, ErrorKeyEnum.badParams)
-
-      let fileData: any
+      let fileData: unknown
       try {
-        fileData = await response.json()
+        fileData = await Utils.fetchSafeJsonFromUrl(body.fileUrl)
       } catch {
         assertExposable(false, ErrorKeyEnum.badParams)
       }

--- a/src/services/aragon-api/routers/v2/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/v2/capitalDistributor.ts
@@ -91,10 +91,7 @@ const CapitalDistributorRouter = {
       rewards = fileData
     } else if (body.fileUrl) {
       assertExposable(Utils.isSafeHttpsUrl(body.fileUrl), ErrorKeyEnum.badParams)
-      assertExposable(
-        await Utils.preflightFileUrl(body.fileUrl),
-        ErrorKeyEnum.badParams,
-      )
+      assertExposable(await Utils.preflightFileUrl(body.fileUrl), ErrorKeyEnum.badParams)
 
       const response = await fetch(body.fileUrl)
       assertExposable(response.ok, ErrorKeyEnum.badParams)

--- a/src/services/aragon-api/routers/v2/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/v2/capitalDistributor.ts
@@ -90,7 +90,7 @@ const CapitalDistributorRouter = {
 
       rewards = fileData
     } else if (body.fileUrl) {
-      let fileData: unknown
+      let fileData: any
       try {
         fileData = await Utils.fetchSafeJsonFromUrl(body.fileUrl)
       } catch {

--- a/src/services/aragon-api/routers/v2/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/v2/capitalDistributor.ts
@@ -10,6 +10,7 @@ import {
   type ICampaignApiParams,
   type IPaginationParams,
   type NetworksEnum,
+  type CampaignUploadBody,
 } from '@types'
 
 const CapitalDistributorRouter = {
@@ -75,7 +76,7 @@ const CapitalDistributorRouter = {
   },
 
   uploadCampaignMembers: async function (ctx: RouterContext) {
-    const body = ctx.request.body as Record<string, any>
+    const body = (ctx.request as unknown as { body: CampaignUploadBody }).body
 
     let rewards: any[] = []
 
@@ -87,6 +88,26 @@ const CapitalDistributorRouter = {
       }
 
       rewards = fileData
+    } else if (body.fileUrl) {
+      const response = await fetch(body.fileUrl as string)
+      assertExposable(response.ok, ErrorKeyEnum.badParams)
+
+      let fileData: any
+      try {
+        fileData = await response.json()
+      } catch {
+        assertExposable(false, ErrorKeyEnum.badParams)
+      }
+
+      if (!Array.isArray(fileData)) {
+        assertExposable(false, ErrorKeyEnum.badParams)
+      }
+
+      rewards = fileData
+    } else {
+
+
+      assertExposable(false, ErrorKeyEnum.badParams)
     }
 
     await ValidationSchema.validateParams(CapitalDistributorSchema.uploadCampaignMembersBody, rewards)
@@ -196,7 +217,8 @@ const CapitalDistributorRouter = {
      * The file must be a JSON array of { address, amount } objects.
      * Returns a draft campaignId (UUID) that reconciles to the real on-chain ID after the campaign tx is confirmed.
      *
-     * @apiParam (FormData) {File} membersFile JSON file with reward recipients
+     * @apiParam (FormData) {File} [membersFile] JSON file with reward recipients (multipart upload)
+     * @apiParam (FormData) {String} [fileUrl] URL to a JSON file with reward recipients (alternative to membersFile)
      * @apiParam (FormData) {String} daoAddress DAO address
      * @apiParam (FormData) {String} capitalDistributorAddress Capital distributor plugin address
      * @apiParam (FormData) {String} network Network name

--- a/src/services/aragon-api/routers/v2/capitalDistributor.ts
+++ b/src/services/aragon-api/routers/v2/capitalDistributor.ts
@@ -1,6 +1,7 @@
 import CapitalDistributorController from '@api/controllers/capitalDistributor'
 import CapitalDistributorSchema from '@api/routers/schema/capitalDistributor'
 import { assertExposable } from '@errors'
+import Utils from '@helpers/utils'
 import ValidationSchema from '@helpers/validationSchema'
 import Router, { type RouterContext } from '@koa/router'
 import UploadMiddleware from '@middlewares/upload'
@@ -89,7 +90,13 @@ const CapitalDistributorRouter = {
 
       rewards = fileData
     } else if (body.fileUrl) {
-      const response = await fetch(body.fileUrl as string)
+      assertExposable(Utils.isSafeHttpsUrl(body.fileUrl), ErrorKeyEnum.badParams)
+      assertExposable(
+        await Utils.preflightFileUrl(body.fileUrl),
+        ErrorKeyEnum.badParams,
+      )
+
+      const response = await fetch(body.fileUrl)
       assertExposable(response.ok, ErrorKeyEnum.badParams)
 
       let fileData: any
@@ -105,8 +112,6 @@ const CapitalDistributorRouter = {
 
       rewards = fileData
     } else {
-
-
       assertExposable(false, ErrorKeyEnum.badParams)
     }
 

--- a/src/services/aragon-api/routers/v2/contract.ts
+++ b/src/services/aragon-api/routers/v2/contract.ts
@@ -23,9 +23,9 @@ const ContractRouter = {
       params: {
         network: ctx.params.network,
         to: ctx.params.address,
-        from: (ctx.request.body as any).from,
-        data: (ctx.request.body as any).data,
-        value: (ctx.request.body as any).value,
+        from: (ctx.request as any).body.from,
+        data: (ctx.request as any).body.data,
+        value: (ctx.request as any).body.value,
       },
       schemas: {
         params: ContractDetailsSchema.decodeActionDataV2,
@@ -38,7 +38,7 @@ const ContractRouter = {
   async decodeActionBatch(ctx: RouterContext) {
     const result = await ValidationSchema.validateRoute(ctx, {
       params: {
-        actions: ctx.request.body as any[],
+        actions: (ctx.request as any).body as any[],
         network: ctx.params.network,
         from: ctx.params.from,
       },

--- a/src/services/aragon-api/routers/v2/simulation.ts
+++ b/src/services/aragon-api/routers/v2/simulation.ts
@@ -9,7 +9,7 @@ const SimulationRouter = {
   async simulate(ctx: RouterContext) {
     const result = await ValidationSchema.validateRoute(ctx, {
       params: {
-        actions: (ctx.request.body as any).actions,
+        actions: (ctx.request as any).body.actions,
         pluginAddress: ctx.params.pluginAddress,
         network: ctx.params.network,
       },
@@ -72,8 +72,8 @@ const SimulationRouter = {
       params: {
         policyAddress: ctx.params.policyAddress,
         network: ctx.params.network,
-        from: (ctx.request.body as any)?.from,
-        data: (ctx.request.body as any)?.data,
+        from: (ctx.request as any).body?.from,
+        data: (ctx.request as any).body?.data,
       },
       schemas: {
         params: DispatchSimulationSchema.simulateDispatch,

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -412,3 +412,10 @@ export interface IGaugeResponse {
   avatar: string
   isActive: boolean
 }
+
+export interface CampaignUploadBody {
+  daoAddress: HexAddress
+  capitalDistributorAddress: HexAddress
+  network: NetworksEnum
+  fileUrl?: string
+}

--- a/test/unit/services/aragon-api/routers/v2/capitalDistributor.spec.ts
+++ b/test/unit/services/aragon-api/routers/v2/capitalDistributor.spec.ts
@@ -2,6 +2,7 @@ import CapitalDistributorController from '@api/controllers/capitalDistributor'
 import CapitalDistributorRouter from '@api/routers/v2/capitalDistributor'
 import CapitalDistributorSchema from '@api/routers/schema/capitalDistributor'
 import * as errors from '@errors'
+import Utils from '@helpers/utils'
 import ValidationSchema from '@helpers/validationSchema'
 import UploadMiddleware from '@middlewares/upload'
 import { ErrorKeyEnum, HexAddress, IUserCampaignStatus, NetworksEnum } from '@types'
@@ -711,7 +712,7 @@ describe('RouterV2: CapitalDistributor', () => {
         },
       }
 
-      sandbox.stub(global, 'fetch').resolves({ ok: true, json: async () => mockRewards } as any)
+      sandbox.stub(Utils, 'fetchSafeJsonFromUrl').resolves(mockRewards)
       const validateParamsStub = sandbox.stub(ValidationSchema, 'validateParams').resolves()
       const validateRouteStub = sandbox.stub(ValidationSchema, 'validateRoute').resolves(validationResult as any)
       const controllerStub = sandbox
@@ -741,8 +742,8 @@ describe('RouterV2: CapitalDistributor', () => {
       })
     })
 
-    it('Should throw badParams when fileUrl fetch returns non-ok response', async () => {
-      sandbox.stub(global, 'fetch').resolves({ ok: false } as any)
+    it('Should throw badParams when fileUrl fetch fails', async () => {
+      sandbox.stub(Utils, 'fetchSafeJsonFromUrl').rejects(new Error('URL is not reachable'))
       const assertExposableStub = sandbox.stub(errors, 'assertExposable').throws(new Error('Bad params'))
 
       const ctx: any = {
@@ -764,9 +765,7 @@ describe('RouterV2: CapitalDistributor', () => {
     })
 
     it('Should throw badParams when fileUrl returns non-array JSON', async () => {
-      sandbox
-        .stub(global, 'fetch')
-        .resolves({ ok: true, json: async () => ({ address: '0x123', amount: '100' }) } as any)
+      sandbox.stub(Utils, 'fetchSafeJsonFromUrl').resolves({ address: '0x123', amount: '100' })
       const assertExposableStub = sandbox.stub(errors, 'assertExposable').throws(new Error('Bad params'))
 
       const ctx: any = {

--- a/test/unit/services/aragon-api/routers/v2/capitalDistributor.spec.ts
+++ b/test/unit/services/aragon-api/routers/v2/capitalDistributor.spec.ts
@@ -668,13 +668,38 @@ describe('RouterV2: CapitalDistributor', () => {
       expect(assertExposableStub.args[0][1]).to.eq(ErrorKeyEnum.badParams)
     })
 
-    it('Should upload campaign members without file (empty rewards)', async () => {
+    it('Should throw badParams when neither file nor fileUrl is provided', async () => {
+      const assertExposableStub = sandbox.stub(errors, 'assertExposable').throws(new Error('Bad params'))
+
+      const ctx: any = {
+        request: {
+          body: {
+            daoAddress: '0xDAO1234567890123456789012345678901234567',
+            capitalDistributorAddress: '0x1234567890123456789012345678901234567890',
+            network: 'ethereum',
+          },
+        },
+      }
+
+      await expect(CapitalDistributorRouter.uploadCampaignMembers(ctx)).to.be.rejectedWith('Bad params')
+
+      expect(assertExposableStub.calledOnce).to.be.true
+      expect(assertExposableStub.args[0][0]).to.eq(false)
+      expect(assertExposableStub.args[0][1]).to.eq(ErrorKeyEnum.badParams)
+    })
+
+    it('Should upload campaign members with fileUrl', async () => {
+      const mockRewards = [
+        { address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', amount: '1000000000000000000' },
+        { address: '0x1234567890123456789012345678901234567890', amount: '2000000000000000000' },
+      ]
+
       const mockResult = {
         success: true,
-        totalInserted: 0,
+        totalInserted: 2,
         totalUpdated: 0,
         totalDeleted: 0,
-        totalProcessed: 0,
+        totalProcessed: 2,
         campaignId: 'draft-campaign-id',
       }
 
@@ -686,6 +711,7 @@ describe('RouterV2: CapitalDistributor', () => {
         },
       }
 
+      sandbox.stub(global, 'fetch').resolves({ ok: true, json: async () => mockRewards } as any)
       const validateParamsStub = sandbox.stub(ValidationSchema, 'validateParams').resolves()
       const validateRouteStub = sandbox.stub(ValidationSchema, 'validateRoute').resolves(validationResult as any)
       const controllerStub = sandbox
@@ -698,6 +724,7 @@ describe('RouterV2: CapitalDistributor', () => {
             daoAddress: '0xDAO1234567890123456789012345678901234567',
             capitalDistributorAddress: '0x1234567890123456789012345678901234567890',
             network: 'ethereum',
+            fileUrl: 'https://example.com/rewards.json',
           },
         },
       }
@@ -710,8 +737,52 @@ describe('RouterV2: CapitalDistributor', () => {
       expect(controllerStub.calledOnce).to.be.true
       expect(controllerStub.args[0][0]).to.deep.eq({
         ...validationResult.params,
-        rewards: [],
+        rewards: mockRewards,
       })
+    })
+
+    it('Should throw badParams when fileUrl fetch returns non-ok response', async () => {
+      sandbox.stub(global, 'fetch').resolves({ ok: false } as any)
+      const assertExposableStub = sandbox.stub(errors, 'assertExposable').throws(new Error('Bad params'))
+
+      const ctx: any = {
+        request: {
+          body: {
+            daoAddress: '0xDAO1234567890123456789012345678901234567',
+            capitalDistributorAddress: '0x1234567890123456789012345678901234567890',
+            network: 'ethereum',
+            fileUrl: 'https://example.com/rewards.json',
+          },
+        },
+      }
+
+      await expect(CapitalDistributorRouter.uploadCampaignMembers(ctx)).to.be.rejectedWith('Bad params')
+
+      expect(assertExposableStub.calledOnce).to.be.true
+      expect(assertExposableStub.args[0][0]).to.eq(false)
+      expect(assertExposableStub.args[0][1]).to.eq(ErrorKeyEnum.badParams)
+    })
+
+    it('Should throw badParams when fileUrl returns non-array JSON', async () => {
+      sandbox
+        .stub(global, 'fetch')
+        .resolves({ ok: true, json: async () => ({ address: '0x123', amount: '100' }) } as any)
+      const assertExposableStub = sandbox.stub(errors, 'assertExposable').throws(new Error('Bad params'))
+
+      const ctx: any = {
+        request: {
+          body: {
+            daoAddress: '0xDAO1234567890123456789012345678901234567',
+            capitalDistributorAddress: '0x1234567890123456789012345678901234567890',
+            network: 'ethereum',
+            fileUrl: 'https://example.com/rewards.json',
+          },
+        },
+      }
+
+      await expect(CapitalDistributorRouter.uploadCampaignMembers(ctx)).to.be.rejectedWith('Bad params')
+
+      expect(assertExposableStub.called).to.be.true
     })
   })
 

--- a/tools/resyncDaoVeGovernance.ts
+++ b/tools/resyncDaoVeGovernance.ts
@@ -26,7 +26,7 @@ export const ResyncDaoVeGovernance: IService = {
     )
 
     const gaugePlugin = plugins.find(p => p.interfaceType === 'gauge')
-    if (!gaugePlugin || !gaugePlugin.votingEscrow) {
+    if (!gaugePlugin?.votingEscrow) {
       logger.error('No gauge plugin found for DAO', llo({ daoAddress: DAO_ADDRESS }))
       return
     }


### PR DESCRIPTION
## 📝 Summary

Adds support for a `fileUrl` field as an alternative to direct file upload in the campaign member upload endpoint. Only URLs from trusted hosts (IPFS gateways, AWS S3, Cloudflare R2) are accepted.

**API changes:**
- Added optional `fileUrl` field to the upload endpoint — accepts a URL to a JSON array of `{ address, amount }` reward recipients
- Either `membersFile` (multipart) or `fileUrl` must be provided; both missing returns `badParams`

**Security:**
- Allowlist-based SSRF protection: only `*.ipfs.io`, `*.pinata.cloud`, `*.mypinata.cloud`, `dweb.link`, `cloudflare-ipfs.com`, `*.s3.amazonaws.com`, `*.r2.dev`, `*.r2.cloudflarestorage.com` are permitted
- Joi schema rejects disallowed hosts at validation time
- HEAD preflight checks reachability and `Content-Type` before the actual GET
- URL must be `https`

**Tests:**
- Added unit tests: fileUrl success path, fetch failure, non-array JSON, neither file nor fileUrl provided

**Misc:**
- Updated Biome schema version (`biome.json`)
- Lint fix in `tools/resyncDaoVeGovernance.ts`

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [x] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities (SSRF mitigated via allowlist)
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members