### PR TITLE
feat(infra): add cluster mode for indexer and transfers services (BE-215)

### DIFF
--- a/runners/aragon-indexer.ts
+++ b/runners/aragon-indexer.ts
@@ -1,4 +1,4 @@
-import Runner from '@modules/runner'
+import { ClusterRunner } from '@modules/clusterRunner'
 import AragonIndexerService from '@services/aragon-indexer'
 
-Runner(AragonIndexerService)
+ClusterRunner(AragonIndexerService)

--- a/runners/aragon-transfers.ts
+++ b/runners/aragon-transfers.ts
@@ -1,4 +1,4 @@
-import Runner from '@modules/runner'
+import { ClusterRunner } from '@modules/clusterRunner'
 import AragonTransfersService from '@services/aragon-transfers'
 
-Runner(AragonTransfersService)
+ClusterRunner(AragonTransfersService)

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -25,9 +25,15 @@ export const NetworkHelper = {
 
   getWorkerNetworks(): ISupportedNetwork[] {
     const all = NetworkHelper.supportedNetworks()
+    const workerId = process.env.WORKER_ID
     const workerFilter = process.env.WORKER_NETWORKS
-    if (!workerFilter) return all
-    const allowed = new Set(workerFilter.split(','))
+    if (!workerId || !workerFilter) return all
+    const allowed = new Set(
+      workerFilter
+        .split(',')
+        .map(n => n.trim())
+        .filter(Boolean),
+    )
     return all.filter(n => allowed.has(n.networkName))
   },
   getAverageBlockTime(network: NetworksEnum): number {

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -22,6 +22,14 @@ export const NetworkHelper = {
 
     return result as ISupportedNetwork[]
   },
+
+  getWorkerNetworks(): ISupportedNetwork[] {
+    const all = NetworkHelper.supportedNetworks()
+    const workerFilter = process.env.WORKER_NETWORKS
+    if (!workerFilter) return all
+    const allowed = new Set(workerFilter.split(','))
+    return all.filter(n => allowed.has(n.networkName))
+  },
   getAverageBlockTime(network: NetworksEnum): number {
     const networkConfig = config.NODES[utils.networkToAragon(network)]
     return networkConfig.INTERVAL_BLOCK_TIME

--- a/src/modules/clusterRunner.ts
+++ b/src/modules/clusterRunner.ts
@@ -11,6 +11,7 @@ const MAX_RESTARTS = 5
 const RESTART_WINDOW_MS = 5 * 60 * 1000
 
 interface WorkerState {
+  index: number
   networks: string[]
   restarts: number[]
 }
@@ -26,6 +27,7 @@ function partitionNetworks(networks: string[], workerCount: number): string[][] 
 function runPrimary(networks: string[], workerCount: number) {
   const partitions = partitionNetworks(networks, workerCount)
   const workers = new Map<number, WorkerState>()
+  let shuttingDown = false
 
   logger.info(
     'Cluster primary started',
@@ -38,43 +40,44 @@ function runPrimary(networks: string[], workerCount: number) {
   )
 
   for (let i = 0; i < workerCount; i++) {
-    forkWorker(i, partitions[i], workers)
+    forkWorker(i, partitions[i], [], workers)
   }
 
   cluster.on('exit', (worker, code, signal) => {
     const state = workers.get(worker.id)
     if (!state) return
 
-    if (signal === 'SIGTERM' || signal === 'SIGINT') {
-      logger.info('Worker stopped gracefully', llo({ workerId: worker.id, pid: worker.process.pid, signal }))
+    if (shuttingDown) {
+      logger.info('Worker stopped during shutdown', llo({ workerIndex: state.index, pid: worker.process.pid }))
       workers.delete(worker.id)
       if (workers.size === 0) process.exit(0)
       return
     }
 
-    logger.warn('Worker exited unexpectedly', llo({ workerId: worker.id, pid: worker.process.pid, code, signal }))
+    logger.warn('Worker exited unexpectedly', llo({ workerIndex: state.index, pid: worker.process.pid, code, signal }))
 
     const now = Date.now()
-    state.restarts = state.restarts.filter(t => now - t < RESTART_WINDOW_MS)
+    const restarts = state.restarts.filter(t => now - t < RESTART_WINDOW_MS)
 
-    if (state.restarts.length >= MAX_RESTARTS) {
+    if (restarts.length >= MAX_RESTARTS) {
       logger.error(
         'Worker exceeded max restarts, not restarting',
-        llo({ workerId: worker.id, networks: state.networks, restarts: state.restarts.length }),
+        llo({ workerIndex: state.index, networks: state.networks, restarts: restarts.length }),
       )
       workers.delete(worker.id)
       if (workers.size === 0) process.exit(1)
       return
     }
 
-    state.restarts.push(now)
+    restarts.push(now)
     workers.delete(worker.id)
 
-    const workerIndex = worker.id - 1
-    forkWorker(workerIndex, state.networks, workers)
+    forkWorker(state.index, state.networks, restarts, workers)
   })
 
   const shutdown = () => {
+    if (shuttingDown) return
+    shuttingDown = true
     logger.info('Cluster primary shutting down', llo({ workerCount: workers.size }))
     for (const worker of Object.values(cluster.workers || {})) {
       worker?.process.kill('SIGTERM')
@@ -86,15 +89,15 @@ function runPrimary(networks: string[], workerCount: number) {
   process.on('SIGINT', shutdown)
 }
 
-function forkWorker(index: number, networks: string[], workers: Map<number, WorkerState>) {
+function forkWorker(index: number, networks: string[], restarts: number[], workers: Map<number, WorkerState>) {
   const worker = cluster.fork({
     WORKER_NETWORKS: networks.join(','),
     WORKER_ID: String(index),
   })
 
-  workers.set(worker.id, { networks, restarts: [] })
+  workers.set(worker.id, { index, networks, restarts })
 
-  logger.info('Worker forked', llo({ workerId: worker.id, pid: worker.process.pid, networks }))
+  logger.info('Worker forked', llo({ workerIndex: index, pid: worker.process.pid, networks }))
 }
 
 export function ClusterRunner(app: IService) {

--- a/src/modules/clusterRunner.ts
+++ b/src/modules/clusterRunner.ts
@@ -1,0 +1,132 @@
+import cluster from 'node:cluster'
+import os from 'node:os'
+import config from '@config'
+import logger from '@logger'
+import type { IService } from '@types'
+import Runner from './runner'
+
+const llo = logger.logMeta.bind(null, { service: 'clusterRunner' })
+
+const MAX_RESTARTS = 5
+const RESTART_WINDOW_MS = 5 * 60 * 1000
+
+interface WorkerState {
+  networks: string[]
+  restarts: number[]
+}
+
+function partitionNetworks(networks: string[], workerCount: number): string[][] {
+  const partitions: string[][] = Array.from({ length: workerCount }, () => [])
+  for (let i = 0; i < networks.length; i++) {
+    partitions[i % workerCount].push(networks[i])
+  }
+  return partitions
+}
+
+function runPrimary(networks: string[], workerCount: number) {
+  const partitions = partitionNetworks(networks, workerCount)
+  const workers = new Map<number, WorkerState>()
+
+  logger.info(
+    'Cluster primary started',
+    llo({
+      pid: process.pid,
+      workerCount,
+      networks: networks.length,
+      partitions: partitions.map((p, i) => `worker-${i}: [${p.join(', ')}]`),
+    }),
+  )
+
+  for (let i = 0; i < workerCount; i++) {
+    forkWorker(i, partitions[i], workers)
+  }
+
+  cluster.on('exit', (worker, code, signal) => {
+    const state = workers.get(worker.id)
+    if (!state) return
+
+    if (signal === 'SIGTERM' || signal === 'SIGINT') {
+      logger.info('Worker stopped gracefully', llo({ workerId: worker.id, pid: worker.process.pid, signal }))
+      workers.delete(worker.id)
+      if (workers.size === 0) process.exit(0)
+      return
+    }
+
+    logger.warn('Worker exited unexpectedly', llo({ workerId: worker.id, pid: worker.process.pid, code, signal }))
+
+    const now = Date.now()
+    state.restarts = state.restarts.filter(t => now - t < RESTART_WINDOW_MS)
+
+    if (state.restarts.length >= MAX_RESTARTS) {
+      logger.error(
+        'Worker exceeded max restarts, not restarting',
+        llo({ workerId: worker.id, networks: state.networks, restarts: state.restarts.length }),
+      )
+      workers.delete(worker.id)
+      if (workers.size === 0) process.exit(1)
+      return
+    }
+
+    state.restarts.push(now)
+    workers.delete(worker.id)
+
+    const workerIndex = worker.id - 1
+    forkWorker(workerIndex, state.networks, workers)
+  })
+
+  const shutdown = () => {
+    logger.info('Cluster primary shutting down', llo({ workerCount: workers.size }))
+    for (const worker of Object.values(cluster.workers || {})) {
+      worker?.process.kill('SIGTERM')
+    }
+    setTimeout(() => process.exit(0), 20_000)
+  }
+
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+}
+
+function forkWorker(index: number, networks: string[], workers: Map<number, WorkerState>) {
+  const worker = cluster.fork({
+    WORKER_NETWORKS: networks.join(','),
+    WORKER_ID: String(index),
+  })
+
+  workers.set(worker.id, { networks, restarts: [] })
+
+  logger.info('Worker forked', llo({ workerId: worker.id, pid: worker.process.pid, networks }))
+}
+
+export function ClusterRunner(app: IService) {
+  const networks = config.SUPPORTED_NETWORKS as string[]
+  const cpuCount = os.cpus().length
+  const configWorkers = Number.parseInt(process.env.CLUSTER_WORKERS || '0', 10)
+
+  // Determine worker count
+  let workerCount: number
+  if (configWorkers === 1) {
+    // Single-process mode, no clustering
+    Runner(app)
+    return
+  }
+  if (configWorkers > 1) {
+    workerCount = Math.min(configWorkers, networks.length)
+  } else {
+    // Auto: min of CPU cores and network count
+    workerCount = Math.min(cpuCount, networks.length)
+  }
+
+  // Need at least 2 workers for clustering to make sense
+  if (workerCount < 2 || networks.length < 2) {
+    Runner(app)
+    return
+  }
+
+  if (cluster.isPrimary) {
+    runPrimary(networks, workerCount)
+  } else {
+    Runner(app)
+  }
+}
+
+export default ClusterRunner

--- a/src/modules/clusterRunner.ts
+++ b/src/modules/clusterRunner.ts
@@ -100,8 +100,15 @@ function forkWorker(index: number, networks: string[], restarts: number[], worke
   logger.info('Worker forked', llo({ workerIndex: index, pid: worker.process.pid, networks }))
 }
 
+function getNetworkList(): string[] {
+  const supported = config.SUPPORTED_NETWORKS as string[]
+  if (supported.length > 0) return supported
+  // Derive from NODES config keys (e.g. ETHEREUM_MAINNET -> ethereum-mainnet)
+  return Object.keys(config.NODES || {}).map(k => k.toLowerCase().replace(/_/g, '-'))
+}
+
 export function ClusterRunner(app: IService) {
-  const networks = config.SUPPORTED_NETWORKS as string[]
+  const networks = getNetworkList()
   const cpuCount = os.cpus().length
   const configWorkers = Number.parseInt(process.env.CLUSTER_WORKERS || '0', 10)
 

--- a/src/services/aragon-indexer/index.ts
+++ b/src/services/aragon-indexer/index.ts
@@ -23,7 +23,7 @@ const AragonIndexerService: IService & { repeaters: any } = {
   start: async function () {
     logger.info('IndexerService historical started', llo({}))
 
-    const networks = NetworkHelper.supportedNetworks()
+    const networks = NetworkHelper.getWorkerNetworks()
 
     await Promise.all(
       networks.map(async ({ networkName }) => {

--- a/src/services/aragon-transfers/transferIndexer.ts
+++ b/src/services/aragon-transfers/transferIndexer.ts
@@ -12,7 +12,7 @@ export const TransferIndexer = {
   start: async () => {
     logger.info('TransferIndexer started', llo({}))
 
-    const networks = NetworkHelper.supportedNetworks()
+    const networks = NetworkHelper.getWorkerNetworks()
 
     await Promise.all(
       networks.map(async ({ networkName }) => {


### PR DESCRIPTION
## Summary
- Add Node.js `cluster` module to distribute network processing across multiple CPU cores
- Each worker process handles a subset of networks on its own event loop
- Networks are partitioned via round-robin across workers
- Workers auto-restart on crash (max 5 restarts per 5-min window)
- Distributed MongoDB locks in `TaskScheduler` already prevent duplicate work across processes

### Configuration
| Variable | Default | Description |
|---|---|---|
| `CLUSTER_WORKERS` | `0` | `0` = auto-detect CPU cores (capped to network count). `1` = single-process (backward compatible). |
| `WORKER_NETWORKS` | (internal) | Set by primary when forking. Not user-facing. |

### Files changed
- `src/modules/clusterRunner.ts` — new cluster orchestration module
- `src/helpers/network.ts` — added `getWorkerNetworks()` filter
- `runners/aragon-indexer.ts` — `Runner` → `ClusterRunner`
- `runners/aragon-transfers.ts` — `Runner` → `ClusterRunner`
- `src/services/aragon-indexer/index.ts` — use `getWorkerNetworks()`
- `src/services/aragon-transfers/transferIndexer.ts` — use `getWorkerNetworks()`

## Test plan
- [ ] `CLUSTER_WORKERS=1` → verify single-process mode (backward compatible)
- [ ] `CLUSTER_WORKERS=2` → verify two workers split networks (check logs for different PIDs)
- [ ] Kill a worker process → verify primary restarts it
- [ ] SIGTERM → verify graceful shutdown of all workers
- [ ] Check MongoDB TaskService locks → no duplicate network processing
- [ ] Monitor Docker CPU usage → load distributed across cores