### PR TITLE
feat(delegateChangedSync): add admin API to force sync historical delegation events

### DIFF
--- a/src/services/aragon-admin-api/controllers/queue.ts
+++ b/src/services/aragon-admin-api/controllers/queue.ts
@@ -10,6 +10,7 @@ import {
   type IAQueueProposal,
   IPluginInterfaceType,
   type IQueueDaoTransactions,
+  type IQueueSyncDelegateChanged,
   type NetworksEnum,
 } from '@src/types'
 import { EnumQueueName, ErrorKeyEnum, IPluginStatus } from '@types'
@@ -133,6 +134,27 @@ const QueueAdminController = {
     logger.verbose(
       'Force queue proposal metrics',
       llo({ proposalIndex: params.proposalIndex, pluginAddress: params.pluginAddress, network: params.network }),
+    )
+    return true
+  },
+
+  queueDelegateChangedSync: async (params: IQueueSyncDelegateChanged): Promise<any> => {
+    const plugin = await Models.Plugin.findOne({
+      address: params.pluginAddress,
+      network: params.network,
+      isSupported: true,
+      status: IPluginStatus.installed,
+    })
+    assertExposable(plugin, ErrorKeyEnum.notFound)
+
+    await RabbitMQHelper.sendMessage(EnumQueueName.syncDelegateChanged, {
+      id: plugin.address,
+      params: { pluginAddress: plugin.address, network: plugin.network },
+    })
+
+    logger.verbose(
+      'Force queue delegate changed sync',
+      llo({ pluginAddress: params.pluginAddress, network: params.network }),
     )
     return true
   },

--- a/src/services/aragon-admin-api/routers/queue.ts
+++ b/src/services/aragon-admin-api/routers/queue.ts
@@ -4,7 +4,7 @@ import Utils from '@helpers/utils'
 import ValidationSchema from '@helpers/validationSchema'
 import Router, { type RouterContext } from '@koa/router'
 import AuthMiddleware from '@middlewares/auth'
-import { type IAQueueDao, type IAQueueProposal, type NetworksEnum } from '@types'
+import { type IAQueueDao, type IAQueueProposal, type IQueueSyncDelegateChanged, type NetworksEnum } from '@types'
 
 const QueueAdminRouter = {
   queueDaoPlugins: async function (ctx: RouterContext) {
@@ -64,6 +64,17 @@ const QueueAdminRouter = {
     ctx.body = await QueueAdminController.queueProposalMetrics(formattedValues)
   },
 
+  queueDelegateChangedSync: async function (ctx: RouterContext) {
+    const params: IQueueSyncDelegateChanged = {
+      pluginAddress: ctx.params.pluginAddress,
+      network: ctx.params.network as NetworksEnum,
+    }
+
+    const formattedValues = await ValidationSchema.validateParams(GenericSchema.delegateChangedSync, params)
+
+    ctx.body = await QueueAdminController.queueDelegateChangedSync(formattedValues)
+  },
+
   recalculateProposalActions: async function (ctx: RouterContext) {
     const params = {
       incrementalId: parseInt(ctx.query.incrementalId as string),
@@ -90,6 +101,11 @@ const QueueAdminRouter = {
       QueueAdminRouter.queueProposalMetrics,
     )
     router.post('/proposals/decode', authedAdmin, QueueAdminRouter.recalculateProposalActions)
+    router.post(
+      '/delegate-changed-sync/:pluginAddress/:network',
+      authedAdmin,
+      QueueAdminRouter.queueDelegateChangedSync,
+    )
 
     return router
   },

--- a/src/services/aragon-admin-api/routers/schema/generic.ts
+++ b/src/services/aragon-admin-api/routers/schema/generic.ts
@@ -41,6 +41,13 @@ const GenericSchema = {
     pluginAddress: ValidationSchema.joiAddress.required(),
     incrementalId: Joi.number().required(),
   }),
+
+  delegateChangedSync: Joi.object({
+    network: Joi.string()
+      .valid(...Object.values(NetworksEnum))
+      .required(),
+    pluginAddress: ValidationSchema.joiAddress.required(),
+  }),
 }
 
 export default GenericSchema

--- a/src/services/aragon-plugins/index.ts
+++ b/src/services/aragon-plugins/index.ts
@@ -3,9 +3,11 @@ import { Models } from '@dbModels'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import logger from '@logger'
 import { LogGauge } from '@plugins/logGauge'
+import { LogPolicy } from '@plugins/logPolicy'
 import { LogAdmin } from '@services/aragon-plugins/logAdmin'
 import { LogCapitalDistributor } from '@services/aragon-plugins/logCapitalDistributor'
 import { LogDao } from '@services/aragon-plugins/logDao'
+import { LogDelegateChanged } from '@services/aragon-plugins/logDelegateChanged'
 import { LogMultiSig } from '@services/aragon-plugins/logMultisig'
 import { LogSelectorPermission } from '@services/aragon-plugins/logSelectorPermission'
 import { LogSpp } from '@services/aragon-plugins/logSPP'
@@ -17,10 +19,10 @@ import {
   IPluginInterfaceType,
   type IQueueDao,
   type IQueuePlugin,
+  type IQueueSyncDelegateChanged,
   type IService,
   ITokenType,
 } from '@types'
-import { LogPolicy } from '@plugins/logPolicy'
 
 const llo = logger.logMeta.bind(null, { service: 'service:PluginSyncService' })
 
@@ -57,6 +59,16 @@ const AragonPluginsService: IService & { pluginQueue: (params: IQueuePlugin) => 
 
     await RabbitMQHelper.process(EnumQueueName.requeue, async job => {
       await AragonPluginsService.pluginQueue(job.params as IQueuePlugin)
+    })
+
+    await RabbitMQHelper.process(EnumQueueName.syncDelegateChanged, async job => {
+      const { pluginAddress, network } = job.params as IQueueSyncDelegateChanged
+      const plugin = await Models.Plugin.findByAddress(pluginAddress, network)
+      if (!plugin) {
+        logger.error('syncDelegateChanged: plugin not found', llo({ pluginAddress, network }))
+        return
+      }
+      await LogDelegateChanged.start(plugin)
     })
 
     logger.info('PluginSyncService service started', llo({}))

--- a/src/services/aragon-plugins/logDelegateChanged.ts
+++ b/src/services/aragon-plugins/logDelegateChanged.ts
@@ -1,0 +1,40 @@
+import configIndexer from '@indexer/configIndexer'
+import logger from '@logger'
+import type Plugin from '@models/schema/plugin'
+import { BlockchainLogCrawler } from '@modules/crawlers'
+import { type IIndexerConfig, IVotingEscrowAdapterLogs } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'service:indexer:LogDelegateChanged' })
+
+export const LogDelegateChanged = {
+  start: async (plugin: Plugin) => {
+    const infoLogs = { network: plugin.network, pluginAddress: plugin.address, tokenAddress: plugin.tokenAddress }
+    logger.verbose('Start LogDelegateChanged historical sync', llo(infoLogs))
+
+    const delegateChangedConfig = configIndexer.filter(
+      (item: IIndexerConfig) => item.event === IVotingEscrowAdapterLogs.DelegateChanged,
+    )
+
+    const crawler = new BlockchainLogCrawler({
+      onlyHistorical: true,
+      network: plugin.network,
+      events: delegateChangedConfig,
+      address: [plugin.tokenAddress],
+      fromBlock: plugin.blockNumber,
+      onError: async (error: any, log: any) => LogDelegateChanged.processError(error, plugin, log),
+      stopOnError: true,
+    })
+
+    await crawler.crawl()
+    await crawler.end?.()
+
+    logger.verbose(
+      'End LogDelegateChanged historical sync',
+      llo({ ...infoLogs, lastSync: crawler.crawlSetting.lastSync }),
+    )
+  },
+
+  processError: async (error: any, plugin: Plugin, log: any) => {
+    logger.error('Error LogDelegateChanged', llo({ log, error, plugin }))
+  },
+}

--- a/src/services/aragon-plugins/logDelegateChanged.ts
+++ b/src/services/aragon-plugins/logDelegateChanged.ts
@@ -1,3 +1,4 @@
+import { Models } from '@dbModels'
 import configIndexer from '@indexer/configIndexer'
 import logger from '@logger'
 import type Plugin from '@models/schema/plugin'
@@ -11,6 +12,9 @@ export const LogDelegateChanged = {
     const infoLogs = { network: plugin.network, pluginAddress: plugin.address, tokenAddress: plugin.tokenAddress }
     logger.verbose('Start LogDelegateChanged historical sync', llo(infoLogs))
 
+    const token = await Models.Token.findOne({ address: plugin.tokenAddress, network: plugin.network })
+    const fromBlock = token?.blockNumber || plugin.blockNumber
+
     const delegateChangedConfig = configIndexer.filter(
       (item: IIndexerConfig) => item.event === IVotingEscrowAdapterLogs.DelegateChanged,
     )
@@ -20,7 +24,7 @@ export const LogDelegateChanged = {
       network: plugin.network,
       events: delegateChangedConfig,
       address: [plugin.tokenAddress],
-      fromBlock: plugin.blockNumber,
+      fromBlock,
       onError: async (error: any, log: any) => LogDelegateChanged.processError(error, plugin, log),
       stopOnError: true,
     })

--- a/src/types/queue.ts
+++ b/src/types/queue.ts
@@ -29,6 +29,7 @@ export enum EnumQueueName {
   metadataRefetch = 'metadata.refetch',
   governanceRewardDistribution = 'governance.rewardDistribution',
   tokenTotalSupply = 'token.totalSupply',
+  syncDelegateChanged = 'sync.delegate.changed',
 }
 
 export interface IQueueAllMetrics {
@@ -173,5 +174,10 @@ export interface IQueueContractDecoderLight {
     data: string
     value: string | number
   }>
+  network: NetworksEnum
+}
+
+export interface IQueueSyncDelegateChanged {
+  pluginAddress: HexAddress
   network: NetworksEnum
 }

--- a/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
+++ b/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
@@ -12,7 +12,6 @@ import {
   IPluginStatus,
   type IQueueDaoTransactions,
   NetworksEnum,
-  type IQueueSyncDelegateChanged,
 } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'

--- a/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
+++ b/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
@@ -12,6 +12,7 @@ import {
   IPluginStatus,
   type IQueueDaoTransactions,
   NetworksEnum,
+  type IQueueSyncDelegateChanged,
 } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
@@ -541,6 +542,54 @@ describe('Controller: QueueAdmin', () => {
 
       expect(loggerStub.calledOnce).to.be.true
       expect(loggerStub.firstCall.args[0]).to.equal('Force queue proposal metrics')
+    })
+  })
+
+  describe('queueDelegateChangedSync', () => {
+    const pluginAddress = '0x1234567890123456789012345678901234567890'
+    const network = NetworksEnum.ethereumMainnet
+
+    it('should queue delegate changed sync and return true', async () => {
+      sandbox.stub(Models.Plugin, 'findOne').resolves({
+        address: pluginAddress,
+        network,
+        isSupported: true,
+        status: IPluginStatus.installed,
+      })
+
+      const result = await QueueAdminController.queueDelegateChangedSync({ pluginAddress, network })
+
+      expect(result).to.be.true
+      expect(rabbitMQ.calledOnce).to.be.true
+      expect(rabbitMQ.firstCall.args[0]).to.equal(EnumQueueName.syncDelegateChanged)
+      expect(rabbitMQ.firstCall.args[1]).to.deep.equal({
+        id: pluginAddress,
+        params: { pluginAddress, network },
+      })
+    })
+
+    it('should throw notFound if plugin does not exist', async () => {
+      sandbox.stub(Models.Plugin, 'findOne').resolves(null)
+
+      await expect(QueueAdminController.queueDelegateChangedSync({ pluginAddress, network })).to.be.rejectedWith(
+        Error,
+        ErrorKeyEnum.notFound,
+      )
+    })
+
+    it('should propagate RabbitMQ errors', async () => {
+      sandbox.stub(Models.Plugin, 'findOne').resolves({
+        address: pluginAddress,
+        network,
+        isSupported: true,
+        status: IPluginStatus.installed,
+      })
+      rabbitMQ.rejects(new Error('RabbitMQ error'))
+
+      await expect(QueueAdminController.queueDelegateChangedSync({ pluginAddress, network })).to.be.rejectedWith(
+        Error,
+        'RabbitMQ error',
+      )
     })
   })
 

--- a/test/unit/services/aragon-admin-api/routers/queue.spec.ts
+++ b/test/unit/services/aragon-admin-api/routers/queue.spec.ts
@@ -122,6 +122,39 @@ describe('Router: QueueAdmin', () => {
     expect(stubCtrl.args[0][0].network).to.eq(params.network)
   })
 
+  it('queueDelegateChangedSync', async () => {
+    const params = {
+      pluginAddress: '0x0eB63a3565942D16C1c1211bD78F1B3Dcfe1A254',
+      network: NetworksEnum.ethereumMainnet,
+    }
+
+    const stubCtrl = sandbox.stub(QueueAdminController, 'queueDelegateChangedSync').returns(true as any)
+
+    const ctx: any = { params }
+
+    await QueueAdminRouter.queueDelegateChangedSync(ctx)
+
+    expect(ctx.body).to.eq(true)
+    expect(stubCtrl.calledOnce).to.be.true
+    expect(stubCtrl.args[0][0].pluginAddress).to.eq(params.pluginAddress)
+    expect(stubCtrl.args[0][0].network).to.eq(params.network)
+  })
+
+  it('queueDelegateChangedSync should reject invalid address', async () => {
+    const stubCtrl = sandbox.stub(QueueAdminController, 'queueDelegateChangedSync')
+
+    const ctx: any = {
+      params: { pluginAddress: 'notanaddress', network: NetworksEnum.ethereumMainnet },
+    }
+
+    try {
+      await QueueAdminRouter.queueDelegateChangedSync(ctx)
+      expect.fail('Should have thrown a validation error')
+    } catch (error) {
+      expect(stubCtrl.called).to.be.false
+    }
+  })
+
   describe('recalculateProposalActions', () => {
     it('should validate and call controller with query parameters', async () => {
       const query = {

--- a/test/unit/services/aragon-plugins/index.spec.ts
+++ b/test/unit/services/aragon-plugins/index.spec.ts
@@ -11,6 +11,7 @@ import { LogSelectorPermission } from '@plugins/logSelectorPermission'
 import { LogSpp } from '@plugins/logSPP'
 import { LogTokenVoting } from '@plugins/logTokenVoting'
 import AragonPluginsService from '@services/aragon-plugins/index'
+import { LogDelegateChanged } from '@services/aragon-plugins/logDelegateChanged'
 import { EnumQueueName, IPluginInterfaceType, ITokenType, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
@@ -41,6 +42,7 @@ describe('AragonPlugins: index', () => {
         EnumQueueName.logSelectorPermission,
         EnumQueueName.plugins,
         EnumQueueName.requeue,
+        EnumQueueName.syncDelegateChanged,
       ]
       expect(processStub.callCount).to.eq(queues.length)
 
@@ -74,6 +76,7 @@ describe('AragonPlugins: index', () => {
         EnumQueueName.logSelectorPermission,
         EnumQueueName.plugins,
         EnumQueueName.requeue,
+        EnumQueueName.syncDelegateChanged,
       ]
       expect(processStub.callCount).to.eq(queues.length)
 
@@ -200,6 +203,7 @@ describe('AragonPlugins: index', () => {
         EnumQueueName.logSelectorPermission,
         EnumQueueName.plugins,
         EnumQueueName.requeue,
+        EnumQueueName.syncDelegateChanged,
       ]
       expect(processStub.callCount).to.eq(queues.length)
       expect(processStub.args[1][0]).to.eq(EnumQueueName.logSelectorPermission)
@@ -847,6 +851,47 @@ describe('AragonPlugins: index', () => {
       })
 
       expect(pluginStub.calledOnceWith('0xPluginWithNoType', NetworksEnum.ethereumMainnet)).to.be.true
+    })
+
+    it('should call LogDelegateChanged.start when syncDelegateChanged message is received', async () => {
+      const processStub = sandbox.stub(RabbitMQHelper, 'process')
+      const pluginStub = sandbox.stub(Models.Plugin, 'findByAddress').resolves({
+        address: '0xPluginAddress',
+        network: NetworksEnum.ethereumMainnet,
+        blockNumber: 100,
+      } as any)
+      const logDelegateChangedStub = sandbox.stub(LogDelegateChanged, 'start').resolves()
+
+      sandbox.stub(logger, 'info')
+      await AragonPluginsService.start()
+
+      const handler = processStub.getCall(4).args[1]
+      await handler({
+        id: 'some-id',
+        params: { pluginAddress: '0xPluginAddress', network: NetworksEnum.ethereumMainnet },
+      })
+
+      expect(pluginStub.calledOnceWith('0xPluginAddress', NetworksEnum.ethereumMainnet)).to.be.true
+      expect(logDelegateChangedStub.calledOnce).to.be.true
+    })
+
+    it('should log error and not call LogDelegateChanged.start when plugin not found for syncDelegateChanged', async () => {
+      const processStub = sandbox.stub(RabbitMQHelper, 'process')
+      sandbox.stub(Models.Plugin, 'findByAddress').resolves(null)
+      const logDelegateChangedStub = sandbox.stub(LogDelegateChanged, 'start').resolves()
+      const loggerStub = sandbox.stub(logger, 'error')
+
+      sandbox.stub(logger, 'info')
+      await AragonPluginsService.start()
+
+      const handler = processStub.getCall(4).args[1]
+      await handler({
+        id: 'some-id',
+        params: { pluginAddress: '0xMissingPlugin', network: NetworksEnum.ethereumMainnet },
+      })
+
+      expect(logDelegateChangedStub.called).to.be.false
+      expect(loggerStub.calledWith('syncDelegateChanged: plugin not found' as any)).to.be.true
     })
   })
 })

--- a/test/unit/services/aragon-plugins/logDelegateChanged.spec.ts
+++ b/test/unit/services/aragon-plugins/logDelegateChanged.spec.ts
@@ -1,3 +1,4 @@
+import { Models } from '@dbModels'
 import logger from '@logger'
 import { BlockchainLogCrawler } from '@modules/crawlers'
 import { LogDelegateChanged } from '@services/aragon-plugins/logDelegateChanged'
@@ -26,7 +27,14 @@ describe('AragonPlugins: LogDelegateChanged', () => {
       interfaceType: 'tokenVoting',
     }
 
+    const token = {
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      network: NetworksEnum.ethereumMainnet,
+      blockNumber: 50,
+    }
+
     it('should crawl DelegateChanged events historically and log start/end', async () => {
+      sandbox.stub(Models.Token, 'findOne').resolves(token as any)
       const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves(undefined)
       sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
       const verboseStub = sandbox.stub(logger, 'verbose')
@@ -38,25 +46,23 @@ describe('AragonPlugins: LogDelegateChanged', () => {
       expect(verboseStub.calledWith('End LogDelegateChanged historical sync' as any)).to.be.true
     })
 
-    it('should crawl successfully for VE plugin with escrow addresses', async () => {
-      const vePlugin = {
-        ...plugin,
-        votingEscrow: {
-          escrowAddress: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
-          exitQueueAddress: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
-        },
-      }
-
-      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves(undefined)
+    it('should use token.blockNumber as fromBlock', async () => {
+      sandbox.stub(Models.Token, 'findOne').resolves(token as any)
+      let capturedFromBlock: any
+      sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').callsFake(async function (this: any): Promise<undefined> {
+        capturedFromBlock = this.crawlSetting.filter.fromBlock
+        return undefined
+      })
       sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
       sandbox.stub(logger, 'verbose')
 
-      await LogDelegateChanged.start(vePlugin as any)
+      await LogDelegateChanged.start(plugin as any)
 
-      expect(crawlStub.calledOnce).to.be.true
+      expect(capturedFromBlock).to.eq(token.blockNumber)
     })
 
-    it('should use plugin.blockNumber as fromBlock', async () => {
+    it('should fall back to plugin.blockNumber when token is not found', async () => {
+      sandbox.stub(Models.Token, 'findOne').resolves(null)
       let capturedFromBlock: any
       sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').callsFake(async function (this: any): Promise<undefined> {
         capturedFromBlock = this.crawlSetting.filter.fromBlock
@@ -70,7 +76,27 @@ describe('AragonPlugins: LogDelegateChanged', () => {
       expect(capturedFromBlock).to.eq(plugin.blockNumber)
     })
 
+    it('should crawl successfully for VE plugin with escrow addresses', async () => {
+      const vePlugin = {
+        ...plugin,
+        votingEscrow: {
+          escrowAddress: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          exitQueueAddress: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        },
+      }
+
+      sandbox.stub(Models.Token, 'findOne').resolves(token as any)
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves(undefined)
+      sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
+      sandbox.stub(logger, 'verbose')
+
+      await LogDelegateChanged.start(vePlugin as any)
+
+      expect(crawlStub.calledOnce).to.be.true
+    })
+
     it('should call processError when crawl triggers onError', async () => {
+      sandbox.stub(Models.Token, 'findOne').resolves(token as any)
       const error = new Error('crawl error')
       sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').callsFake(async function (this: any): Promise<undefined> {
         this.crawlParams.onError(error, { transactionHash: '0xhash' })

--- a/test/unit/services/aragon-plugins/logDelegateChanged.spec.ts
+++ b/test/unit/services/aragon-plugins/logDelegateChanged.spec.ts
@@ -1,0 +1,104 @@
+import logger from '@logger'
+import { BlockchainLogCrawler } from '@modules/crawlers'
+import { LogDelegateChanged } from '@services/aragon-plugins/logDelegateChanged'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+describe('AragonPlugins: LogDelegateChanged', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  describe('start', () => {
+    const plugin = {
+      address: '0x1234567890123456789012345678901234567890',
+      tokenAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      network: NetworksEnum.ethereumMainnet,
+      blockNumber: 100,
+      interfaceType: 'tokenVoting',
+    }
+
+    it('should crawl DelegateChanged events historically and log start/end', async () => {
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves(undefined)
+      sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
+      const verboseStub = sandbox.stub(logger, 'verbose')
+
+      await LogDelegateChanged.start(plugin as any)
+
+      expect(crawlStub.calledOnce).to.be.true
+      expect(verboseStub.calledWith('Start LogDelegateChanged historical sync' as any)).to.be.true
+      expect(verboseStub.calledWith('End LogDelegateChanged historical sync' as any)).to.be.true
+    })
+
+    it('should crawl successfully for VE plugin with escrow addresses', async () => {
+      const vePlugin = {
+        ...plugin,
+        votingEscrow: {
+          escrowAddress: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          exitQueueAddress: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        },
+      }
+
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').resolves(undefined)
+      sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
+      sandbox.stub(logger, 'verbose')
+
+      await LogDelegateChanged.start(vePlugin as any)
+
+      expect(crawlStub.calledOnce).to.be.true
+    })
+
+    it('should use plugin.blockNumber as fromBlock', async () => {
+      let capturedFromBlock: any
+      sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').callsFake(async function (this: any): Promise<undefined> {
+        capturedFromBlock = this.crawlSetting.filter.fromBlock
+        return undefined
+      })
+      sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
+      sandbox.stub(logger, 'verbose')
+
+      await LogDelegateChanged.start(plugin as any)
+
+      expect(capturedFromBlock).to.eq(plugin.blockNumber)
+    })
+
+    it('should call processError when crawl triggers onError', async () => {
+      const error = new Error('crawl error')
+      sandbox.stub(BlockchainLogCrawler.prototype, 'crawl').callsFake(async function (this: any): Promise<undefined> {
+        this.crawlParams.onError(error, { transactionHash: '0xhash' })
+        return undefined
+      })
+      sandbox.stub(BlockchainLogCrawler.prototype, 'end').resolves()
+      sandbox.stub(logger, 'verbose')
+
+      const processErrorStub = sandbox.stub(LogDelegateChanged, 'processError').resolves()
+
+      await LogDelegateChanged.start(plugin as any)
+
+      expect(processErrorStub.calledOnce).to.be.true
+      expect(processErrorStub.firstCall.args[0]).to.equal(error)
+      expect(processErrorStub.firstCall.args[2]).to.deep.equal({ transactionHash: '0xhash' })
+    })
+  })
+
+  describe('processError', () => {
+    it('should log an error', async () => {
+      const errorStub = sandbox.stub(logger, 'error')
+      const plugin = { address: '0x123', network: NetworksEnum.ethereumMainnet }
+      const log = { transactionHash: '0xhash' }
+
+      await LogDelegateChanged.processError('some error', plugin as any, log)
+
+      expect(errorStub.calledOnce).to.be.true
+      expect(errorStub.calledWith('Error LogDelegateChanged' as any)).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
## 📝 Summary

- Add `POST /queue/delegate-changed-sync/:pluginAddress/:network` admin endpoint to trigger a full historical re-sync of `DelegateChanged` events for a given plugin
- New `syncDelegateChanged` RabbitMQ queue and consumer in `aragon-plugins` — crawls from the plugin's deploy block with no configIndexer tracking, so each trigger always starts fresh
- Idempotent by design: the handler uses `upsert` + `$setOnInsert` and the `id` field has a unique index, so re-running produces no duplicates
- Unit tests added for the controller, router, handler, and queue consumer

Closes BE-198

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added unit tests for new functionality