### PR TITLE
fix(assets): route Citrea token balances through Blockscout v2

### DIFF
--- a/src/helpers/evmExplorerClient.ts
+++ b/src/helpers/evmExplorerClient.ts
@@ -123,6 +123,14 @@ class EvmExplorerClient {
     address: HexAddress,
     network: NetworksEnum,
   ): Promise<IWeb3TokenBalance[]> {
+    // Blockscout's Etherscan-compat layer (?module=account&action=addresstokenbalance)
+    // returns 400 on some deployments (confirmed on Citrea mainnet). The modern
+    // REST v2 endpoint is supported on every current Blockscout release and
+    // returns strictly-typed ERC-20 / ERC-721 / ERC-1155 balances in one shot.
+    if (explorerType === EvmExplorerEnum.BLOCKSCOUT) {
+      return this.getBlockscoutV2TokenBalances(address, network)
+    }
+
     try {
       const params = {
         module: 'account',
@@ -149,6 +157,52 @@ class EvmExplorerClient {
       )
     } catch (error) {
       logger.warn('Error fetching token balances', llo({ error, address, network, explorerType }))
+      return []
+    }
+  }
+
+  // Blockscout REST v2 token balances — filters to ERC-20 only (ERC-721 /
+  // ERC-1155 entries have a populated `token_id` or `token_instance`). Balances
+  // come back as base-unit strings which we normalize through the same
+  // `parseTokenBalance` used by the legacy path so downstream callers see a
+  // consistent shape.
+  private async getBlockscoutV2TokenBalances(address: HexAddress, network: NetworksEnum): Promise<IWeb3TokenBalance[]> {
+    try {
+      const explorerConfig = this.configs[EvmExplorerEnum.BLOCKSCOUT]
+      const result = explorerConfig?.buildUrlAndParams(network)
+      if (!result) return []
+
+      const url = `${result.url.replace(/\/api\/?$/, '')}/api/v2/addresses/${address}/token-balances`
+
+      const limiter = BottleneckModule.getEtherScanLimiter(network)
+      const response = await retryRequest(async () => limiter.schedule(async () => axios.get(url)))
+
+      if (!Array.isArray(response?.data)) return []
+
+      return response.data
+        .filter(
+          (entry: any) =>
+            entry?.token?.type === 'ERC-20' &&
+            entry.token_id === null &&
+            typeof entry?.value === 'string' &&
+            entry.value !== '0' &&
+            entry.token.address_hash &&
+            entry.token.decimals,
+        )
+        .map((entry: any) => {
+          const decimals = Number(entry.token.decimals)
+          return {
+            contractAddress: Web3Utils.parseAddress(entry.token.address_hash) || entry.token.address_hash,
+            name: entry.token.name,
+            symbol: entry.token.symbol,
+            decimals,
+            tokenBalance: utils.parseTokenBalance(entry.value, decimals),
+            originalBalance: entry.value,
+            priceUsd: entry.token.exchange_rate ?? null,
+          }
+        })
+    } catch (error) {
+      logger.warn('Error fetching blockscout v2 token balances', llo({ error, address, network }))
       return []
     }
   }

--- a/src/modules/proxyProvider/web3Provider.ts
+++ b/src/modules/proxyProvider/web3Provider.ts
@@ -29,20 +29,38 @@ const Web3Provider: IWeb3Provider = {
   },
 
   getTokenBalances: async ({ address, network }) => {
-    const tokensBalance = await Web3Helper.getTokenBalances(address, network)
+    // Alchemy's Enhanced API (`alchemy_getTokenBalances`) is disabled on some
+    // networks Alchemy otherwise supports as an RPC provider. Citrea returns
+    //   -32600 "EAPIs not enabled on specified network: [CITREA_MAINNET]"
+    // Route such chains to their block explorer's token-balance endpoint.
+    // Same pattern used for `fetchContractCreation` / `fetchContractSourceCode`
+    // below, where Citrea is already routed to Blockscout.
+    const useExplorer = network === NetworksEnum.citreaMainnet
+    const rawBalances = useExplorer
+      ? await evmExplorerClient.getTokenBalances(EvmExplorerEnum.BLOCKSCOUT, address, network)
+      : await Web3Helper.getTokenBalances(address, network)
 
     return (
       await Promise.all(
-        tokensBalance.map(async (tokenBalance: IWeb3TokenBalance) => {
+        rawBalances.map(async (tokenBalance: IWeb3TokenBalance) => {
           if (tokenBalance.tokenBalance === utils.emptyData) return null
 
           const token = await ProxyToken.saveAndGetToken(tokenBalance.contractAddress, network)
           if (!token) return null
 
+          // Alchemy returns hex-encoded raw base units that need decimal
+          // parsing via `handleAlchemyCrazyBalance`. Blockscout v2 returns
+          // already-parsed decimal strings (see
+          // `evmExplorerClient.getBlockscoutV2TokenBalances`), so we pass
+          // them through unchanged.
+          const parsedBalance = useExplorer
+            ? tokenBalance.tokenBalance
+            : Alchemy.handleAlchemyCrazyBalance(tokenBalance.tokenBalance, token?.decimals)
+
           return {
             contractAddress: Web3Utils.parseAddress(tokenBalance.contractAddress) || tokenBalance.contractAddress,
-            tokenBalance: Alchemy.handleAlchemyCrazyBalance(tokenBalance.tokenBalance, token?.decimals),
-            originalBalance: tokenBalance.tokenBalance,
+            tokenBalance: parsedBalance,
+            originalBalance: useExplorer ? tokenBalance.originalBalance : tokenBalance.tokenBalance,
           }
         }),
       )

--- a/test/unit-dep/citreaBlockscoutBalances.spec.ts
+++ b/test/unit-dep/citreaBlockscoutBalances.spec.ts
@@ -1,0 +1,62 @@
+import { EvmExplorerEnum, evmExplorerClient } from '@helpers/evmExplorerClient'
+import MongoDB from '@modules/mongo'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import sinon from 'sinon'
+
+// Integration test for the Citrea token-balance source. Alchemy's Enhanced
+// API (`alchemy_getTokenBalances`) is disabled on Citrea by Alchemy itself
+// (`-32600 EAPIs not enabled on specified network: [CITREA_MAINNET]`), so
+// we fetch balances via Blockscout's REST v2 endpoint instead.
+//
+// This hits the real Citrea Blockscout API. Run with:
+//   DOTENV_CONFIG_PATH=.env.unit-deep yarn test:unit-dep -g "Blockscout"
+describe.only('Integration: Citrea Blockscout token balances', () => {
+  let dropStub: sinon.SinonStub
+
+  // Same stub used by daoTransaction.spec.ts — the global beforeEach drops
+  // every collection, which times out against a production-like DB. This
+  // test doesn't touch Mongo at all, but the drop fires regardless.
+  before(() => {
+    dropStub = sinon.stub(MongoDB, 'drop').resolves()
+  })
+
+  after(() => {
+    dropStub?.restore()
+  })
+
+  it('returns the JUCY ERC20 balance for DAO 0x10FD… via Blockscout v2', async function () {
+    this.timeout(60_000)
+
+    const daoAddress = '0x10FD1a9E6aA2635bAED729A4f4a1f43e470C6dB2'
+    const expectedJucyToken = '0x28CeBE1B35B04f9f39c42fC5CA80160C4608FA0B'
+
+    const balances = await evmExplorerClient.getTokenBalances(
+      EvmExplorerEnum.BLOCKSCOUT,
+      daoAddress,
+      NetworksEnum.citreaMainnet,
+    )
+
+    console.log(`Blockscout returned ${balances.length} token balance row(s):`)
+    balances.forEach((b: any, i: number) => {
+      console.log(
+        `  ${i + 1}. addr=${b.contractAddress} name=${b.name} symbol=${b.symbol} ` +
+          `decimals=${b.decimals} balance=${b.tokenBalance} raw=${b.originalBalance} ` +
+          `priceUsd=${b.priceUsd ?? 'n/a'}`,
+      )
+    })
+
+    expect(balances, 'Blockscout must return an array').to.be.an('array')
+    expect(balances.length, 'Blockscout must return at least one balance row').to.be.at.least(1)
+
+    const jucy = balances.find((b: any) => b.contractAddress?.toLowerCase() === expectedJucyToken.toLowerCase())
+    expect(jucy, 'JUCY balance row must be present for the DAO').to.exist
+    expect(jucy!.symbol, 'JUCY symbol must be populated').to.equal('JUCY')
+    expect(jucy!.name, 'JUCY name must be populated').to.be.a('string').and.not.empty
+    expect(jucy!.decimals, 'JUCY decimals must be 18').to.equal(18)
+    expect(jucy!.originalBalance, 'JUCY raw balance must be the 5e18 deposit').to.equal('5000000000000000000')
+    expect(jucy!.tokenBalance, 'JUCY parsed balance must be non-zero').to.not.equal('0')
+
+    console.log(`\n✓ Blockscout v2 is a viable token-balance source for Citrea`)
+  })
+})


### PR DESCRIPTION
## Summary

Citrea DAOs show no ERC20 assets in the UI. Root cause chain:

1. `Web3Provider.getTokenBalances` calls `Web3Helper.getTokenBalances` → `alchemy_getTokenBalances`
2. Alchemy rejects the call on Citrea with `-32600 "EAPIs not enabled on specified network: [CITREA_MAINNET]"` — their Enhanced API is not enabled for this chain (they will not enable it on request)
3. `Web3Helper.getTokenBalances` swallows the error and returns `[]`
4. `DaoAssets.assets` writes only the native cBTC row, never any ERC20 Asset rows

## Fix

Route Citrea through its Blockscout explorer instead of Alchemy Enhanced API, same pattern the file already uses for `fetchContractCreation` and `fetchContractSourceCode`.

### Why not the legacy Etherscan-compat endpoint

`evmExplorerClient.getTokenBalances` already had a Blockscout code path using `?module=account&action=addresstokenbalance`, but Citrea's Blockscout deployment returns **HTTP 400** on that — they don't expose the legacy Etherscan-compat layer. Their modern REST v2 endpoint `/api/v2/addresses/{addr}/token-balances` does work, with full token metadata.

Verified against the real endpoint:

\`\`\`
[{"token":{"address_hash":"0x28CeBE1B35B04f9f39c42fC5CA80160C4608FA0B","name":"JUICE","symbol":"JUCY","decimals":"18","type":"ERC-20",…},"value":"5000000000000000000","token_id":null,"token_instance":null}]
\`\`\`

### Changes

- **`src/helpers/evmExplorerClient.ts`** — `getTokenBalances` now branches on `explorerType === BLOCKSCOUT` and dispatches to a new private `getBlockscoutV2TokenBalances(address, network)`. v2 filters strictly to ERC-20 (`entry.token.type === 'ERC-20'` + `entry.token_id === null`) so ERC-721 / ERC-1155 entries are excluded. Non-Blockscout explorers continue using the existing Etherscan-compat route.

- **`src/modules/proxyProvider/web3Provider.ts`** — `Web3Provider.getTokenBalances` routes `citreaMainnet` to `evmExplorerClient.getTokenBalances(BLOCKSCOUT, …)`. The explorer path skips `Alchemy.handleAlchemyCrazyBalance` because Blockscout v2 already returns parsed decimal strings; all other chains keep the Alchemy Enhanced API path verbatim.

- **`test/unit-dep/citreaBlockscoutBalances.spec.ts`** — new integration test hitting the real Citrea Blockscout. Asserts the JUCY 5e18 deposit is returned with correct name/symbol/decimals/originalBalance. Runtime ~430ms.

### Scope

This only affects networks explicitly routed through \`EvmExplorerEnum.BLOCKSCOUT\` — currently just Citrea. Ethereum / Polygon / Base / Arbitrum / Optimism / etc. continue to use Alchemy's Enhanced API unchanged.

## Test plan

- [x] Unit-dep test passes locally (confirmed: 1 row, JUCY 5.0, 428ms)
- [ ] `yarn lint` + `yarn format:check` clean
- [ ] After merge + deploy, re-enqueue \`POST /admin/queue/dao-transactions/0x10FD1a9E6aA2635bAED729A4f4a1f43e470C6dB2/citrea-mainnet?reset=true\` and verify:
  - \`Models.Asset\` now contains a row with \`tokenAddress=0x28CeBE1B35B04f9f39c42fC5CA80160C4608FA0B\` and \`amount=5.0\`
  - Native cBTC Asset row still present
  - UI at \`/dao/citrea-mainnet/0x10FD…/assets\` shows both
- [ ] Spot-check a non-Citrea DAO (e.g. ethereum-mainnet) to confirm the Alchemy path is untouched

## Follow-ups (not in this PR)

- `RabbitMQHelper.process` handler-throw leak + channel drop detection (separate PR, see conversation about the dao.transactions consumer hang)
- `auth.ts:34` broken assertion + Prometheus `/metrics` auth exemption (separate PR)