### PR TITLE
fix(api): block prototype-pollution via pagination date props (BE-219)

### DIFF
--- a/src/helpers/validationSchema.ts
+++ b/src/helpers/validationSchema.ts
@@ -119,8 +119,14 @@ const ValidationSchema = {
     page: Joi.number().integer().greater(-1).min(1).optional().default(1),
     order: Joi.string().valid('asc', 'desc').optional().default('asc'),
     sort: Joi.string().optional().default('createdAt'),
-    startDateProp: Joi.string().optional(),
-    endDateProp: Joi.string().optional(),
+    startDateProp: Joi.string()
+      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
+      .invalid('__proto__', 'prototype', 'constructor')
+      .optional(),
+    endDateProp: Joi.string()
+      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
+      .invalid('__proto__', 'prototype', 'constructor')
+      .optional(),
     startDate: Joi.alternatives()
       .try(Joi.number(), Joi.date())
       .optional()

--- a/src/models/utils/models.ts
+++ b/src/models/utils/models.ts
@@ -5,7 +5,10 @@ import { type IPaginatedResult, type IPaginationParams } from '@types'
 import { getAddress } from 'ethers'
 
 const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
-const isUnsafeKey = (key: unknown): boolean => typeof key === 'string' && UNSAFE_OBJECT_KEYS.has(key)
+const isUnsafeKey = (key: unknown): boolean => {
+  if (typeof key !== 'string') return true
+  return UNSAFE_OBJECT_KEYS.has(key)
+}
 
 export function utcDateProp(options = {}) {
   return prop({
@@ -43,8 +46,6 @@ const ModelUtils = {
     { search, startDateProp = 'startDate', endDateProp = 'endDate', startDate, endDate }: IPaginationParams = {},
     searchBy: string[] = [],
   ) {
-    // Reject prototype-pollution attempts. createFilter writes user-supplied keys directly onto an object,
-    // so '__proto__'/'constructor'/'prototype' would mutate Object.prototype globally and crash the process.
     if (isUnsafeKey(startDateProp) || isUnsafeKey(endDateProp)) {
       throw new Error('Invalid date property name')
     }

--- a/src/models/utils/models.ts
+++ b/src/models/utils/models.ts
@@ -4,6 +4,9 @@ import { prop } from '@typegoose/typegoose'
 import { type IPaginatedResult, type IPaginationParams } from '@types'
 import { getAddress } from 'ethers'
 
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+const isUnsafeKey = (key: unknown): boolean => typeof key === 'string' && UNSAFE_OBJECT_KEYS.has(key)
+
 export function utcDateProp(options = {}) {
   return prop({
     ...options,
@@ -40,6 +43,12 @@ const ModelUtils = {
     { search, startDateProp = 'startDate', endDateProp = 'endDate', startDate, endDate }: IPaginationParams = {},
     searchBy: string[] = [],
   ) {
+    // Reject prototype-pollution attempts. createFilter writes user-supplied keys directly onto an object,
+    // so '__proto__'/'constructor'/'prototype' would mutate Object.prototype globally and crash the process.
+    if (isUnsafeKey(startDateProp) || isUnsafeKey(endDateProp)) {
+      throw new Error('Invalid date property name')
+    }
+
     const filter: any = {}
 
     // Search functionality using regex

--- a/test/unit/models/utils/models.spec.ts
+++ b/test/unit/models/utils/models.spec.ts
@@ -87,6 +87,18 @@ describe('Model/Utils: models', () => {
       expect((Object.prototype as any).$gte).to.equal(undefined)
       expect((Object.prototype as any).$lte).to.equal(undefined)
     })
+
+    it('should reject non-string date prop values that would be coerced to unsafe keys', () => {
+      const nonStringInputs: any[] = [['__proto__'], { toString: () => '__proto__' }, 0, true]
+      for (const value of nonStringInputs) {
+        expect(() => ModelUtils.createFilter({ startDateProp: value, startDate: 1 })).to.throw(
+          'Invalid date property name',
+        )
+        expect(() => ModelUtils.createFilter({ endDateProp: value, endDate: 1 })).to.throw('Invalid date property name')
+      }
+      expect((Object.prototype as any).$gte).to.equal(undefined)
+      expect((Object.prototype as any).$lte).to.equal(undefined)
+    })
   })
 
   describe('parsePaginationParams', () => {

--- a/test/unit/models/utils/models.spec.ts
+++ b/test/unit/models/utils/models.spec.ts
@@ -74,6 +74,19 @@ describe('Model/Utils: models', () => {
         $lte: 2019577224,
       })
     })
+
+    it('should reject prototype-pollution attempts via startDateProp/endDateProp', () => {
+      for (const unsafe of ['__proto__', 'prototype', 'constructor']) {
+        expect(() => ModelUtils.createFilter({ startDateProp: unsafe, startDate: 1 })).to.throw(
+          'Invalid date property name',
+        )
+        expect(() => ModelUtils.createFilter({ endDateProp: unsafe, endDate: 1 })).to.throw(
+          'Invalid date property name',
+        )
+      }
+      expect((Object.prototype as any).$gte).to.equal(undefined)
+      expect((Object.prototype as any).$lte).to.equal(undefined)
+    })
   })
 
   describe('parsePaginationParams', () => {


### PR DESCRIPTION
## Summary

Resolves [BE-219](https://linear.app/aragon/issue/BE-219/production-api-outage-caused-by-malicious-request).

A malicious request hit production API today (~13:00 UTC) sending `?startDateProp=__proto__&startDate=1`. `createFilter` writes user-supplied keys directly onto a filter object, so this mutated `Object.prototype` globally for the running process.

Two visible symptoms, one root cause:
- **API 500s** — joi's `_assign` does `for (key in this.$_terms)` which then visited the polluted `$gte` and tried to call `.slice()` on a number.
- **Crash loop** — prom-client's `validateLabel` does `for (label in labels)` which saw `$gte` not in the GC histogram's labelset and threw, hitting the runner's `uncaughtException` handler and exiting the process.

Reproduced locally: setting `Object.prototype.$gte = 1` then importing joi throws the exact production stack.

## Changes

- `src/models/utils/models.ts` — `createFilter` rejects `__proto__`/`prototype`/`constructor` as `startDateProp`/`endDateProp`.
- `src/helpers/validationSchema.ts` — pagination joi schema tightens both fields to an alphanumeric pattern and `.invalid('__proto__','prototype','constructor')`.
- `test/unit/models/utils/models.spec.ts` — new test asserts the three unsafe keys throw and `Object.prototype` is not mutated.

No version bumps. `prometheusStore` is **not** the cause and is not touched (verified that the prefix-mode would crash under pollution too).

## Test plan

- [x] `yarn test:unit` — all passing locally (11/11 in the affected describe).
- [x] `yarn format:fix` — clean.
- [ ] After merge & deploy, confirm in logz: `ARAGON-API-PRODUCTION` no longer logs `Added label "$gte"` or `this.$_terms[key].slice is not a function`.
- [ ] Smoke a `?startDateProp=__proto__` request against staging — should return 400, process stays up.

## Follow-ups (separate work)

- Edge/WAF rule to drop `__proto__`/`constructor` query strings before they reach the app.
- Audit other `ctx.query` → object-key sinks for the same class of bug.