### PR TITLE
fix(infra): drop @platform mention from deploy slack notifications

### DIFF
--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -83,7 +83,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
           SLACK_BOT_TOKEN: "op://kv_backend2_infra/SLACK_BOT_TOKEN/credential"
           SLACK_CHANNEL_ID: "op://kv_backend2_infra/SLACK_CHANNEL_ID/credential"
-          SLACK_PLATFORM_GROUP_ID: "op://kv_backend2_infra/SLACK_PLATFORM_GROUP_ID/credential"
 
       # Step 2: Configure deployment environment
       - name: Configure deployment environment
@@ -470,7 +469,6 @@ jobs:
             Branch: `${{ needs.validate.outputs.branch }}`
             ${{ job.status == 'success' && format('Deployed by: {0}', github.actor) || format('Attempted by: {0}', github.actor) }}
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>
-            ${{ job.status != 'success' && format('<!subteam^{0}>', steps.slack-secrets.outputs.SLACK_PLATFORM_GROUP_ID) || '' }}
 
       # Step 14: Fallback webhook notification (remove after Bot Token is verified)
       - name: Fallback - Webhook notification


### PR DESCRIPTION
## Summary
- Removes the `<!subteam^SLACK_PLATFORM_GROUP_ID>` ping appended to failed/cancelled backend deploy notifications in Slack — every push was tagging `@platform` unnecessarily.
- Drops the now-unused `SLACK_PLATFORM_GROUP_ID` 1Password secret load.

## Test plan
- [ ] Trigger a deploy that fails (or cancel one) and confirm the Slack message no longer contains the `@platform` group mention
- [ ] Confirm successful deploy notifications still post correctly