### PR TITLE
fix(proposal): serialize settings.minProposerVotingPower as string

### DIFF
--- a/src/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType.ts
+++ b/src/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType.ts
@@ -1,0 +1,135 @@
+import { Models } from '@dbModels'
+import logger from '@logger'
+import type { IMigration } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: fixProposalSettingsMinProposerVotingPowerType' })
+
+const WRITE_BATCH_SIZE = 1000
+const SETTING_LOOKUP_CHUNK = 5000
+const PROGRESS_LOG_EVERY = 25_000
+
+type AffectedDoc = {
+  _id: any
+  settings?: {
+    id?: string
+    minProposerVotingPower?: unknown
+  }
+}
+
+const filter = {
+  'settings.minProposerVotingPower': { $type: ['double', 'int', 'long', 'decimal'] as any },
+}
+
+const buildSettingMap = async (settingIds: string[]): Promise<Map<string, string>> => {
+  const map = new Map<string, string>()
+  for (let i = 0; i < settingIds.length; i += SETTING_LOOKUP_CHUNK) {
+    const chunk = settingIds.slice(i, i + SETTING_LOOKUP_CHUNK)
+    const cursor = Models.Setting.collection.find(
+      { id: { $in: chunk }, minProposerVotingPower: { $type: 'string' } },
+      { projection: { id: 1, minProposerVotingPower: 1 } },
+    )
+    for await (const row of cursor as AsyncIterable<{ id: string; minProposerVotingPower: string }>) {
+      map.set(row.id, row.minProposerVotingPower)
+    }
+  }
+  return map
+}
+
+export const fixProposalSettingsMinProposerVotingPowerTypeMigration: IMigration = {
+  start: async () => {
+    logger.info(
+      'Starting migration',
+      llo({ migration: '20260501100801-fixProposalSettingsMinProposerVotingPowerType' }),
+    )
+
+    try {
+      const total = await Models.Proposal.countDocuments(filter)
+      logger.info('Affected proposal docs', llo({ total }))
+      if (total === 0) return
+
+      const settingIds = (await Models.Proposal.distinct('settings.id', filter)) as Array<string | null>
+      const validSettingIds = settingIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      logger.info('Distinct setting ids to look up', llo({ count: validSettingIds.length }))
+
+      const settingMap = await buildSettingMap(validSettingIds)
+      logger.info('Built setting map', llo({ entries: settingMap.size }))
+
+      const cursor = Models.Proposal.find(filter, {
+        _id: 1,
+        'settings.id': 1,
+        'settings.minProposerVotingPower': 1,
+      })
+        .lean()
+        .cursor() as AsyncIterable<AffectedDoc>
+
+      let ops: any[] = []
+      let processed = 0
+      let updated = 0
+      let recoveredFromSetting = 0
+      let fallbackStringified = 0
+
+      for await (const doc of cursor) {
+        const settingId = doc.settings?.id
+        const lossyNum = doc.settings?.minProposerVotingPower as number | undefined
+
+        let value: string | undefined
+        if (settingId && settingMap.has(settingId)) {
+          value = settingMap.get(settingId)!
+          recoveredFromSetting++
+        } else if (typeof lossyNum === 'number' && Number.isFinite(lossyNum)) {
+          value = BigInt(Math.trunc(lossyNum)).toString()
+          fallbackStringified++
+        }
+
+        if (value === undefined) continue
+
+        ops.push({
+          updateOne: {
+            filter: { _id: doc._id },
+            update: { $set: { 'settings.minProposerVotingPower': value } },
+          },
+        })
+
+        if (ops.length >= WRITE_BATCH_SIZE) {
+          const result = await Models.Proposal.bulkWrite(ops, { ordered: false })
+          updated += result.modifiedCount ?? 0
+          ops = []
+        }
+
+        processed++
+        if (processed % PROGRESS_LOG_EVERY === 0) {
+          logger.info(
+            'Backfill progress',
+            llo({ processed, total, updated, recoveredFromSetting, fallbackStringified }),
+          )
+        }
+      }
+
+      if (ops.length) {
+        const result = await Models.Proposal.bulkWrite(ops, { ordered: false })
+        updated += result.modifiedCount ?? 0
+      }
+
+      logger.info(
+        'Migration completed successfully',
+        llo({
+          migration: '20260501100801-fixProposalSettingsMinProposerVotingPowerType',
+          processed,
+          updated,
+          recoveredFromSetting,
+          fallbackStringified,
+        }),
+      )
+    } catch (error) {
+      logger.error(
+        'Migration failed',
+        llo({ migration: '20260501100801-fixProposalSettingsMinProposerVotingPowerType', error }),
+      )
+      throw error
+    }
+  },
+
+  stop: async () => {},
+}
+
+export default fixProposalSettingsMinProposerVotingPowerTypeMigration

--- a/src/models/schema/proposal.ts
+++ b/src/models/schema/proposal.ts
@@ -140,8 +140,8 @@ class Settings {
   @prop({ type: () => Number })
   public minDuration!: number
 
-  @prop({ type: () => Number })
-  public minProposerVotingPower!: number
+  @prop({ type: () => String })
+  public minProposerVotingPower!: string
 
   @prop({ type: () => [Stages], _id: false })
   public stages!: Stages[]

--- a/test/mock/fakeProposal.ts
+++ b/test/mock/fakeProposal.ts
@@ -46,7 +46,7 @@ export const ProposalList = [
       supportThreshold: 500000,
       minParticipation: 150000,
       minDuration: 3600,
-      minProposerVotingPower: 0,
+      minProposerVotingPower: '0',
     },
     snapshot: {
       totalSupply: '10000000000000000000000',
@@ -155,7 +155,7 @@ export const ProposalList = [
       supportThreshold: 500000,
       minParticipation: 150000,
       minDuration: 3600,
-      minProposerVotingPower: 0,
+      minProposerVotingPower: '0',
     },
     snapshot: {
       totalSupply: '10000000000000000000000',

--- a/test/unit/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType.spec.ts
+++ b/test/unit/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType.spec.ts
@@ -1,0 +1,125 @@
+import { Models } from '@dbModels'
+import fixProposalSettingsMinProposerVotingPowerTypeMigration from '@src/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+
+describe('migration: fixProposalSettingsMinProposerVotingPowerType', () => {
+  const network = NetworksEnum.ethereumMainnet
+  const pluginAddress = '0xA000000000000000000000000000000000000001'
+  const daoAddress = '0xD000000000000000000000000000000000000003'
+
+  let counter = 0
+  const uid = (prefix: string) => `${prefix}-${++counter}`
+
+  const seedProposal = async (settings: Record<string, unknown> | null, blockNumber = 1000) => {
+    const id = uid('proposal')
+    await Models.Proposal.collection.insertOne({
+      id,
+      transactionHash: '0xtx',
+      blockNumber,
+      network,
+      pluginAddress,
+      daoAddress,
+      settings,
+    } as any)
+    return id
+  }
+
+  const seedSetting = async (settingId: string, minProposerVotingPower: string, blockNumber = 1000) => {
+    await Models.Setting.collection.insertOne({
+      id: settingId,
+      transactionHash: '0xtx',
+      blockNumber,
+      network,
+      pluginAddress,
+      daoAddress,
+      minProposerVotingPower,
+    } as any)
+  }
+
+  const fetchProposal = async (id: string) => Models.Proposal.collection.findOne({ id })
+
+  it('recovers the exact string from the source Setting when settings.id is present', async () => {
+    const settingId = uid('setting')
+    await seedSetting(settingId, '100000000000000000000000', 900)
+    // Seed a proposal with the lossy number that JSON-serializing 1e23 would land at.
+    const proposalId = await seedProposal({
+      id: settingId,
+      blockNumber: 900,
+      minProposerVotingPower: 1e23, // becomes 99999999999999991611392 once stored
+    })
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+
+    const result = await fetchProposal(proposalId)
+    expect(result?.settings.minProposerVotingPower).to.eq('100000000000000000000000')
+    expect(typeof result?.settings.minProposerVotingPower).to.eq('string')
+  })
+
+  it('falls back to stringifying the numeric value when no matching Setting exists', async () => {
+    const proposalId = await seedProposal({
+      id: 'missing-setting',
+      blockNumber: 900,
+      minProposerVotingPower: 12345,
+    })
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+
+    const result = await fetchProposal(proposalId)
+    expect(result?.settings.minProposerVotingPower).to.eq('12345')
+    expect(typeof result?.settings.minProposerVotingPower).to.eq('string')
+  })
+
+  it('converts zero to the string "0"', async () => {
+    const proposalId = await seedProposal({
+      id: 'zero-setting',
+      blockNumber: 900,
+      minProposerVotingPower: 0,
+    })
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+
+    const result = await fetchProposal(proposalId)
+    expect(result?.settings.minProposerVotingPower).to.eq('0')
+  })
+
+  it('leaves proposals that already store a string untouched', async () => {
+    const proposalId = await seedProposal({
+      id: 'string-setting',
+      blockNumber: 900,
+      minProposerVotingPower: '100000000000000000000000',
+    })
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+
+    const result = await fetchProposal(proposalId)
+    expect(result?.settings.minProposerVotingPower).to.eq('100000000000000000000000')
+  })
+
+  it('skips proposals with no settings subdocument', async () => {
+    const proposalId = await seedProposal(null)
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+
+    const result = await fetchProposal(proposalId)
+    expect(result?.settings).to.be.null
+  })
+
+  it('is idempotent: re-running does not change a backfilled doc', async () => {
+    const settingId = uid('setting')
+    await seedSetting(settingId, '50000000000000000000000', 900)
+    const proposalId = await seedProposal({
+      id: settingId,
+      blockNumber: 900,
+      minProposerVotingPower: 5e22,
+    })
+
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+    const after1 = await fetchProposal(proposalId)
+    await fixProposalSettingsMinProposerVotingPowerTypeMigration.start()
+    const after2 = await fetchProposal(proposalId)
+
+    expect(after1?.settings.minProposerVotingPower).to.eq('50000000000000000000000')
+    expect(after2?.settings.minProposerVotingPower).to.eq('50000000000000000000000')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes [BE-218](https://linear.app/aragon/issue/BE-218/proposal-endpoint-serializes-minproposervotingpower-as-number).

The proposal endpoint returned `settings.minProposerVotingPower` as a JSON number while the DAO endpoint (and the existing TypeScript types) returned it as a string. For values above `Number.MAX_SAFE_INTEGER` (e.g. Cryptex's `100000000000000000000000` / 1e23) this caused precision loss after `JSON.parse` (`99999999999999991611392`), which is why the Cryptex Settings tab showed `Members with ≥ 99,999.99999999999 CTX`.

## Root cause

`Proposal.settings.minProposerVotingPower` was declared as `@prop({ type: () => Number })` in `src/models/schema/proposal.ts`. The handler copied the correctly-stringified value from the source `Setting` doc, but Mongoose then cast it to a JS double on save — so precision was lost at write time, not just at JSON serialization. A read-side getter wouldn't fix it because the DB already holds a lossy double for fresh writes.

## What changed

- `src/models/schema/proposal.ts` — embedded `settings.minProposerVotingPower` is now `String` (matches `Setting`, `ISettingResponse`, and `IProposalsResponse.settings`).
- `src/migrations/20260501100801-fixProposalSettingsMinProposerVotingPowerType.ts` — new migration:
  - Filters proposals whose `settings.minProposerVotingPower` is stored as a BSON number.
  - Bulk-loads the source `Setting` docs (one `$in` query per 5k ids, in-memory map) and recovers the exact string by `settings.id`.
  - Falls back to `BigInt(num).toString()` when no matching Setting exists (no scientific notation; bounded by the already-lossy stored double).
  - Bulk-writes updates in batches of 1000 (`ordered: false`).
- `test/unit/migrations/...spec.ts` — covers exact-recovery from `Setting`, fallback path, zero handling, idempotency, no-op when the field is already a string, and proposals with no settings subdoc.
- `test/mock/fakeProposal.ts` — mock `minProposerVotingPower: 0` → `'0'` (matches new schema).

## Audit of related fields

Per the ticket's request, scanned every schema for wei-scale / large-int fields stored as `Number`. All relevant fields (`Vote.votingPower`, `Proposal.snapshot.totalSupply`, `Proposal.metrics.votesByOption.totalVotingPower`, `CampaignReward.amount/totalClaimed/claims.claimedAmount`, `Setting.minProposerVotingPower`, `Setting.minDeposit`, all `PolicySource` amount fields, `MerkleClaim`/`Lock` amount fields) are already `String`. Other `Number`-typed fields are counts, timestamps, block numbers, durations, enums, or fractions (`supportThreshold`, `minParticipation`) — none are wei-scale.

One cosmetic mismatch noted but not addressed here: `Asset.amountUsd` is declared as `@prop({ type: () => Number, default: '0' })` while typed `string` in TS — practically not a precision bug today (USD amounts fit in `Number`), but worth a follow-up cleanup.

## Test plan

- [ ] Unit tests: `TS_NODE_TRANSPILE_ONLY=true yarn test:unit` (migration suite passes locally).
- [ ] After deploy: spot-check `/v2/proposals/...` for a Cryptex proposal — `settings.minProposerVotingPower` should now match `/v2/daos/...` exactly (`"100000000000000000000000"`).
- [ ] Run migration on staging; confirm `db.Proposal.find({ 'settings.minProposerVotingPower': { \$type: 'double' } }).count()` is 0 after.

## Checklist

- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Successfully tested on remote server
- [ ] Verified no secrets or credentials are exposed
- [ ] Verified commit authorship