### PR TITLE
fix: extend DAO indexing status

### DIFF
--- a/src/services/aragon-api/controllers/transaction.ts
+++ b/src/services/aragon-api/controllers/transaction.ts
@@ -10,6 +10,7 @@ import {
   type IPaginatedResult,
   type IPaginationParams,
   type IPairParams,
+  IPluginInterfaceType,
   type ITransactionExtraParams,
   ITransactionIndexCheckType,
   type ITransactionIndexingStatusResponse,
@@ -66,7 +67,16 @@ const TransactionController = {
 
       response.isProcessed = Boolean(data)
 
-      if (data && action === ITransactionIndexCheckType.PROPOSAL_CREATE) {
+      if (data && action === ITransactionIndexCheckType.DAO_CREATE) {
+        const anyAdminMemberExists = await Models.PluginMember.exists({
+          daoAddress: data.address,
+          network: data.network,
+        })
+
+        if (!anyAdminMemberExists) {
+          response.isProcessed = false
+        }
+      } else if (data && action === ITransactionIndexCheckType.PROPOSAL_CREATE) {
         let pluginAddress = data.pluginAddress
         const plugin = await Models.Plugin.findByAddress(pluginAddress, data.network)
 
@@ -111,6 +121,7 @@ const TransactionController = {
         response.isSupported = data.isSupported
         response.interfaceType = data.interfaceType
       }
+
       return response
     } catch (_error) {
       return response

--- a/src/services/aragon-api/controllers/transaction.ts
+++ b/src/services/aragon-api/controllers/transaction.ts
@@ -68,9 +68,21 @@ const TransactionController = {
       response.isProcessed = Boolean(data)
 
       if (data && action === ITransactionIndexCheckType.DAO_CREATE) {
+        const adminPlugin = await Models.Plugin.findOne({
+          interfaceType: IPluginInterfaceType.admin,
+          daoAddress: data.address,
+          network: data.network,
+        })
+
+        if (!adminPlugin) {
+          response.isProcessed = false
+          return response
+        }
+
         const anyAdminMemberExists = await Models.PluginMember.exists({
           daoAddress: data.address,
           network: data.network,
+          pluginAddress: adminPlugin.address,
         })
 
         if (!anyAdminMemberExists) {

--- a/test/unit-dep/daoIndexingStatus.spec.ts
+++ b/test/unit-dep/daoIndexingStatus.spec.ts
@@ -16,7 +16,7 @@ import { Interface } from 'ethers'
 import { expect } from 'chai'
 import PluginRepoMockData from '@test/unit-dep/mockData/pluginRepo.json'
 
-describe.only('Integ: DAO create indexing status includes admin plugin member', () => {
+describe('Integ: DAO create indexing status includes admin plugin member', () => {
   let sandbox: SinonSandbox
 
   const network = NetworksEnum.ethereumSepolia

--- a/test/unit-dep/daoIndexingStatus.spec.ts
+++ b/test/unit-dep/daoIndexingStatus.spec.ts
@@ -16,16 +16,22 @@ import { Interface } from 'ethers'
 import { expect } from 'chai'
 import PluginRepoMockData from '@test/unit-dep/mockData/pluginRepo.json'
 
-describe('Integ: DAO create indexing status includes admin plugin member', () => {
+describe.only('Integ: DAO create indexing status includes admin plugin member', () => {
   let sandbox: SinonSandbox
 
   const network = NetworksEnum.ethereumSepolia
   const txHash = '0x5f3f21bf0fbbfd8296dfe74575ce001e6feeeeb33366309c72a41c34b4976301'
 
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
   it('should return isProcessed=true after dao and admin plugin are indexed', async function () {
     this.timeout(1000000000)
-
-    sandbox = sinon.createSandbox()
 
     if (PluginRepoMockData[network]) {
       await Models.PluginRepo.insertMany(PluginRepoMockData[network])
@@ -84,7 +90,5 @@ describe('Integ: DAO create indexing status includes admin plugin member', () =>
     )
 
     expect(result.isProcessed).to.be.true
-
-    sandbox.restore()
   })
 })

--- a/test/unit-dep/daoIndexingStatus.spec.ts
+++ b/test/unit-dep/daoIndexingStatus.spec.ts
@@ -1,0 +1,90 @@
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+import { EnumQueueName, IPluginInterfaceType, ITransactionIndexCheckType, NetworksEnum } from '@types'
+import Web3Helper from '@helpers/web3'
+import Web3Utils from '@helpers/web3Utils'
+import RabbitMQHelper from '@helpers/rabbitMQ'
+import { DAORegistry } from '@artifacts/daoRegistry'
+import { PluginSetupProcessor } from '@artifacts/pluginSetupProcessor'
+import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
+import { PluginSetupProcessorHandler } from '@handlers/pluginSetupProcessorHandler'
+import { LogAdmin } from '@plugins/logAdmin'
+import { LogDao } from '@plugins/logDao'
+import { Models } from '@dbModels'
+import TransactionController from '@api/controllers/transaction'
+import { Interface } from 'ethers'
+import { expect } from 'chai'
+import PluginRepoMockData from '@test/unit-dep/mockData/pluginRepo.json'
+
+describe('Integ: DAO create indexing status includes admin plugin member', () => {
+  let sandbox: SinonSandbox
+
+  const network = NetworksEnum.ethereumSepolia
+  const txHash = '0x5f3f21bf0fbbfd8296dfe74575ce001e6feeeeb33366309c72a41c34b4976301'
+
+  it('should return isProcessed=true after dao and admin plugin are indexed', async function () {
+    this.timeout(1000000000)
+
+    sandbox = sinon.createSandbox()
+
+    if (PluginRepoMockData[network]) {
+      await Models.PluginRepo.insertMany(PluginRepoMockData[network])
+    }
+
+    sandbox.stub(RabbitMQHelper, 'sendMessage').callsFake(async (queue: string, job: any) => {
+      if (queue === EnumQueueName.logDao) {
+        const dao = await Models.Dao.findByAddress(job.params.address, job.params.network)
+        if (dao) {
+          await LogDao.start(dao)
+        }
+      }
+
+      if (queue === EnumQueueName.plugins) {
+        const plugin = await Models.Plugin.findByAddress(job.params.address, job.params.network)
+        if (plugin?.interfaceType === IPluginInterfaceType.admin) {
+          await LogAdmin.start(plugin)
+        }
+      }
+    })
+
+    const receipt = await Web3Helper.getTransactionReceipt(txHash, network)
+
+    const daoRegistryIface = new Interface(DAORegistry.abi)
+    const pspIface = new Interface(PluginSetupProcessor.abi)
+
+    const daoRegisteredLogs = Web3Utils.findLogsByName(receipt!, 'DAORegistered', DAORegistry.abi)
+    for (const log of daoRegisteredLogs) {
+      const event = Web3Utils.parseLog(log.txLog, daoRegistryIface)!
+      const info = Web3Utils.parseInfoLog(log.txLog, 'DAORegistered', network)
+      await DaoRegistryHandler.daoRegistered(event, info)
+    }
+
+    const installationPreparedLogs = Web3Utils.findLogsByName(
+      receipt!,
+      'InstallationPrepared',
+      PluginSetupProcessor.abi,
+    )
+    for (const log of installationPreparedLogs) {
+      const event = Web3Utils.parseLog(log.txLog, pspIface)!
+      const info = Web3Utils.parseInfoLog(log.txLog, 'InstallationPrepared', network)
+      await PluginSetupProcessorHandler.installationPrepared(event, info)
+    }
+
+    const installationAppliedLogs = Web3Utils.findLogsByName(receipt!, 'InstallationApplied', PluginSetupProcessor.abi)
+    for (const log of installationAppliedLogs) {
+      const event = Web3Utils.parseLog(log.txLog, pspIface)!
+      const info = Web3Utils.parseInfoLog(log.txLog, 'InstallationApplied', network)
+      await PluginSetupProcessorHandler.installationApplied(event, info)
+    }
+
+    const result = await TransactionController.getTransactionIndexingStatus(
+      txHash,
+      ITransactionIndexCheckType.DAO_CREATE,
+      network,
+    )
+
+    expect(result.isProcessed).to.be.true
+
+    sandbox.restore()
+  })
+})

--- a/test/unit/services/aragon-api/controllers/transaction.spec.ts
+++ b/test/unit/services/aragon-api/controllers/transaction.spec.ts
@@ -132,24 +132,39 @@ describe('TransactionController', () => {
     })
 
     describe('DAO_CREATE indexing', () => {
-      it('should return isProcessed true when DAO creation transaction is found', async () => {
+      it('should return isProcessed true when DAO and admin plugin member exist', async () => {
+        const fakeDao = DaoList[0]
+        await Models.Dao.create(fakeDao)
+        await Models.PluginMember.create({
+          daoAddress: fakeDao.address,
+          network: fakeDao.network,
+          address: '0xadminmember001',
+          memberAddress: '0xadminmember001',
+          pluginAddress: '0xadminplugin001',
+          blockNumber: 1,
+          transactionHash: fakeDao.transactionHash,
+        })
+
+        const response = await TransactionController.getTransactionIndexingStatus(
+          fakeDao.transactionHash!,
+          ITransactionIndexCheckType.DAO_CREATE,
+          fakeDao.network!,
+        )
+
+        expect(response).to.deep.eq({ isProcessed: true })
+      })
+
+      it('should return isProcessed false when DAO exists but no admin plugin member', async () => {
         const fakeDao = DaoList[0]
         await Models.Dao.create(fakeDao)
 
-        const txHash = fakeDao.transactionHash
-        const network = fakeDao.network
-        const spyReq = sandbox.spy(Models.Dao, 'findOne')
-
         const response = await TransactionController.getTransactionIndexingStatus(
-          txHash!,
+          fakeDao.transactionHash!,
           ITransactionIndexCheckType.DAO_CREATE,
-          network!,
+          fakeDao.network!,
         )
 
-        expect(spyReq.calledOnce).to.be.true
-        expect(response).to.deep.eq({
-          isProcessed: true,
-        })
+        expect(response).to.deep.eq({ isProcessed: false })
       })
 
       it('should return isProcessed false when DAO creation transaction is not found', async () => {
@@ -164,9 +179,7 @@ describe('TransactionController', () => {
         )
 
         expect(spyReq.calledOnce).to.be.true
-        expect(response).to.deep.eq({
-          isProcessed: false,
-        })
+        expect(response).to.deep.eq({ isProcessed: false })
       })
     })
 

--- a/test/unit/services/aragon-api/controllers/transaction.spec.ts
+++ b/test/unit/services/aragon-api/controllers/transaction.spec.ts
@@ -134,13 +134,23 @@ describe('TransactionController', () => {
     describe('DAO_CREATE indexing', () => {
       it('should return isProcessed true when DAO and admin plugin member exist', async () => {
         const fakeDao = DaoList[0]
+        const adminPluginAddress = '0xadminplugin001'
         await Models.Dao.create(fakeDao)
+        await Models.Plugin.create({
+          transactionHash: fakeDao.transactionHash,
+          daoAddress: fakeDao.address,
+          network: fakeDao.network,
+          address: adminPluginAddress,
+          interfaceType: IPluginInterfaceType.admin,
+          status: IPluginStatus.installed,
+          blockNumber: 1,
+        })
         await Models.PluginMember.create({
           daoAddress: fakeDao.address,
           network: fakeDao.network,
           address: '0xadminmember001',
           memberAddress: '0xadminmember001',
-          pluginAddress: '0xadminplugin001',
+          pluginAddress: adminPluginAddress,
           blockNumber: 1,
           transactionHash: fakeDao.transactionHash,
         })


### PR DESCRIPTION
## 📝 Summary

When DAO is created we should enter a "DAO onboarding" screen, which depends on the check if a user is admin or not. So, we need to update indexing status check to wait for members list to be available.

This endpoint should correctly return immediately after indexing is done: `/v2/members/:memberAddress/:pluginAddress/exists`

## 🔄 What Changed

> 💡 **Use GitHub Copilot's "Generate Summary" button to auto-generate this section**

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [x] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
