### PR TITLE
fix(assets): balanceOf fallback when Alchemy Enhanced API is disabled (Citrea)

### DIFF
--- a/src/modules/proxyProvider/web3Provider.ts
+++ b/src/modules/proxyProvider/web3Provider.ts
@@ -1,13 +1,77 @@
+import { ERC20 } from '@artifacts/ERC20'
+import { Models } from '@dbModels'
 import Alchemy from '@helpers/alchemy'
 import { EvmExplorerEnum, evmExplorerClient } from '@helpers/evmExplorerClient'
+import { retryRequest } from '@helpers/retryRequest'
 import utils from '@helpers/utils'
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
 import { ProxyToken } from '@modules/proxyToken'
-import { IContractAddressType, type IWeb3Provider, type IWeb3TokenBalance, NetworksEnum } from '@types'
+import {
+  type HexAddress,
+  IContractAddressType,
+  ITransactionType,
+  type IWeb3Provider,
+  type IWeb3TokenBalance,
+  NetworksEnum,
+} from '@types'
+import { Interface } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'helpers:ProxyWeb3' })
+
+// Discover ERC20 holdings from the DAO's own Transaction history and read each
+// balance via a direct `balanceOf` eth_call. Used as a fallback for chains where
+// Alchemy's Enhanced API is not enabled — e.g. Citrea returns
+// `-32600 EAPIs not enabled on specified network: [CITREA_MAINNET]`, which
+// Web3Helper.getTokenBalances swallows into an empty array.
+//
+// Only tokens the crawler has already seen a Transfer event for are covered.
+// That's acceptable because (a) new holdings first appear via a Transfer, and
+// (b) Alchemy's Enhanced API is itself just an index of those same events.
+async function getTokenBalancesFromTxHistory(address: HexAddress, network: NetworksEnum): Promise<IWeb3TokenBalance[]> {
+  const knownTokenAddresses: HexAddress[] = await Models.Transaction.distinct('tokenAddress', {
+    daoAddress: address,
+    network,
+    type: ITransactionType.erc20,
+    tokenAddress: { $ne: utils.zeroAddress },
+  })
+
+  if (knownTokenAddresses.length === 0) {
+    return []
+  }
+
+  const provider = ProviderModule.getAnyRpcProvider(network)
+  const limiter = BottleneckModule.getNodeLimiter(network)
+  const iface = new Interface(ERC20.abi)
+  const callData = iface.encodeFunctionData('balanceOf', [address])
+
+  const balances = await Promise.all(
+    knownTokenAddresses.map(async (tokenAddress: HexAddress) => {
+      try {
+        const raw = await retryRequest(async () =>
+          limiter.schedule(async () => provider.call({ to: tokenAddress, data: callData })),
+        )
+        const [balance] = iface.decodeFunctionResult('balanceOf', raw)
+        if (balance === 0n) return null
+        return {
+          contractAddress: tokenAddress,
+          tokenBalance: balance.toString(),
+        } as IWeb3TokenBalance
+      } catch (error) {
+        logger.warn(
+          'Failed to read ERC20 balance via balanceOf fallback',
+          llo({ address, tokenAddress, network, error: (error as Error).message }),
+        )
+        return null
+      }
+    }),
+  )
+
+  return balances.filter((b): b is IWeb3TokenBalance => b !== null)
+}
 
 const Web3Provider: IWeb3Provider = {
   getNativeBalance: async ({ address, network }) => {
@@ -29,7 +93,16 @@ const Web3Provider: IWeb3Provider = {
   },
 
   getTokenBalances: async ({ address, network }) => {
-    const tokensBalance = await Web3Helper.getTokenBalances(address, network)
+    let tokensBalance = await Web3Helper.getTokenBalances(address, network)
+
+    // Web3Helper.getTokenBalances swallows `-32600 EAPIs not enabled` into []
+    // on chains where Alchemy's Enhanced API is disabled (e.g. Citrea). We
+    // can't distinguish that from a DAO that genuinely holds no tokens, so
+    // we always run the fallback on an empty result — it's a cheap DB
+    // distinct() + one balanceOf per token the crawler has already seen.
+    if (tokensBalance.length === 0) {
+      tokensBalance = await getTokenBalancesFromTxHistory(address, network)
+    }
 
     return (
       await Promise.all(


### PR DESCRIPTION
## Summary

Citrea DAOs show empty ERC20 assets in the UI because `alchemy_getTokenBalances` isn't enabled on that network. Alchemy returns:

\`\`\`
-32600 EAPIs not enabled on specified network: [CITREA_MAINNET]
\`\`\`

`Web3Helper.getTokenBalances` (src/helpers/web3.ts:203) catches that error and returns `[]`, so `DaoAssets.start` sees zero ERC20 holdings and only writes the native-token Asset row. Every Citrea DAO is affected — this is the root cause of the missing assets we've been seeing on dev.

## Fix

Add a fallback path inside `Web3Provider.getTokenBalances` (src/modules/proxyProvider/web3Provider.ts) that runs when the Alchemy path returns empty:

1. `Models.Transaction.distinct('tokenAddress', …)` — discover every ERC20 the crawler has already seen an incoming Transfer for on this DAO.
2. For each, call `balanceOf(daoAddress)` via a standard `eth_call` using the `BottleneckModule` rate limiter + `retryRequest`.
3. Return the same `IWeb3TokenBalance` shape the Alchemy path produces, so downstream normalization (`handleAlchemyCrazyBalance`, `ProxyToken.saveAndGetToken`) is unchanged.

Only tokens the crawler has already observed a Transfer event for are covered. That's acceptable because Alchemy's Enhanced API is itself just an index of those same events — new holdings surface on their first Transfer either way.

The fallback also benefits any other chain where Alchemy returns empty: chiliz, corn, peaq (which has its own provider), katana (ditto), and any future network without Enhanced API support.

## Why this path (not a CitreaProvider subclass)

PeaqProvider / KatanaProvider / RoutescanProvider exist for chains that need an entirely different token-balance source (Subscan, block explorer APIs). Citrea has working standard JSON-RPC via Alchemy — we don't need a new provider, we just need a fallback for when Alchemy's value-add API tier isn't available. Keeping it in the default `Web3Provider` means every chain benefits without per-chain branching.

## Test plan

- [ ] \`yarn lint\` clean on the modified file
- [ ] \`yarn test:unit\` passes
- [ ] On dev, after merge + deploy, re-enqueue \`0x10FD1a9E6aA2635bAED729A4f4a1f43e470C6dB2\` on citrea-mainnet and verify:
  - \`Transaction\` row still present (unchanged path)
  - \`Asset\` collection now has a row for JUCY (\`0x28CeBE1B35B04f9f39c42fC5CA80160C4608FA0B\`) with non-zero \`amount\`
  - Native cBTC asset row still present (unchanged path)
- [ ] UI shows JUCY balance on \`https://app-next-…/dao/citrea-mainnet/0x10FD…/assets\`

## Follow-ups (not in this PR)

- Fix the `RabbitMQHelper.process` activeJobs leak on handler throw (separate PR — the cause of today's dao consumer hang).
- Fix `src/middlewares/auth.ts:34` assertion logic + exempt `/metrics` from auth (separate PR).