### PR TITLE
fix(auth): correct admin token assertion to deny null tokens (BE-214)

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -31,7 +31,7 @@ const AuthMiddleware = {
     assertExposable(!!tokenValue, ErrorKeyEnum.accessDenied)
 
     const token = ctx.state.token || (await Models.Jwt.findByValue(tokenValue))
-    assertExposable(!!token || token?.type !== IJwtTokenType.admin, ErrorKeyEnum.accessDenied)
+    assertExposable(!!token && token.type === IJwtTokenType.admin, ErrorKeyEnum.accessDenied)
 
     // const tokenExpired = moment(token.updatedAt).isBefore(moment().subtract({ days: CONFIG.SERVICES.API.SESSION_EXPIRATION_DAY }))
     // if (tokenExpired) {

--- a/test/unit/middlewares/auth.spec.ts
+++ b/test/unit/middlewares/auth.spec.ts
@@ -73,5 +73,17 @@ describe('middlewares: auth', () => {
       ctx.state[JwtHelper.JWT_KEY] = null
       await expect(AuthMiddleware.authAssertAdmin()(ctx, next)).to.be.rejectedWith(Error, ErrorKeyEnum.accessDenied)
     })
+
+    it('should deny access when token is not found in DB', async () => {
+      findByValueStub.resolves(null)
+      await expect(AuthMiddleware.authAssertAdmin()(ctx, next)).to.be.rejectedWith(Error, ErrorKeyEnum.accessDenied)
+      expect(next.called).to.be.false
+    })
+
+    it('should deny access for non-admin token type', async () => {
+      findByValueStub.resolves({ type: 'user' as IJwtTokenType, updateOnly: sinon.stub().resolves() })
+      await expect(AuthMiddleware.authAssertAdmin()(ctx, next)).to.be.rejectedWith(Error, ErrorKeyEnum.accessDenied)
+      expect(next.called).to.be.false
+    })
   })
 })


### PR DESCRIPTION
## 📝 Summary

The sandbox Prometheus scraper hits the admin-api `/metrics` endpoint without a JWT. An inverted boolean in `authAssertAdmin` let `null` tokens bypass the access check, then crashed on `token.updateOnly()` — producing ~240 errors/hour in sandbox logs. After the fix, unauthenticated requests are rejected cleanly with a 401 instead of throwing.

The underlying scraper-config decision (give it credentials vs. drop auth on `/metrics`) is tracked separately in BE-214.

**Task:** [BE-214](https://linear.app/aragon/issue/BE-214/sandbox-metrics-setup-is-generating-noise-in-logs)

## 🔄 What Changed

- `src/middlewares/auth.ts`: fixed inverted assertion in `authAssertAdmin` (`||` → `&&`, `!==` → `===`) so missing/non-admin tokens are denied instead of falling through to a null dereference.
- `test/unit/middlewares/auth.spec.ts`: added two cases — token not found in DB, and non-admin token type — to lock in the fix.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)