### PR TITLE
fix(rates): exclude fdv_usd from dead token market data check

### DIFF
--- a/src/helpers/coinGecko.ts
+++ b/src/helpers/coinGecko.ts
@@ -179,7 +179,6 @@ const CoinGeckoHelper = {
 
     const volume24h = parseFloat(token.volume_usd?.h24 || '0')
     const marketCapUsd = parseFloat(token.market_cap_usd || '0')
-    const fdvUsd = parseFloat(token.fdv_usd || '0')
 
     const hasValidMarketData = marketCapUsd > 0
     const isDeadToken = !hasValidMarketData && volume24h < config.COINGECKO.DEAD_TOKEN_VOLUME_THRESHOLD

--- a/src/helpers/coinGecko.ts
+++ b/src/helpers/coinGecko.ts
@@ -181,7 +181,7 @@ const CoinGeckoHelper = {
     const marketCapUsd = parseFloat(token.market_cap_usd || '0')
     const fdvUsd = parseFloat(token.fdv_usd || '0')
 
-    const hasValidMarketData = marketCapUsd > 0 || fdvUsd > 0
+    const hasValidMarketData = marketCapUsd > 0
     const isDeadToken = !hasValidMarketData && volume24h < config.COINGECKO.DEAD_TOKEN_VOLUME_THRESHOLD
 
     return {

--- a/src/services/aragon-admin-api/controllers/queue.ts
+++ b/src/services/aragon-admin-api/controllers/queue.ts
@@ -159,6 +159,19 @@ const QueueAdminController = {
     return true
   },
 
+  refreshTokenPrice: async (params: IAQueueDao): Promise<any> => {
+    const token = await Models.Token.findExistingLog({ address: params.address, network: params.network })
+    assertExposable(token, ErrorKeyEnum.notFound)
+
+    await RabbitMQHelper.sendMessage(EnumQueueName.tokenInfo, {
+      id: params.address,
+      params: { address: params.address, network: params.network, forceUpdate: true },
+    })
+
+    logger.verbose('Force refresh token price', llo({ address: params.address, network: params.network }))
+    return true
+  },
+
   recalculateProposalActions: async (params: {
     pluginAddress: string
     incrementalId: number

--- a/src/services/aragon-admin-api/routers/queue.ts
+++ b/src/services/aragon-admin-api/routers/queue.ts
@@ -75,6 +75,17 @@ const QueueAdminRouter = {
     ctx.body = await QueueAdminController.queueDelegateChangedSync(formattedValues)
   },
 
+  refreshTokenPrice: async function (ctx: RouterContext) {
+    const params: IAQueueDao = {
+      address: ctx.params.tokenAddress,
+      network: ctx.params.network,
+    }
+
+    const formattedValues = await ValidationSchema.validateParams(GenericSchema.defaultParams, params)
+
+    ctx.body = await QueueAdminController.refreshTokenPrice(formattedValues)
+  },
+
   recalculateProposalActions: async function (ctx: RouterContext) {
     const params = {
       incrementalId: parseInt(ctx.query.incrementalId as string),
@@ -100,6 +111,7 @@ const QueueAdminRouter = {
       authedAdmin,
       QueueAdminRouter.queueProposalMetrics,
     )
+    router.post('/token-price/:tokenAddress/:network', authedAdmin, QueueAdminRouter.refreshTokenPrice)
     router.post('/proposals/decode', authedAdmin, QueueAdminRouter.recalculateProposalActions)
     router.post(
       '/delegate-changed-sync/:pluginAddress/:network',

--- a/src/services/aragon-gateway/index.ts
+++ b/src/services/aragon-gateway/index.ts
@@ -1,16 +1,16 @@
 import config from '@config'
+import { Models } from '@dbModels'
 import GaugeHelper from '@helpers/gauge'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import Web3Helper from '@helpers/web3'
 import logger from '@logger'
-import { Models } from '@dbModels'
+import GovernanceRewards from '@modules/governanceRewards'
 import { ProxyToken } from '@modules/proxyToken'
+import VeRewardDistribution from '@modules/veRewardDistribution'
 import ActionDecoder from '@services/aragon-gateway/actionDecoder'
 import { CapitalDistributorGateway } from '@services/aragon-gateway/capitalDistributor'
 import { ContractInfo } from '@services/aragon-gateway/contractInfo'
 import { GaugeInfo } from '@services/aragon-gateway/gauge'
-import GovernanceRewards from '@modules/governanceRewards'
-import VeRewardDistribution from '@modules/veRewardDistribution'
 import { MemberInfo } from '@services/aragon-gateway/memberInfo'
 import { MetadataRefetchProcessor } from '@services/aragon-gateway/metadataRefetch'
 import Plugin from '@services/aragon-gateway/plugin'
@@ -136,8 +136,8 @@ const AragonGatewayService: IService = {
     )
 
     await RabbitMQHelper.process(EnumQueueName.tokenInfo, async (job: { params: IQueueTokenInfo }) => {
-      const { address, network } = job.params
-      await ProxyToken.saveAndGetToken(address, network)
+      const { address, network, forceUpdate } = job.params
+      await ProxyToken.saveAndGetToken(address, network, forceUpdate)
       return true
     })
 

--- a/src/types/queue.ts
+++ b/src/types/queue.ts
@@ -139,6 +139,7 @@ export interface IGetGaugeInfoId {
 export interface IQueueTokenInfo {
   address: HexAddress
   network: NetworksEnum
+  forceUpdate?: boolean
 }
 
 export interface IGaugeInfo {

--- a/test/unit/helpers/coinGecko.spec.ts
+++ b/test/unit/helpers/coinGecko.spec.ts
@@ -432,7 +432,7 @@ describe('Helpers: CoinGecko', () => {
       expect(result.symbol).to.eq('ZKC')
     })
 
-    it('should return actual priceUsd for tokens with low volume but valid fdv_usd', () => {
+    it('should return priceUsd as 0 for tokens with zero volume and null market cap even if fdv_usd is set', () => {
       const response = {
         data: {
           id: 'fdv-token',
@@ -454,7 +454,7 @@ describe('Helpers: CoinGecko', () => {
 
       const result = CoinGeckoHelper._parseToken(response, NetworksEnum.ethereumMainnet)
 
-      expect(result.priceUsd).to.eq('2.5')
+      expect(result.priceUsd).to.eq('0')
     })
   })
 })

--- a/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
+++ b/test/unit/services/aragon-admin-api/controllers/queue.spec.ts
@@ -544,6 +544,44 @@ describe('Controller: QueueAdmin', () => {
     })
   })
 
+  describe('refreshTokenPrice', () => {
+    const tokenAddress = '0x1234567890123456789012345678901234567890'
+    const network = NetworksEnum.ethereumMainnet
+
+    it('should send tokenInfo queue message with forceUpdate=true', async () => {
+      sandbox.stub(Models.Token, 'findExistingLog').resolves({ address: tokenAddress, network } as any)
+
+      const result = await QueueAdminController.refreshTokenPrice({ address: tokenAddress, network })
+
+      expect(result).to.be.true
+      expect(rabbitMQ.calledOnce).to.be.true
+      expect(rabbitMQ.firstCall.args[0]).to.equal(EnumQueueName.tokenInfo)
+      expect(rabbitMQ.firstCall.args[1]).to.deep.equal({
+        id: tokenAddress,
+        params: { address: tokenAddress, network, forceUpdate: true },
+      })
+    })
+
+    it('should throw notFound if token does not exist', async () => {
+      sandbox.stub(Models.Token, 'findExistingLog').resolves(null)
+
+      await expect(QueueAdminController.refreshTokenPrice({ address: tokenAddress, network })).to.be.rejectedWith(
+        Error,
+        ErrorKeyEnum.notFound,
+      )
+    })
+
+    it('should propagate RabbitMQ errors', async () => {
+      sandbox.stub(Models.Token, 'findExistingLog').resolves({ address: tokenAddress, network } as any)
+      rabbitMQ.rejects(new Error('RabbitMQ error'))
+
+      await expect(QueueAdminController.refreshTokenPrice({ address: tokenAddress, network })).to.be.rejectedWith(
+        Error,
+        'RabbitMQ error',
+      )
+    })
+  })
+
   describe('queueDelegateChangedSync', () => {
     const pluginAddress = '0x1234567890123456789012345678901234567890'
     const network = NetworksEnum.ethereumMainnet

--- a/test/unit/services/aragon-gateway/index.spec.ts
+++ b/test/unit/services/aragon-gateway/index.spec.ts
@@ -1,8 +1,8 @@
+import { Models } from '@dbModels'
 import GaugeHelper from '@helpers/gauge'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import Web3Helper from '@helpers/web3'
 import logger from '@logger'
-import { Models } from '@dbModels'
 import GovernanceRewards from '@modules/governanceRewards'
 import { ProxyToken } from '@modules/proxyToken'
 import VeRewardDistribution from '@modules/veRewardDistribution'
@@ -449,7 +449,27 @@ describe('AragonGateway: index', () => {
       } as any)
 
       expect(queueName).to.eq(EnumQueueName.tokenInfo)
-      expect(proxyTokenStub.calledOnceWith('0xTokenAddress', NetworksEnum.ethereumMainnet)).to.be.true
+      expect(proxyTokenStub.calledOnceWith('0xTokenAddress', NetworksEnum.ethereumMainnet, undefined)).to.be.true
+      expect(result).to.be.true
+    })
+
+    it('should handle tokenInfo queue with forceUpdate=true', async () => {
+      const processStub = sandbox.stub(RabbitMQHelper, 'process')
+      const proxyTokenStub = sandbox.stub(ProxyToken, 'saveAndGetToken').resolves()
+
+      await AragonGatewayService.start()
+
+      const handler = processStub.getCall(11).args[1]
+
+      const result = await handler({
+        params: {
+          address: '0xTokenAddress',
+          network: NetworksEnum.ethereumMainnet,
+          forceUpdate: true,
+        },
+      } as any)
+
+      expect(proxyTokenStub.calledOnceWith('0xTokenAddress', NetworksEnum.ethereumMainnet, true)).to.be.true
       expect(result).to.be.true
     })
 


### PR DESCRIPTION
## Summary
- Tokens with artificially inflated pool prices (zero volume, null market cap) were passing the dead token filter because `fdv_usd` is derived from `price_usd × total_supply` — non-zero even when the price is fake
- Only `market_cap_usd` (independently tracked by CoinGecko) reliably signals a legitimate token
- Removed `fdvUsd > 0` from the `hasValidMarketData` check so tokens with `market_cap_usd = null` and `volume_h24 = 0` correctly get `priceUsd = '0'`
- Added an admin endpoint `POST /queue/token-price/:tokenAddress/:network` to force-refresh a token's price on demand (re-queues `tokenInfo` with `forceUpdate: true`), so admins can retrigger price syncing for previously cached tokens after this fix lands

## Examples fixed
| Token | Network | Fake price | volume_h24 | market_cap_usd |
|---|---|---|---|---|
| SPX | Ethereum | \$10.4B | 0 | null |
| gtUSDCp | Base | \$14,073 | 0 | null |

## Files touched
- `src/helpers/coinGecko.ts`
- `src/services/aragon-admin-api/controllers/queue.ts`
- `src/services/aragon-admin-api/routers/queue.ts`
- `src/types/queue.ts`