### PR TITLE
feat(api): live totalSupply for escrowAdapter tokens (BE-221)

### DIFF
--- a/src/helpers/governanceVe.ts
+++ b/src/helpers/governanceVe.ts
@@ -254,6 +254,27 @@ const GovernanceVeHelper = {
       return nameAndSymbol
     }
   },
+
+  async getVePastTotalSupply(adapterAddress: HexAddress, network: NetworksEnum): Promise<string> {
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    const abi = [
+      'function getPastTotalSupply(uint256) view returns (uint256)',
+      'function clock() view returns (uint256)',
+    ]
+    const contract = new Contract(adapterAddress, abi, provider)
+    try {
+      const clock = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => (await contract.clock()) - 1n),
+      )
+      const supply = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getPastTotalSupply(clock)),
+      )
+
+      return supply.toString()
+    } catch (_error) {
+      return '0'
+    }
+  },
 }
 
 export default GovernanceVeHelper

--- a/src/helpers/governanceVe.ts
+++ b/src/helpers/governanceVe.ts
@@ -255,7 +255,7 @@ const GovernanceVeHelper = {
     }
   },
 
-  async getVePastTotalSupply(adapterAddress: HexAddress, network: NetworksEnum): Promise<string | null> {
+  async getVePastTotalSupply(adapterAddress: HexAddress, network: NetworksEnum): Promise<string> {
     const provider = ProviderModule.getAnyRpcProvider(network)
     const abi = [
       'function getPastTotalSupply(uint256) view returns (uint256)',

--- a/src/helpers/governanceVe.ts
+++ b/src/helpers/governanceVe.ts
@@ -273,7 +273,7 @@ const GovernanceVeHelper = {
 
       return supply.toString()
     } catch (_error) {
-      return null
+      return '0'
     }
   },
 }

--- a/src/helpers/governanceVe.ts
+++ b/src/helpers/governanceVe.ts
@@ -255,7 +255,7 @@ const GovernanceVeHelper = {
     }
   },
 
-  async getVePastTotalSupply(adapterAddress: HexAddress, network: NetworksEnum): Promise<string> {
+  async getVePastTotalSupply(adapterAddress: HexAddress, network: NetworksEnum): Promise<string | null> {
     const provider = ProviderModule.getAnyRpcProvider(network)
     const abi = [
       'function getPastTotalSupply(uint256) view returns (uint256)',
@@ -264,15 +264,16 @@ const GovernanceVeHelper = {
     const contract = new Contract(adapterAddress, abi, provider)
     try {
       const clock = await retryRequest(async () =>
-        BottleneckModule.getNodeLimiter(network).schedule(async () => (await contract.clock()) - 1n),
+        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.clock()),
       )
+      const timepoint = clock > 0n ? clock - 1n : 0n
       const supply = await retryRequest(async () =>
-        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getPastTotalSupply(clock)),
+        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getPastTotalSupply(timepoint)),
       )
 
       return supply.toString()
     } catch (_error) {
-      return '0'
+      return null
     }
   },
 }

--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -58,7 +58,11 @@ export const ProxyToken = {
       const isTestnet = CoinGeckoHelper.isTestNetwork(network)
 
       const totalSupply =
-        !isNativeToken && token.hasTotalSupply ? await Web3Helper.getTokenTotalSupply(tokenAddress, network) : null
+        token.type === ITokenType.escrowAdapter
+          ? await GovernanceVeHelper.getVePastTotalSupply(tokenAddress, network)
+          : !isNativeToken && token.hasTotalSupply
+            ? await Web3Helper.getTokenTotalSupply(tokenAddress, network)
+            : null
 
       const coingeckoInfo =
         !isTestnet || isNativeToken ? (await CoinGeckoHelper.getToken(tokenAddress, network)) || null : null
@@ -89,10 +93,16 @@ export const ProxyToken = {
       }
     }
     const isTestnet = CoinGeckoHelper.isTestNetwork(network)
+
     const coinGeckoTokenInfo =
       isTestnet && tokenTypeInfo.type !== ITokenType.native
         ? null
         : (await CoinGeckoHelper.getToken(wrappedToken!, network)) || null
+
+    let escrowTotalSupply: string | undefined
+    if (tokenTypeInfo.type === ITokenType.escrowAdapter) {
+      escrowTotalSupply = await GovernanceVeHelper.getVePastTotalSupply(tokenAddress, network)
+    }
 
     return {
       address: wrappedToken!,
@@ -101,7 +111,7 @@ export const ProxyToken = {
       name: coinGeckoTokenInfo?.name || '',
       symbol: coinGeckoTokenInfo?.symbol || '',
       decimals: coinGeckoTokenInfo?.decimals || 18,
-      totalSupply: coinGeckoTokenInfo?.totalSupply || '0',
+      totalSupply: escrowTotalSupply ?? coinGeckoTokenInfo?.totalSupply ?? '0',
       logo: coinGeckoTokenInfo?.logo || '',
       priceUsd: coinGeckoTokenInfo?.priceUsd || '0',
       underlying: tokenTypeInfo.type === ITokenType.escrowAdapter ? wrappedToken : undefined,

--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -99,7 +99,7 @@ export const ProxyToken = {
         ? null
         : (await CoinGeckoHelper.getToken(wrappedToken!, network)) || null
 
-    let escrowTotalSupply: string | undefined
+    let escrowTotalSupply: string | null = null
     if (tokenTypeInfo.type === ITokenType.escrowAdapter) {
       escrowTotalSupply = await GovernanceVeHelper.getVePastTotalSupply(tokenAddress, network)
     }

--- a/src/services/aragon-rates/fetchRates.ts
+++ b/src/services/aragon-rates/fetchRates.ts
@@ -166,15 +166,17 @@ export const FetchRates = {
 
   async onTestnetDocument(token: Token) {
     try {
-      let onChainSupply: bigint | string | null
+      let onChainSupply: bigint
       if (token.type === ITokenType.escrowAdapter) {
         const veSupply = await GovernanceVeHelper.getVePastTotalSupply(token.address, token.network)
-        onChainSupply = veSupply !== null ? BigInt(veSupply) : null
+        onChainSupply = BigInt(veSupply)
       } else {
-        onChainSupply = await Web3Helper.getTokenTotalSupply(token.address, token.network)
+        const erc20Supply = await Web3Helper.getTokenTotalSupply(token.address, token.network)
+        if (!erc20Supply) return
+        onChainSupply = erc20Supply
       }
 
-      if (!onChainSupply || token.totalSupply === onChainSupply.toString()) return
+      if (token.totalSupply === onChainSupply.toString()) return
 
       const rawTokenUpdate = {
         totalSupply: onChainSupply.toString(),

--- a/src/services/aragon-rates/fetchRates.ts
+++ b/src/services/aragon-rates/fetchRates.ts
@@ -166,10 +166,13 @@ export const FetchRates = {
 
   async onTestnetDocument(token: Token) {
     try {
-      const onChainSupply =
-        token.type === ITokenType.escrowAdapter
-          ? BigInt(await GovernanceVeHelper.getVePastTotalSupply(token.address, token.network))
-          : await Web3Helper.getTokenTotalSupply(token.address, token.network)
+      let onChainSupply: bigint | string | null
+      if (token.type === ITokenType.escrowAdapter) {
+        const veSupply = await GovernanceVeHelper.getVePastTotalSupply(token.address, token.network)
+        onChainSupply = veSupply !== null ? BigInt(veSupply) : null
+      } else {
+        onChainSupply = await Web3Helper.getTokenTotalSupply(token.address, token.network)
+      }
 
       if (!onChainSupply || token.totalSupply === onChainSupply.toString()) return
 

--- a/src/services/aragon-rates/fetchRates.ts
+++ b/src/services/aragon-rates/fetchRates.ts
@@ -2,6 +2,7 @@ import config from '@config'
 import { Models } from '@dbModels'
 import CoinGeckoHelper from '@helpers/coinGecko'
 import dayjs from '@helpers/dayjs'
+import GovernanceVeHelper from '@helpers/governanceVe'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import TokenUtils from '@helpers/tokenUtils'
 import Web3Helper from '@helpers/web3'
@@ -60,7 +61,9 @@ export const FetchRates = {
       },
       where: {
         $and: [
-          { type: ITokenType.ERC20, isGovernance: true },
+          {
+            $or: [{ type: ITokenType.ERC20, isGovernance: true }, { type: ITokenType.escrowAdapter }],
+          },
           { network: { $in: [NetworksEnum.zksyncSepolia, NetworksEnum.ethereumSepolia] } },
           {
             $or: [
@@ -163,7 +166,10 @@ export const FetchRates = {
 
   async onTestnetDocument(token: Token) {
     try {
-      const onChainSupply = await Web3Helper.getTokenTotalSupply(token.address, token.network)
+      const onChainSupply =
+        token.type === ITokenType.escrowAdapter
+          ? BigInt(await GovernanceVeHelper.getVePastTotalSupply(token.address, token.network))
+          : await Web3Helper.getTokenTotalSupply(token.address, token.network)
 
       if (!onChainSupply || token.totalSupply === onChainSupply.toString()) return
 
@@ -194,9 +200,11 @@ export const FetchRates = {
     try {
       const isNativeToken = token.type === ITokenType.native
       const totalSupply =
-        !isNativeToken && token.hasTotalSupply
-          ? await Web3Helper.getTokenTotalSupply(token.address, token.network)
-          : null
+        token.type === ITokenType.escrowAdapter
+          ? await GovernanceVeHelper.getVePastTotalSupply(token.address, token.network)
+          : !isNativeToken && token.hasTotalSupply
+            ? await Web3Helper.getTokenTotalSupply(token.address, token.network)
+            : null
 
       const coingeckoInfo = await CoinGeckoHelper.getToken(token.address, token.network)
 

--- a/test/unit/helpers/governanceVe.spec.ts
+++ b/test/unit/helpers/governanceVe.spec.ts
@@ -854,7 +854,7 @@ describe('Helpers: GovernanceVe', () => {
       expect(getPastTotalSupplyStub.calledOnceWith(0n)).to.be.true
     })
 
-    it('should return null when the RPC call fails', async () => {
+    it("should return '0' when the RPC call fails", async () => {
       const clockStub = sandbox.stub().rejects(new Error('RPC Call Failed'))
       const getPastTotalSupplyStub = sandbox.stub()
 
@@ -868,7 +868,7 @@ describe('Helpers: GovernanceVe', () => {
 
       const result = await MockedGovernanceVeHelper.getVePastTotalSupply('0xAdapter', NetworksEnum.ethereumMainnet)
 
-      expect(result).to.be.null
+      expect(result).to.eq('0')
       expect(getPastTotalSupplyStub.called).to.be.false
     })
   })

--- a/test/unit/helpers/governanceVe.spec.ts
+++ b/test/unit/helpers/governanceVe.spec.ts
@@ -836,7 +836,25 @@ describe('Helpers: GovernanceVe', () => {
       expect(getPastTotalSupplyStub.calledOnceWith(999n)).to.be.true
     })
 
-    it('should return "0" when the RPC call fails', async () => {
+    it('should clamp the timepoint to 0n when clock() returns 0n', async () => {
+      const clockStub = sandbox.stub().resolves(0n)
+      const getPastTotalSupplyStub = sandbox.stub().resolves(42n)
+
+      const { default: MockedGovernanceVeHelper } = proxyquire.noCallThru()('@helpers/governanceVe', {
+        ethers: {
+          Contract: function () {
+            return { clock: clockStub, getPastTotalSupply: getPastTotalSupplyStub }
+          },
+        },
+      })
+
+      const result = await MockedGovernanceVeHelper.getVePastTotalSupply('0xAdapter', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.eq('42')
+      expect(getPastTotalSupplyStub.calledOnceWith(0n)).to.be.true
+    })
+
+    it('should return null when the RPC call fails', async () => {
       const clockStub = sandbox.stub().rejects(new Error('RPC Call Failed'))
       const getPastTotalSupplyStub = sandbox.stub()
 
@@ -850,7 +868,7 @@ describe('Helpers: GovernanceVe', () => {
 
       const result = await MockedGovernanceVeHelper.getVePastTotalSupply('0xAdapter', NetworksEnum.ethereumMainnet)
 
-      expect(result).to.eq('0')
+      expect(result).to.be.null
       expect(getPastTotalSupplyStub.called).to.be.false
     })
   })

--- a/test/unit/helpers/governanceVe.spec.ts
+++ b/test/unit/helpers/governanceVe.spec.ts
@@ -815,4 +815,43 @@ describe('Helpers: GovernanceVe', () => {
       expect(ownerOfStub.calledOnce).to.be.true
     })
   })
+
+  describe('getVePastTotalSupply', () => {
+    it('should call getPastTotalSupply with clock() - 1n and return its value as a string', async () => {
+      const clockStub = sandbox.stub().resolves(1000n)
+      const getPastTotalSupplyStub = sandbox.stub().resolves(123456789n)
+
+      const { default: MockedGovernanceVeHelper } = proxyquire.noCallThru()('@helpers/governanceVe', {
+        ethers: {
+          Contract: function () {
+            return { clock: clockStub, getPastTotalSupply: getPastTotalSupplyStub }
+          },
+        },
+      })
+
+      const result = await MockedGovernanceVeHelper.getVePastTotalSupply('0xAdapter', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.eq('123456789')
+      expect(clockStub.calledOnce).to.be.true
+      expect(getPastTotalSupplyStub.calledOnceWith(999n)).to.be.true
+    })
+
+    it('should return "0" when the RPC call fails', async () => {
+      const clockStub = sandbox.stub().rejects(new Error('RPC Call Failed'))
+      const getPastTotalSupplyStub = sandbox.stub()
+
+      const { default: MockedGovernanceVeHelper } = proxyquire.noCallThru()('@helpers/governanceVe', {
+        ethers: {
+          Contract: function () {
+            return { clock: clockStub, getPastTotalSupply: getPastTotalSupplyStub }
+          },
+        },
+      })
+
+      const result = await MockedGovernanceVeHelper.getVePastTotalSupply('0xAdapter', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.eq('0')
+      expect(getPastTotalSupplyStub.called).to.be.false
+    })
+  })
 })

--- a/test/unit/modules/proxyToken.spec.ts
+++ b/test/unit/modules/proxyToken.spec.ts
@@ -282,7 +282,7 @@ describe('Modules: ProxyToken', () => {
       expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '1780000' })
     })
 
-    it('should keep the existing totalSupply when getVePastTotalSupply returns null', async () => {
+    it("should persist '0' when getVePastTotalSupply returns '0' on RPC error", async () => {
       const tokenAddress = '0xAdapter'
       const network = NetworksEnum.ethereumMainnet
 
@@ -300,14 +300,14 @@ describe('Modules: ProxyToken', () => {
         type: ITokenType.escrowAdapter,
       } as any
 
-      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('0')
       sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
       sandbox.stub(CoinGeckoHelper, 'getToken').resolves({ priceUsd: '1.0', logo: 'l' } as any)
       sandbox.stub(logger, 'verbose')
 
       await ProxyToken.updateTokenMetrics(token, tokenAddress, network, false)
 
-      expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '10000000' })
+      expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '0' })
     })
 
     it('should handle when session is undefined', async () => {
@@ -430,7 +430,7 @@ describe('Modules: ProxyToken', () => {
       })
     })
 
-    it('should fall back to CoinGecko totalSupply when getVePastTotalSupply returns null', async () => {
+    it("should use '0' from getVePastTotalSupply over CoinGecko totalSupply on RPC error", async () => {
       const tokenAddress = '0x123456789abcdef'
       const underlyingTokenAddress = '0xunderlyingtoken'
       const network = NetworksEnum.ethereumMainnet
@@ -458,11 +458,11 @@ describe('Modules: ProxyToken', () => {
         logo: 'under-logo',
         priceUsd: '2.0',
       } as any)
-      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('0')
 
       const result = await ProxyToken.wrapTokenDetails(tokenTypeInfo as any, tokenAddress, network)
 
-      expect(result).to.deep.include({ totalSupply: '5000000' })
+      expect(result).to.deep.include({ totalSupply: '0' })
     })
 
     it('should handle escrowAdapter tokens when plugin is not found', async () => {

--- a/test/unit/modules/proxyToken.spec.ts
+++ b/test/unit/modules/proxyToken.spec.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import CoinGeckoHelper from '@helpers/coinGecko'
 import dayjs from '@helpers/dayjs'
+import GovernanceVeHelper from '@helpers/governanceVe'
 import TokenDetector from '@helpers/tokenDetector'
 import TokenUtils from '@helpers/tokenUtils'
 import Web3Helper from '@helpers/web3'
@@ -250,6 +251,37 @@ describe('Modules: ProxyToken', () => {
       expect(result).to.equal(token)
     })
 
+    it('should use getVePastTotalSupply for escrowAdapter tokens', async () => {
+      const tokenAddress = '0xAdapter'
+      const network = NetworksEnum.ethereumMainnet
+
+      const token = {
+        id: 'token-veadap',
+        address: tokenAddress,
+        network,
+        skipFetchRate: false,
+        lastUpdatedAt: dayjs().subtract(10, 'hour').toDate(),
+        priceUsd: '0',
+        logo: '',
+        totalSupply: '10000000',
+        update: sandbox.stub(),
+        hasTotalSupply: true,
+        type: ITokenType.escrowAdapter,
+      } as any
+
+      const veSupplyStub = sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('1780000')
+      const erc20SupplyStub = sandbox.stub(Web3Helper, 'getTokenTotalSupply')
+      sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
+      sandbox.stub(CoinGeckoHelper, 'getToken').resolves({ priceUsd: '1.0', logo: 'l' } as any)
+      sandbox.stub(logger, 'verbose')
+
+      await ProxyToken.updateTokenMetrics(token, tokenAddress, network, false)
+
+      expect(veSupplyStub.calledOnceWith(tokenAddress, network)).to.be.true
+      expect(erc20SupplyStub.called).to.be.false
+      expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '1780000' })
+    })
+
     it('should handle when session is undefined', async () => {
       const tokenAddress = '0x123456789abcdef'
       const network = NetworksEnum.ethereumMainnet
@@ -353,9 +385,11 @@ describe('Modules: ProxyToken', () => {
         logo: 'under-logo',
         priceUsd: '2.0',
       } as any)
+      const veSupplyStub = sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('1780000')
 
       const result = await ProxyToken.wrapTokenDetails(tokenTypeInfo as any, tokenAddress, network)
 
+      expect(veSupplyStub.calledOnceWith(tokenAddress, network)).to.be.true
       expect(result).to.deep.include({
         address: underlyingTokenAddress,
         network,
@@ -363,7 +397,7 @@ describe('Modules: ProxyToken', () => {
         name: 'Underlying Token',
         symbol: 'UNDER',
         decimals: 18,
-        totalSupply: '5000000',
+        totalSupply: '1780000',
         underlying: underlyingTokenAddress,
       })
     })
@@ -393,6 +427,7 @@ describe('Modules: ProxyToken', () => {
       })
       sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
       sandbox.stub(CoinGeckoHelper, 'getToken').resolves({ logo: 'test-logo', priceUsd: '1.5' } as any)
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('0')
 
       const result = await ProxyToken.wrapTokenDetails(tokenTypeInfo as any, tokenAddress, network)
 

--- a/test/unit/modules/proxyToken.spec.ts
+++ b/test/unit/modules/proxyToken.spec.ts
@@ -282,6 +282,34 @@ describe('Modules: ProxyToken', () => {
       expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '1780000' })
     })
 
+    it('should keep the existing totalSupply when getVePastTotalSupply returns null', async () => {
+      const tokenAddress = '0xAdapter'
+      const network = NetworksEnum.ethereumMainnet
+
+      const token = {
+        id: 'token-veadap-fail',
+        address: tokenAddress,
+        network,
+        skipFetchRate: false,
+        lastUpdatedAt: dayjs().subtract(10, 'hour').toDate(),
+        priceUsd: '0',
+        logo: '',
+        totalSupply: '10000000',
+        update: sandbox.stub(),
+        hasTotalSupply: true,
+        type: ITokenType.escrowAdapter,
+      } as any
+
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
+      sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
+      sandbox.stub(CoinGeckoHelper, 'getToken').resolves({ priceUsd: '1.0', logo: 'l' } as any)
+      sandbox.stub(logger, 'verbose')
+
+      await ProxyToken.updateTokenMetrics(token, tokenAddress, network, false)
+
+      expect(token.update.firstCall.args[0]).to.deep.include({ totalSupply: '10000000' })
+    })
+
     it('should handle when session is undefined', async () => {
       const tokenAddress = '0x123456789abcdef'
       const network = NetworksEnum.ethereumMainnet
@@ -400,6 +428,41 @@ describe('Modules: ProxyToken', () => {
         totalSupply: '1780000',
         underlying: underlyingTokenAddress,
       })
+    })
+
+    it('should fall back to CoinGecko totalSupply when getVePastTotalSupply returns null', async () => {
+      const tokenAddress = '0x123456789abcdef'
+      const underlyingTokenAddress = '0xunderlyingtoken'
+      const network = NetworksEnum.ethereumMainnet
+      const tokenTypeInfo = {
+        type: ITokenType.escrowAdapter,
+        isGovernance: false,
+        hasBalanceOfERC20: true,
+        hasName: true,
+        hasSymbol: true,
+        hasDecimals: true,
+        hasTotalSupply: true,
+        proxy: false,
+        implementationAddress: null,
+      }
+
+      sandbox.stub(Models.Plugin, 'findByTokenAddress').resolves({
+        votingEscrow: { underlying: underlyingTokenAddress },
+      } as any)
+      sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
+      sandbox.stub(CoinGeckoHelper, 'getToken').resolves({
+        name: 'Underlying Token',
+        symbol: 'UNDER',
+        decimals: 18,
+        totalSupply: '5000000',
+        logo: 'under-logo',
+        priceUsd: '2.0',
+      } as any)
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
+
+      const result = await ProxyToken.wrapTokenDetails(tokenTypeInfo as any, tokenAddress, network)
+
+      expect(result).to.deep.include({ totalSupply: '5000000' })
     })
 
     it('should handle escrowAdapter tokens when plugin is not found', async () => {

--- a/test/unit/services/aragon-rates/fetchRates.spec.ts
+++ b/test/unit/services/aragon-rates/fetchRates.spec.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import CoinGeckoHelper from '@helpers/coinGecko'
 import dayjs from '@helpers/dayjs'
+import GovernanceVeHelper from '@helpers/governanceVe'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import TokenUtils from '@helpers/tokenUtils'
 import Web3Helper from '@helpers/web3'
@@ -223,6 +224,38 @@ describe('AragonRates: FetchRates', () => {
       expect(loggerErrorStub.calledOnce).to.be.true
       expect(loggerErrorStub.calledWith('Error FetchRates' as any)).to.be.true
     })
+
+    it('should use getVePastTotalSupply for escrowAdapter tokens', async () => {
+      const adapterToken = await Models.Token.create({
+        network: NetworksEnum.ethereumMainnet,
+        type: ITokenType.escrowAdapter,
+        address: '0xAdapterMainnet',
+        logo: 'fake-logo',
+        name: 'Adapter',
+        symbol: 'CTX',
+        decimals: 18,
+        holders: 1,
+        totalSupply: '10000000',
+        priceUsd: '1.1',
+        hasTotalSupply: true,
+      })
+
+      const veSupplyStub = sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('1780000')
+      const erc20SupplyStub = sandbox.stub(Web3Helper, 'getTokenTotalSupply')
+      sandbox.stub(CoinGeckoHelper, 'getToken').resolves({ priceUsd: '1.1', logo: 'fake-logo' } as any)
+      sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
+
+      const mockDate = new Date('2023-01-01T00:00:00Z')
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => mockDate } as any)
+      const updateStub = sandbox.stub(adapterToken, 'update').resolves(adapterToken as any)
+      sandbox.stub(logger, 'verbose')
+
+      await FetchRates.onMainnetDocument(adapterToken as any)
+
+      expect(veSupplyStub.calledOnceWith(adapterToken.address, adapterToken.network)).to.be.true
+      expect(erc20SupplyStub.called).to.be.false
+      expect(updateStub.firstCall.args[0]).to.deep.include({ totalSupply: '1780000' })
+    })
   })
 
   describe('onTestnetDocument', () => {
@@ -288,6 +321,35 @@ describe('AragonRates: FetchRates', () => {
 
       expect(loggerErrorStub.calledOnce).to.be.true
       expect(loggerErrorStub.calledWith('Error FetchRates on testnet' as any)).to.be.true
+    })
+
+    it('should use getVePastTotalSupply for escrowAdapter tokens on testnet', async () => {
+      const adapterToken = await Models.Token.create({
+        network: NetworksEnum.ethereumSepolia,
+        type: ITokenType.escrowAdapter,
+        address: '0xAdapterTestnet',
+        logo: 'fake-logo',
+        name: 'Adapter',
+        symbol: 'CTX',
+        decimals: 18,
+        holders: 1,
+        totalSupply: '10000000',
+        priceUsd: '1.1',
+      })
+
+      const veSupplyStub = sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('1780000')
+      const erc20SupplyStub = sandbox.stub(Web3Helper, 'getTokenTotalSupply')
+
+      const mockDate = new Date('2023-01-01T00:00:00Z')
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => mockDate } as any)
+      const updateStub = sandbox.stub(adapterToken, 'update').resolves(adapterToken as any)
+      sandbox.stub(logger, 'verbose')
+
+      await FetchRates.onTestnetDocument(adapterToken as any)
+
+      expect(veSupplyStub.calledOnceWith(adapterToken.address, adapterToken.network)).to.be.true
+      expect(erc20SupplyStub.called).to.be.false
+      expect(updateStub.calledWith({ totalSupply: '1780000', lastUpdatedAt: mockDate })).to.be.true
     })
   })
 

--- a/test/unit/services/aragon-rates/fetchRates.spec.ts
+++ b/test/unit/services/aragon-rates/fetchRates.spec.ts
@@ -351,6 +351,30 @@ describe('AragonRates: FetchRates', () => {
       expect(erc20SupplyStub.called).to.be.false
       expect(updateStub.calledWith({ totalSupply: '1780000', lastUpdatedAt: mockDate })).to.be.true
     })
+
+    it('should not update or throw when getVePastTotalSupply returns null on testnet', async () => {
+      const adapterToken = await Models.Token.create({
+        network: NetworksEnum.ethereumSepolia,
+        type: ITokenType.escrowAdapter,
+        address: '0xAdapterTestnetNull',
+        logo: 'fake-logo',
+        name: 'Adapter',
+        symbol: 'CTX',
+        decimals: 18,
+        holders: 1,
+        totalSupply: '10000000',
+        priceUsd: '1.1',
+      })
+
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
+      const updateStub = sandbox.stub(adapterToken, 'update')
+      const loggerErrorStub = sandbox.stub(logger, 'error')
+
+      await FetchRates.onTestnetDocument(adapterToken as any)
+
+      expect(updateStub.notCalled).to.be.true
+      expect(loggerErrorStub.notCalled).to.be.true
+    })
   })
 
   describe('updateDaoMetrics', () => {

--- a/test/unit/services/aragon-rates/fetchRates.spec.ts
+++ b/test/unit/services/aragon-rates/fetchRates.spec.ts
@@ -352,11 +352,11 @@ describe('AragonRates: FetchRates', () => {
       expect(updateStub.calledWith({ totalSupply: '1780000', lastUpdatedAt: mockDate })).to.be.true
     })
 
-    it('should not update or throw when getVePastTotalSupply returns null on testnet', async () => {
+    it("should persist '0' when getVePastTotalSupply returns '0' on testnet", async () => {
       const adapterToken = await Models.Token.create({
         network: NetworksEnum.ethereumSepolia,
         type: ITokenType.escrowAdapter,
-        address: '0xAdapterTestnetNull',
+        address: '0xAdapterTestnetZero',
         logo: 'fake-logo',
         name: 'Adapter',
         symbol: 'CTX',
@@ -366,14 +366,15 @@ describe('AragonRates: FetchRates', () => {
         priceUsd: '1.1',
       })
 
-      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves(null)
-      const updateStub = sandbox.stub(adapterToken, 'update')
-      const loggerErrorStub = sandbox.stub(logger, 'error')
+      sandbox.stub(GovernanceVeHelper, 'getVePastTotalSupply').resolves('0')
+      const mockDate = new Date('2023-01-01T00:00:00Z')
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => mockDate } as any)
+      const updateStub = sandbox.stub(adapterToken, 'update').resolves(adapterToken as any)
+      sandbox.stub(logger, 'verbose')
 
       await FetchRates.onTestnetDocument(adapterToken as any)
 
-      expect(updateStub.notCalled).to.be.true
-      expect(loggerErrorStub.notCalled).to.be.true
+      expect(updateStub.calledWith({ totalSupply: '0', lastUpdatedAt: mockDate })).to.be.true
     })
   })
 


### PR DESCRIPTION
## Summary

Closes [BE-221](https://linear.app/aragon/issue/BE-221).

For DAOs whose voting token is an `escrowAdapter` (e.g. Cryptex), `plugin.settings.token.totalSupply` on the DAO endpoint was inheriting from the underlying ERC20 (~10M CTX) instead of the adapter's actual voting-power supply (~1.78M). The proposal serializer was already correct via `historicalTotalSupply`; the persisted `Token.totalSupply` field was the stale one.

This PR routes every write of `Token.totalSupply` through an adapter-aware path: when `token.type === escrowAdapter`, it calls `getPastTotalSupply(clock() - 1)` on the adapter instead of `ERC20.totalSupply()`.

## Changes

- **`helpers/governanceVe.ts`** — new `getVePastTotalSupply(adapter, network)` helper. Reads `clock()`, calls `getPastTotalSupply(clock - 1n)`, returns string. Catches → `'0'`.
- **`modules/proxyToken.ts`**
  - `wrapTokenDetails` — for new escrowAdapter tokens, override CoinGecko-derived `totalSupply` with the adapter value.
  - `updateTokenMetrics` — branch on `escrowAdapter` so on-demand refreshes use the adapter helper.
- **`services/aragon-rates/fetchRates.ts`**
  - `onMainnetDocument` — same escrowAdapter branch (otherwise the periodic cron would clobber the correct value with the stale ERC20 supply every tick).
  - `onTestnetDocument` + crawler `where` — loosened to also match `escrowAdapter` tokens, with the same branch in the handler.

## Why three write paths
`Token.totalSupply` is written from: first-time creation (`wrapTokenDetails`), on-demand refresh (`updateTokenMetrics` via `saveAndGetToken`), and the periodic FetchRates cron (`onMainnetDocument` / `onTestnetDocument`). Missing any one would leave a hole — e.g. fixing only `wrapTokenDetails` would still let the cron overwrite Cryptex's value back to wrong every refresh.

## Test plan

- [x] `yarn test:unit` passes for `helpers/governanceVe.spec.ts`, `modules/proxyToken.spec.ts`, `services/aragon-rates/fetchRates.spec.ts`
- [x] New unit tests assert: `getVePastTotalSupply` calls `getPastTotalSupply` with `clock - 1n` and returns its value as a string; `'0'` on RPC error
- [x] New unit tests assert escrowAdapter tokens skip `Web3Helper.getTokenTotalSupply` in `updateTokenMetrics`, `onMainnetDocument`, and `onTestnetDocument` and write the adapter value instead
- [x] Existing escrowAdapter `wrapTokenDetails` test updated — adapter override wins over CoinGecko's `totalSupply`
- [ ] Post-merge: force-refresh Cryptex's existing Token doc (`ProxyToken.saveAndGetToken(<adapter>, <network>, true)`) so the fix shows up before the next cron tick, OR wait ≤6h
- [ ] Verify on staging: Cryptex DAO endpoint shows `plugin.settings.token.totalSupply ≈ 1.78M`, matching `historicalTotalSupply` on its tokenVoting proposal