### PR TITLE
fix(peaq): skip native crawlers for duplicate transaction fix

### DIFF
--- a/src/migrations/20260401090000-rm-duplicate-transaction-peaq.ts
+++ b/src/migrations/20260401090000-rm-duplicate-transaction-peaq.ts
@@ -1,0 +1,32 @@
+import { Models } from '@dbModels'
+import logger from '@logger'
+import { type IMigration, ITransactionType, NetworksEnum } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: rm-duplicate-transaction-peaq' })
+
+export const rmDuplicateTransactionPeaqMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: '20260401090000-rm-duplicate-transaction-peaq' }))
+
+    try {
+      const result = await Models.Transaction.deleteMany({
+        network: NetworksEnum.peaqMainnet,
+        type: ITransactionType.native,
+      })
+
+      logger.info(
+        'Migration completed successfully',
+        llo({ migration: '20260401090000-rm-duplicate-transaction-peaq', deletedCount: result.deletedCount }),
+      )
+    } catch (error) {
+      logger.error('Migration failed', llo({ migration: '20260401090000-rm-duplicate-transaction-peaq', error }))
+      throw error
+    }
+  },
+
+  stop: async () => {
+    // Usually empty for migrations
+  },
+}
+
+export default rmDuplicateTransactionPeaqMigration

--- a/src/services/aragon-dao/daoTransactions.ts
+++ b/src/services/aragon-dao/daoTransactions.ts
@@ -159,8 +159,8 @@ export const DaoTransactions = {
       // Crawl events - all crawlers
       const crawlers: BlockchainLogCrawler[] = [crawlerIncomingTokenTransfers, crawlerOutgoingTokenTransfers]
 
-      // on zksync and peaq native token is also an erc20
-      if (network !== NetworksEnum.zksyncMainnet && network !== NetworksEnum.peaqMainnet) {
+      // On zkSync and Peaq, the native token is also an ERC20
+      if (daoDb.network !== NetworksEnum.zksyncMainnet && daoDb.network !== NetworksEnum.peaqMainnet) {
         crawlers.push(crawlerIncomingNativeDeposits)
         crawlers.push(crawlerOutgoingNativeTransfers)
       }

--- a/src/services/aragon-dao/daoTransactions.ts
+++ b/src/services/aragon-dao/daoTransactions.ts
@@ -159,8 +159,8 @@ export const DaoTransactions = {
       // Crawl events - all crawlers
       const crawlers: BlockchainLogCrawler[] = [crawlerIncomingTokenTransfers, crawlerOutgoingTokenTransfers]
 
-      // on zksync native token is also a erc20
-      if (network !== NetworksEnum.zksyncMainnet) {
+      // on zksync and peaq native token is also an erc20
+      if (network !== NetworksEnum.zksyncMainnet && network !== NetworksEnum.peaqMainnet) {
         crawlers.push(crawlerIncomingNativeDeposits)
         crawlers.push(crawlerOutgoingNativeTransfers)
       }


### PR DESCRIPTION
## Summary
- Skip native deposit/withdraw crawlers for peaq-mainnet (same fix as zkSync)
- PEAQ native token at `0x0000...0809` is also an ERC20, causing duplicate transactions
- Migration to delete existing native-type duplicate transactions in prod

## Root Cause
PEAQ's native token is an ERC20 contract at `0x0000000000000000000000000000000000000809`. When DAOs execute transfers, the chain emits both `NativeTokenDeposited` events AND `Transfer` events from the ERC20 contract. This creates duplicate transaction records.

**Prod data:**
- 22 duplicate ERC20 transactions with `tokenAddress: 0x0809` across 2 DAOs
- DAO to verify: `0x12Fec1A67fD8B6603084C8307fa8ccCc964686Df` (20 duplicate withdrawals)

## Changes
- `src/services/aragon-dao/daoTransactions.ts`: Add `peaqMainnet` to the condition that skips native crawlers (same pattern as zkSync)
- `src/migrations/20260401090000-rm-duplicate-transaction-peaq.ts`: Delete all `type: native` transactions for peaq-mainnet

## Test plan
- [ ] CI passes
- [ ] After migration, verify no native-type transactions exist for peaq-mainnet
- [ ] New deposits to peaq DAOs only create ERC20 transfer records (no duplicates)
- [ ] Verify DAO `0x12Fec1A67fD8B6603084C8307fa8ccCc964686Df` no longer shows duplicate transfers