### PR TITLE
feat(infra): restore CHANGELOG.md + PR-based main→dev sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,15 +104,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.op-secrets.outputs.GITHUB_RELEASE_TOKEN }}
         run: |
-          EXISTING_PR=$(gh pr list --base development --head main --state open --json number -q '.[0].number')
+          # Check if main has commits ahead of development
+          DIFF=$(gh api repos/${{ github.repository }}/compare/development...main --jq '.ahead_by')
+          if [ "$DIFF" = "0" ]; then
+            echo "main and development are in sync, skipping PR"
+            exit 0
+          fi
+
+          EXISTING_PR=$(gh pr list --base development --head main --state open --json number -q '.[0].number // empty')
 
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "chore: sync main (v${{ env.VERSION }}) back to development" \
-              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md and version bump."
+              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md update."
           else
             gh pr create --base development --head main \
               --title "chore: sync main (v${{ env.VERSION }}) back to development" \
-              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md and version bump."
+              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md update."
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,11 +104,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.op-secrets.outputs.GITHUB_RELEASE_TOKEN }}
         run: |
-          # Try auto-merge, fall back to PR if conflicts
-          git fetch origin development
-          git checkout development
-          git merge origin/main --no-edit && git push origin development || \
+          EXISTING_PR=$(gh pr list --base development --head main --state open --json number -q '.[0].number')
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --title "chore: sync main (v${{ env.VERSION }}) back to development" \
+              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md and version bump."
+          else
             gh pr create --base development --head main \
               --title "chore: sync main (v${{ env.VERSION }}) back to development" \
-              --body "Auto-generated after release v${{ env.VERSION }}. Merge to keep branches in sync."
+              --body "Auto-generated after release v${{ env.VERSION }}. Includes CHANGELOG.md and version bump."
+          fi
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,12 +4,11 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
-    ["@semantic-release/npm", { "npmPublish": false }],
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version}"
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,15 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/npm", { "npmPublish": false }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version}"
+      }
+    ],
     [
       "@semantic-release/github",
       {


### PR DESCRIPTION
## Summary
- Restore `@semantic-release/changelog` and `@semantic-release/git` plugins so CHANGELOG.md is generated on release
- After release, automatically opens a PR from `main` → `development` to sync the changelog commit
- If a sync PR already exists, updates it instead of creating a duplicate

### Release flow
```
staging → main (merge PR)
  → semantic-release: creates tag, GitHub Release, commits CHANGELOG.md to main
  → Slack notification
  → Opens PR: main → development (CHANGELOG.md + version bump)
```

## Test plan
- [ ] Merge staging → main → verify CHANGELOG.md committed
- [ ] Verify PR opened from main → development
- [ ] Run release again → verify existing PR is updated, not duplicated