### PR TITLE
feat(delegation): enhancements to the voting power and delegation APIs with integration test

### DIFF
--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -508,18 +508,27 @@ export default class Lock extends Model {
       this.aggregate([...baseQuery, { $count: 'totalRecords' }])
         .allowDiskUse(true)
         .then(results => (results[0] ? results[0].totalRecords : 0)),
-      this.aggregate([...baseQuery, { $group: { _id: null, sum: { $sum: '$votingPower' } } }])
+      this.aggregate([
+        ...baseQuery,
+        { $group: { _id: null, sum: { $sum: '$votingPower' } } },
+        {
+          $project: {
+            _id: 0,
+            sumString: {
+              $convert: {
+                input: { $round: ['$sum', 0] },
+                to: 'string',
+                onError: { $toString: { $round: ['$sum', 0] } },
+              },
+            },
+          },
+        },
+      ])
         .allowDiskUse(true)
-        .then(results => (results[0] ? results[0].sum : null)),
+        .then(results => (results[0]?.sumString ?? null) as string | null),
     ])
 
-    const totalVotingPower =
-      totalVotingPowerAgg == null
-        ? '0'
-        : (() => {
-            const rounded = Math.round(Number(totalVotingPowerAgg))
-            return Number.isFinite(rounded) ? rounded.toString() : '0'
-          })()
+    const totalVotingPower = totalVotingPowerAgg ?? '0'
 
     const totalPages = Math.ceil(totalRecords / request.limit) || 1
 

--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -441,10 +441,14 @@ export default class Lock extends Model {
           },
         },
       },
+      { $sort: { blockNumber: -1, blockTimestamp: -1 } },
       {
         $group: {
           _id: '$memberAddress',
           votingPower: { $sum: '$rawVotingPower' },
+          transactionHash: { $first: '$transactionHash' },
+          blockNumber: { $first: '$blockNumber' },
+          blockTimestamp: { $first: '$blockTimestamp' },
         },
       },
     ]
@@ -492,21 +496,37 @@ export default class Lock extends Model {
           address: '$_id',
           ens: '$memberInfo.ens',
           votingPower: '$votingPowerString',
+          transactionHash: 1,
+          blockNumber: 1,
+          blockTimestamp: 1,
         },
       },
     ]
 
-    const [data, totalRecords] = await Promise.all([
+    const [data, totalRecords, totalVotingPowerAgg] = await Promise.all([
       this.aggregate(dataQuery).allowDiskUse(true),
       this.aggregate([...baseQuery, { $count: 'totalRecords' }])
         .allowDiskUse(true)
         .then(results => (results[0] ? results[0].totalRecords : 0)),
+      this.aggregate([...baseQuery, { $group: { _id: null, sum: { $sum: '$votingPower' } } }])
+        .allowDiskUse(true)
+        .then(results => (results[0] ? results[0].sum : null)),
     ])
+
+    const totalVotingPower =
+      totalVotingPowerAgg == null
+        ? '0'
+        : (() => {
+            const rounded = Math.round(Number(totalVotingPowerAgg))
+            return Number.isFinite(rounded) ? rounded.toString() : '0'
+          })()
 
     const totalPages = Math.ceil(totalRecords / request.limit) || 1
 
     if (currentPage > totalPages) {
-      return ModelUtils.paginateEmptyResponse(request.limit)
+      const empty = ModelUtils.paginateEmptyResponse(request.limit)
+      empty.metadata.totalVotingPower = totalVotingPower
+      return empty
     }
 
     return {
@@ -515,6 +535,7 @@ export default class Lock extends Model {
         pageSize: request.limit,
         totalPages,
         totalRecords,
+        totalVotingPower,
       },
       data,
     }

--- a/src/models/schema/logDelegateChanged.ts
+++ b/src/models/schema/logDelegateChanged.ts
@@ -1,3 +1,4 @@
+import { Models } from '@dbModels'
 import { assert } from '@errors'
 import { index, modelOptions, prop } from '@typegoose/typegoose'
 import {
@@ -117,6 +118,9 @@ export default class LogDelegateChanged extends Model {
         $group: {
           _id: '$delegator',
           toDelegate: { $first: '$toDelegate' },
+          transactionHash: { $first: '$transactionHash' },
+          blockNumber: { $first: '$blockNumber' },
+          blockTimestamp: { $first: '$blockTimestamp' },
         },
       },
       {
@@ -221,21 +225,28 @@ export default class LogDelegateChanged extends Model {
           address: '$_id',
           ens: '$memberInfo.ens',
           votingPower: { $ifNull: ['$tokenMember.votingPower', '0'] },
+          transactionHash: 1,
+          blockNumber: 1,
+          blockTimestamp: 1,
         },
       },
     ]
 
-    const [data, totalRecords] = await Promise.all([
+    const [data, totalRecords, targetMember] = await Promise.all([
       this.aggregate(dataQuery).allowDiskUse(true),
       this.aggregate([...baseQuery, { $count: 'totalRecords' }])
         .allowDiskUse(true)
         .then(results => (results[0] ? results[0].totalRecords : 0)),
+      Models.TokenMember.findOne({ memberAddress, tokenAddress, network }).lean(),
     ])
 
+    const totalVotingPower = (targetMember as { votingPower?: string } | null)?.votingPower ?? '0'
     const totalPages = Math.ceil(totalRecords / request.limit) || 1
 
     if (currentPage > totalPages) {
-      return ModelUtils.paginateEmptyResponse(request.limit)
+      const empty = ModelUtils.paginateEmptyResponse(request.limit)
+      empty.metadata.totalVotingPower = totalVotingPower
+      return empty
     }
 
     return {
@@ -244,6 +255,7 @@ export default class LogDelegateChanged extends Model {
         pageSize: request.limit,
         totalPages,
         totalRecords,
+        totalVotingPower,
       },
       data,
     }

--- a/src/models/schema/logDelegateChanged.ts
+++ b/src/models/schema/logDelegateChanged.ts
@@ -30,6 +30,8 @@ const customName = ICollectionNames.LogDelegateChanged
 @index({ tokenAddress: 1, network: 1, blockNumber: -1, logIndex: -1 })
 @index({ toDelegate: 1, network: 1, blockNumber: 1 })
 @index({ delegator: 1, network: 1, blockNumber: 1 })
+@index({ network: 1, tokenAddress: 1, toDelegate: 1 })
+@index({ network: 1, tokenAddress: 1, delegator: 1, blockNumber: -1, logIndex: -1 })
 export default class LogDelegateChanged extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string
@@ -101,19 +103,28 @@ export default class LogDelegateChanged extends Model {
     return await this.findOne({ id: entityId }, null, tOpts)
   }
 
-  /**
-   * Base pipeline: one document per delegator with their CURRENT toDelegate, filtered to only
-   * those currently pointing at one of the target members. Shared between count and list APIs
-   * so delegationCount and the delegators list are always consistent.
-   */
-  private static activeDelegatorsPipeline(
+  private static async findCandidateDelegators(
     tokenAddress: HexAddress,
     network: NetworksEnum,
     memberAddresses: string[],
+  ): Promise<string[]> {
+    if (!memberAddresses.length) return []
+    return (await this.distinct('delegator', {
+      network,
+      tokenAddress,
+      toDelegate: { $in: memberAddresses },
+    })) as string[]
+  }
+
+  private static currentDelegationStatePipeline(
+    tokenAddress: HexAddress,
+    network: NetworksEnum,
+    candidates: string[],
+    memberAddresses: string[],
   ): any[] {
     return [
-      { $match: { tokenAddress, network } },
-      { $sort: { blockNumber: -1, logIndex: -1 } },
+      { $match: { network, tokenAddress, delegator: { $in: candidates } } },
+      { $sort: { delegator: 1, blockNumber: -1, logIndex: -1 } },
       {
         $group: {
           _id: '$delegator',
@@ -123,11 +134,7 @@ export default class LogDelegateChanged extends Model {
           blockTimestamp: { $first: '$blockTimestamp' },
         },
       },
-      {
-        $match: {
-          toDelegate: { $in: memberAddresses },
-        },
-      },
+      { $match: { toDelegate: { $in: memberAddresses } } },
     ]
   }
 
@@ -136,16 +143,12 @@ export default class LogDelegateChanged extends Model {
     network: NetworksEnum,
     memberAddresses: string[],
   ): Promise<Record<string, number>> {
-    if (!memberAddresses.length) return {}
+    const candidates = await this.findCandidateDelegators(tokenAddress, network, memberAddresses)
+    if (candidates.length === 0) return {}
 
     const results = await this.aggregate([
-      ...this.activeDelegatorsPipeline(tokenAddress, network, memberAddresses),
-      {
-        $group: {
-          _id: '$toDelegate',
-          count: { $sum: 1 },
-        },
-      },
+      ...this.currentDelegationStatePipeline(tokenAddress, network, candidates, memberAddresses),
+      { $group: { _id: '$toDelegate', count: { $sum: 1 } } },
     ]).allowDiskUse(true)
 
     return results.reduce((acc: Record<string, number>, item: { _id: string; count: number }) => {
@@ -163,8 +166,18 @@ export default class LogDelegateChanged extends Model {
     const request = ModelUtils.paginateAndSort({ ...paginationParams, sort: 'votingPower' })
     const currentPage = request.skip / request.limit + 1
 
+    const candidates = await LogDelegateChanged.findCandidateDelegators(tokenAddress, network, [memberAddress])
+
+    if (candidates.length === 0) {
+      const targetMember = await Models.TokenMember.findOne({ memberAddress, tokenAddress, network }).lean()
+      const totalVotingPower = (targetMember as { votingPower?: string } | null)?.votingPower ?? '0'
+      const empty = ModelUtils.paginateEmptyResponse(request.limit)
+      empty.metadata.totalVotingPower = totalVotingPower
+      return empty
+    }
+
     const baseQuery: any[] = [
-      ...LogDelegateChanged.activeDelegatorsPipeline(tokenAddress, network, [memberAddress]),
+      ...LogDelegateChanged.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
       {
         $lookup: {
           from: ICollectionNames.TokenMember,
@@ -185,18 +198,7 @@ export default class LogDelegateChanged extends Model {
           as: 'tokenMember',
         },
       },
-      {
-        $addFields: {
-          tokenMember: { $arrayElemAt: ['$tokenMember', 0] },
-        },
-      },
-      {
-        $addFields: {
-          votingPower: {
-            $toDouble: { $ifNull: ['$tokenMember.votingPower', '0'] },
-          },
-        },
-      },
+      { $addFields: { tokenMember: { $arrayElemAt: ['$tokenMember', 0] } } },
       {
         $lookup: {
           from: ICollectionNames.Member,
@@ -205,11 +207,7 @@ export default class LogDelegateChanged extends Model {
           as: 'memberInfo',
         },
       },
-      {
-        $addFields: {
-          memberInfo: { $arrayElemAt: ['$memberInfo', 0] },
-        },
-      },
+      { $addFields: { memberInfo: { $arrayElemAt: ['$memberInfo', 0] } } },
     ]
 
     const dataQuery: any[] = [
@@ -234,7 +232,10 @@ export default class LogDelegateChanged extends Model {
 
     const [data, totalRecords, targetMember] = await Promise.all([
       this.aggregate(dataQuery).allowDiskUse(true),
-      this.aggregate([...baseQuery, { $count: 'totalRecords' }])
+      this.aggregate([
+        ...LogDelegateChanged.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
+        { $count: 'totalRecords' },
+      ])
         .allowDiskUse(true)
         .then(results => (results[0] ? results[0].totalRecords : 0)),
       Models.TokenMember.findOne({ memberAddress, tokenAddress, network }).lean(),

--- a/src/models/schema/logDelegateChanged.ts
+++ b/src/models/schema/logDelegateChanged.ts
@@ -166,7 +166,7 @@ export default class LogDelegateChanged extends Model {
     const request = ModelUtils.paginateAndSort({ ...paginationParams, sort: 'votingPower' })
     const currentPage = request.skip / request.limit + 1
 
-    const candidates = await LogDelegateChanged.findCandidateDelegators(tokenAddress, network, [memberAddress])
+    const candidates = await this.findCandidateDelegators(tokenAddress, network, [memberAddress])
 
     if (candidates.length === 0) {
       const targetMember = await Models.TokenMember.findOne({ memberAddress, tokenAddress, network }).lean()
@@ -177,7 +177,7 @@ export default class LogDelegateChanged extends Model {
     }
 
     const baseQuery: any[] = [
-      ...LogDelegateChanged.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
+      ...this.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
       {
         $lookup: {
           from: ICollectionNames.TokenMember,
@@ -233,7 +233,7 @@ export default class LogDelegateChanged extends Model {
     const [data, totalRecords, targetMember] = await Promise.all([
       this.aggregate(dataQuery).allowDiskUse(true),
       this.aggregate([
-        ...LogDelegateChanged.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
+        ...this.currentDelegationStatePipeline(tokenAddress, network, candidates, [memberAddress]),
         { $count: 'totalRecords' },
       ])
         .allowDiskUse(true)

--- a/src/services/aragon-api/routers/schema/member.ts
+++ b/src/services/aragon-api/routers/schema/member.ts
@@ -71,7 +71,6 @@ const MemberSchema = {
       .valid(...Object.values(NetworksEnum))
       .optional(),
     pluginAddress: ValidationSchema.joiAddress.optional(),
-    tokenAddress: ValidationSchema.joiAddress.optional(),
   }),
 }
 

--- a/src/services/aragon-api/routers/v2/member.ts
+++ b/src/services/aragon-api/routers/v2/member.ts
@@ -99,7 +99,6 @@ const MemberRouter = {
       extraParams: {
         network: ctx.query.network as NetworksEnum,
         pluginAddress: ctx.query.pluginAddress as HexAddress,
-        tokenAddress: ctx.query.tokenAddress as HexAddress,
       },
       pairParams: {
         daoId: ctx.query.daoId as string,

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -162,6 +162,7 @@ export interface IPaginationMetadata {
   pageSize: number
   totalPages: number
   totalRecords: number
+  totalVotingPower?: string
 }
 
 export interface IPaginatedResult<T> {

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -109,6 +109,9 @@ export interface IDelegatorResponse {
   address: HexAddress
   ens?: ENS | null
   votingPower: string
+  transactionHash: HexAddress
+  blockNumber: number
+  blockTimestamp?: number | null
 }
 
 export interface IDaoResponse {

--- a/test/integration/helpers/services.ts
+++ b/test/integration/helpers/services.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import CoinGeckoHelper from '@helpers/coinGecko'
 import ConfigIndexerHelper from '@helpers/configIndexer'
+import { evmExplorerClient } from '@helpers/evmExplorerClient'
 import Connections from '@modules/connections'
 import MongoDB from '@modules/mongo'
 import AragonDaoService from '@services/aragon-dao'
@@ -42,6 +43,13 @@ export async function startServices(forkBlock?: number): Promise<void> {
   await seedForkBlock(forkBlock ?? (await getAnvilProvider().getBlockNumber()) - 1)
   sinon.stub(CoinGeckoHelper, 'getToken').resolves(false)
   sinon.stub(CoinGeckoHelper, 'getNativeToken').resolves(false)
+  sinon.stub(evmExplorerClient, 'fetchContractCreation').callsFake(async (_type, address) => ({
+    blockNumber: 0,
+    transactionHash: '',
+    address,
+  }))
+  sinon.stub(evmExplorerClient, 'fetchContractSourceCode').resolves(null)
+  sinon.stub(evmExplorerClient, 'getTokenBalances').resolves([])
   stubRabbitmqSend()
   for (const service of SERVICES) {
     await Connections.open(service.NEED_CONNECTIONS ?? [], service.options)

--- a/test/integration/setups/erc20DelegationActivity.ts
+++ b/test/integration/setups/erc20DelegationActivity.ts
@@ -1,4 +1,3 @@
-import logger from '@logger'
 import { ethers } from 'ethers'
 import { setBalance } from '../helpers/anvilRpc'
 import { getAnvilProvider } from '../helpers/constants'
@@ -10,7 +9,6 @@ import {
   type TokenVotingDaoDeployment,
 } from '../types/tokenVotingFixture'
 
-// Re-export the public surface so callers can `import { ... } from './erc20DelegationActivity'`.
 export {
   type DelegationSpec,
   type DelegationTarget,
@@ -27,43 +25,27 @@ const TOKEN_VOTING_ABI = [
 
 const TOKEN_MINT_ABI = ['function mint(address to, uint256 amount)'] as const
 
-const TOKEN_BALANCE_ABI = ['function balanceOf(address account) view returns (uint256)'] as const
-
 const TOKEN_DELEGATE_ABI = ['function delegate(address delegatee)'] as const
 
-/**
- * Drives realistic on-chain ERC20 delegation activity against a token-voting DAO created
- * by the parallel setup. Mints tokens to N holders via an early-executed proposal and then
- * sequentially calls `delegate(target)` per the config (re-delegations included), so each
- * `DelegateChanged` event lands in its own block — important for the indexer's
- * "latest event wins" semantics.
- */
 export async function runErc20DelegationActivity(
   dep: TokenVotingDaoDeployment,
   config: Erc20DelegationActivityConfig,
 ): Promise<Erc20DelegationActivityResult> {
   const provider = getAnvilProvider()
 
-  // 1. Create + fund holder wallets (1 ETH each, gas only).
   const holders: ethers.HDNodeWallet[] = []
   for (let i = 0; i < config.holders.length; i++) {
     const wallet = ethers.Wallet.createRandom().connect(provider)
     await setBalance(wallet.address, 10n ** 18n)
     holders.push(wallet)
   }
-  logger.info(`runErc20DelegationActivity: created + funded ${holders.length} holder wallets`)
 
-  // 2. Random member targets — never funded, only ever receive delegation.
   const members = {
     memberA: ethers.Wallet.createRandom().address,
     memberB: ethers.Wallet.createRandom().address,
     memberC: ethers.Wallet.createRandom().address,
   }
-  logger.info(
-    `runErc20DelegationActivity: member targets memberA=${members.memberA} memberB=${members.memberB} memberC=${members.memberC}`,
-  )
 
-  // 3. Build the actions array — one mint(holder, amount) per holder.
   const tokenInterface = new ethers.Interface(TOKEN_MINT_ABI)
   const actions = config.holders.map((spec, i) => ({
     to: dep.token,
@@ -71,63 +53,32 @@ export async function runErc20DelegationActivity(
     data: tokenInterface.encodeFunctionData('mint', [holders[i].address, spec.amount]),
   }))
 
-  // 4. Deployer creates the proposal voting Yes with tryEarlyExecution=true. Deployer holds
-  //    100% VP from the setup's seed mint (self-delegated 2 blocks earlier), so this single
-  //    call satisfies the support threshold and early-executes the actions in the same tx.
   const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerWallet)
   const nowTs = (await provider.getBlock('latest'))!.timestamp
-  // endDate must be >= startDate + minDuration (3600s). Pad by an extra hour so the inevitable
-  // block-timestamp drift between calling and mining doesn't bump us under the floor.
+  // endDate must be >= startDate + minDuration (3600s); pad against block-timestamp drift.
   const endDate = BigInt(nowTs) + 7200n
 
-  const tx = await tokenVoting.createProposal('0x', actions, 0, 0, endDate, VoteOption.Yes, true)
-  const receipt = await tx.wait()
-  logger.info(
-    `runErc20DelegationActivity: mint proposal early-executed (block=${receipt!.blockNumber}, txHash=${receipt!.hash})`,
-  )
+  await (await tokenVoting.createProposal('0x', actions, 0, 0, endDate, VoteOption.Yes, true)).wait()
 
-  // Sanity-check the mint executed by reading the first holder's balance.
-  const tokenReader = new ethers.Contract(dep.token, TOKEN_BALANCE_ABI, provider)
-  const firstHolder = holders[0]
-  const firstSpec = config.holders[0]
-  const firstBalance: bigint = await tokenReader.balanceOf(firstHolder.address)
-  if (firstBalance !== firstSpec.amount) {
-    throw new Error(
-      `runErc20DelegationActivity: expected first holder ${firstHolder.address} to have balance ${firstSpec.amount} ` +
-        `after early-execution, got ${firstBalance}. Likely the proposal did not early-execute (check setup's voting params, ` +
-        `deployer self-delegation, and that token mint permissions are granted to the DAO/TokenVoting plugin).`,
-    )
-  }
-
-  // 5. Run delegations sequentially so each lands in its own block, giving distinct
-  //    (block, logIndex) ordering for the indexer's latest-event-wins assertion.
+  // Sequential — when two delegates of the same target land in the same block, the indexer's
+  // DelegateVotesChanged batch handler can race and overwrite with a stale newBalance.
   const delegations: ResolvedErc20Delegation[] = []
   for (const spec of config.delegations) {
-    const holderWallet = holders[spec.fromHolder]
-    if (!holderWallet) {
-      throw new Error(
-        `runErc20DelegationActivity: holder index ${spec.fromHolder} out of range (holders=${holders.length})`,
-      )
+    if (spec.fromHolder < 0 || spec.fromHolder >= holders.length) {
+      throw new Error(`holder index ${spec.fromHolder} out of range (holders=${holders.length})`)
     }
+    const holderWallet = holders[spec.fromHolder]
     const targetAddr = members[spec.to]
-
     const token = new ethers.Contract(dep.token, TOKEN_DELEGATE_ABI, holderWallet)
-    const delegateTx = await token.delegate(targetAddr)
-    const delegateReceipt = await delegateTx.wait()
-    const block = await provider.getBlock(delegateReceipt!.blockNumber)
-
+    const receipt = await (await token.delegate(targetAddr)).wait()
+    const block = await provider.getBlock(receipt!.blockNumber)
     delegations.push({
       from: holderWallet.address,
       to: targetAddr,
-      transactionHash: delegateReceipt!.hash,
-      blockNumber: delegateReceipt!.blockNumber,
+      transactionHash: receipt!.hash,
+      blockNumber: receipt!.blockNumber,
       blockTimestamp: Number(block!.timestamp),
     })
-
-    logger.info(
-      `runErc20DelegationActivity: holder[${spec.fromHolder}]=${holderWallet.address} → ${spec.to} (${targetAddr}) ` +
-        `at block=${delegateReceipt!.blockNumber}`,
-    )
   }
 
   return { holders, members, delegations }

--- a/test/integration/setups/erc20DelegationActivity.ts
+++ b/test/integration/setups/erc20DelegationActivity.ts
@@ -1,0 +1,134 @@
+import logger from '@logger'
+import { ethers } from 'ethers'
+import { setBalance } from '../helpers/anvilRpc'
+import { getAnvilProvider } from '../helpers/constants'
+import { VoteOption } from '../types/gaugesFixture'
+import {
+  type Erc20DelegationActivityConfig,
+  type Erc20DelegationActivityResult,
+  type ResolvedErc20Delegation,
+  type TokenVotingDaoDeployment,
+} from '../types/tokenVotingFixture'
+
+// Re-export the public surface so callers can `import { ... } from './erc20DelegationActivity'`.
+export {
+  type DelegationSpec,
+  type DelegationTarget,
+  type Erc20DelegationActivityConfig,
+  type Erc20DelegationActivityResult,
+  type HolderSpec,
+  type ResolvedErc20Delegation,
+  type TokenVotingDaoDeployment,
+} from '../types/tokenVotingFixture'
+
+const TOKEN_VOTING_ABI = [
+  'function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap, uint64 _startDate, uint64 _endDate, uint8 _voteOption, bool _tryEarlyExecution) returns (uint256 proposalId)',
+] as const
+
+const TOKEN_MINT_ABI = ['function mint(address to, uint256 amount)'] as const
+
+const TOKEN_BALANCE_ABI = ['function balanceOf(address account) view returns (uint256)'] as const
+
+const TOKEN_DELEGATE_ABI = ['function delegate(address delegatee)'] as const
+
+/**
+ * Drives realistic on-chain ERC20 delegation activity against a token-voting DAO created
+ * by the parallel setup. Mints tokens to N holders via an early-executed proposal and then
+ * sequentially calls `delegate(target)` per the config (re-delegations included), so each
+ * `DelegateChanged` event lands in its own block — important for the indexer's
+ * "latest event wins" semantics.
+ */
+export async function runErc20DelegationActivity(
+  dep: TokenVotingDaoDeployment,
+  config: Erc20DelegationActivityConfig,
+): Promise<Erc20DelegationActivityResult> {
+  const provider = getAnvilProvider()
+
+  // 1. Create + fund holder wallets (1 ETH each, gas only).
+  const holders: ethers.HDNodeWallet[] = []
+  for (let i = 0; i < config.holders.length; i++) {
+    const wallet = ethers.Wallet.createRandom().connect(provider)
+    await setBalance(wallet.address, 10n ** 18n)
+    holders.push(wallet)
+  }
+  logger.info(`runErc20DelegationActivity: created + funded ${holders.length} holder wallets`)
+
+  // 2. Random member targets — never funded, only ever receive delegation.
+  const members = {
+    memberA: ethers.Wallet.createRandom().address,
+    memberB: ethers.Wallet.createRandom().address,
+    memberC: ethers.Wallet.createRandom().address,
+  }
+  logger.info(
+    `runErc20DelegationActivity: member targets memberA=${members.memberA} memberB=${members.memberB} memberC=${members.memberC}`,
+  )
+
+  // 3. Build the actions array — one mint(holder, amount) per holder.
+  const tokenInterface = new ethers.Interface(TOKEN_MINT_ABI)
+  const actions = config.holders.map((spec, i) => ({
+    to: dep.token,
+    value: 0n,
+    data: tokenInterface.encodeFunctionData('mint', [holders[i].address, spec.amount]),
+  }))
+
+  // 4. Deployer creates the proposal voting Yes with tryEarlyExecution=true. Deployer holds
+  //    100% VP from the setup's seed mint (self-delegated 2 blocks earlier), so this single
+  //    call satisfies the support threshold and early-executes the actions in the same tx.
+  const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerWallet)
+  const nowTs = (await provider.getBlock('latest'))!.timestamp
+  // endDate must be >= startDate + minDuration (3600s). Pad by an extra hour so the inevitable
+  // block-timestamp drift between calling and mining doesn't bump us under the floor.
+  const endDate = BigInt(nowTs) + 7200n
+
+  const tx = await tokenVoting.createProposal('0x', actions, 0, 0, endDate, VoteOption.Yes, true)
+  const receipt = await tx.wait()
+  logger.info(
+    `runErc20DelegationActivity: mint proposal early-executed (block=${receipt!.blockNumber}, txHash=${receipt!.hash})`,
+  )
+
+  // Sanity-check the mint executed by reading the first holder's balance.
+  const tokenReader = new ethers.Contract(dep.token, TOKEN_BALANCE_ABI, provider)
+  const firstHolder = holders[0]
+  const firstSpec = config.holders[0]
+  const firstBalance: bigint = await tokenReader.balanceOf(firstHolder.address)
+  if (firstBalance !== firstSpec.amount) {
+    throw new Error(
+      `runErc20DelegationActivity: expected first holder ${firstHolder.address} to have balance ${firstSpec.amount} ` +
+        `after early-execution, got ${firstBalance}. Likely the proposal did not early-execute (check setup's voting params, ` +
+        `deployer self-delegation, and that token mint permissions are granted to the DAO/TokenVoting plugin).`,
+    )
+  }
+
+  // 5. Run delegations sequentially so each lands in its own block, giving distinct
+  //    (block, logIndex) ordering for the indexer's latest-event-wins assertion.
+  const delegations: ResolvedErc20Delegation[] = []
+  for (const spec of config.delegations) {
+    const holderWallet = holders[spec.fromHolder]
+    if (!holderWallet) {
+      throw new Error(
+        `runErc20DelegationActivity: holder index ${spec.fromHolder} out of range (holders=${holders.length})`,
+      )
+    }
+    const targetAddr = members[spec.to]
+
+    const token = new ethers.Contract(dep.token, TOKEN_DELEGATE_ABI, holderWallet)
+    const delegateTx = await token.delegate(targetAddr)
+    const delegateReceipt = await delegateTx.wait()
+    const block = await provider.getBlock(delegateReceipt!.blockNumber)
+
+    delegations.push({
+      from: holderWallet.address,
+      to: targetAddr,
+      transactionHash: delegateReceipt!.hash,
+      blockNumber: delegateReceipt!.blockNumber,
+      blockTimestamp: Number(block!.timestamp),
+    })
+
+    logger.info(
+      `runErc20DelegationActivity: holder[${spec.fromHolder}]=${holderWallet.address} → ${spec.to} (${targetAddr}) ` +
+        `at block=${delegateReceipt!.blockNumber}`,
+    )
+  }
+
+  return { holders, members, delegations }
+}

--- a/test/integration/setups/tokenVotingDaoSetup.ts
+++ b/test/integration/setups/tokenVotingDaoSetup.ts
@@ -1,0 +1,201 @@
+import logger from '@logger'
+import { ethers } from 'ethers'
+import { mine, setBalance } from '../helpers/anvilRpc'
+import { getAnvilProvider } from '../helpers/constants'
+import type { TokenVotingDaoDeployment } from '../types/tokenVotingFixture'
+
+// Ethereum mainnet addresses — match the OSx deployment the Aragon FE actually uses
+// (newer than the v1.3 entries in config/contracts/ethereumMainnet.json which reject
+// ANY_ADDR Grant in applyInstallation for TokenVoting build 4).
+const DAO_FACTORY = '0x246503df057A9a85E0144b6867a828c99676128B'
+const PSP = '0xE978942c691e43f65c1B7c7F8f1dc8cDF061B13f'
+
+const ADMIN_REPO = '0xA4371a239D08bfBA6E8894eccf8466C6323A52C3'
+const ADMIN_RELEASE = 1
+const ADMIN_BUILD = 2
+
+const TOKEN_VOTING_REPO = '0xb7401cD221ceAFC54093168B814Cc3d42579287f'
+const TOKEN_VOTING_RELEASE = 1
+const TOKEN_VOTING_BUILD = 4
+
+const DAO_FACTORY_ABI = [
+  'function createDao(tuple(address trustedForwarder, string daoURI, string subdomain, bytes metadata) _daoSettings, tuple(tuple(tuple(uint8 release, uint16 build) versionTag, address pluginSetupRepo) pluginSetupRef, bytes data)[] _pluginSettings) returns (address createdDao)',
+]
+
+// PluginSetupProcessor ABI for the install dance after the DAO + Admin plugin exists.
+const PSP_ABI = [
+  'function APPLY_INSTALLATION_PERMISSION_ID() view returns (bytes32)',
+  'function prepareInstallation(address dao, tuple(tuple(tuple(uint8 release, uint16 build) versionTag, address pluginSetupRepo) pluginSetupRef, bytes data) params) returns (address plugin, tuple(address[] helpers, tuple(uint8 operation, address where, address who, address condition, bytes32 permissionId)[] permissions) preparedSetupData)',
+  'function applyInstallation(address dao, tuple(tuple(tuple(uint8 release, uint16 build) versionTag, address pluginSetupRepo) pluginSetupRef, address plugin, tuple(uint8 operation, address where, address who, address condition, bytes32 permissionId)[] permissions, bytes32 helpersHash) params)',
+  'event InstallationApplied(address indexed dao, address indexed plugin, bytes32 preparedSetupId, bytes32 appliedSetupId)',
+]
+
+// Aragon DAORegistry — emits DAORegistered when a fresh DAO is created via DAOFactory.
+const DAO_REGISTRY_ABI = ['event DAORegistered(address indexed dao, address indexed creator, string subdomain)']
+
+const DAO_ABI = [
+  'function grant(address where, address who, bytes32 permissionId)',
+  'function ROOT_PERMISSION_ID() view returns (bytes32)',
+]
+
+// Admin plugin (build 2) auto-executes on createProposal.
+const ADMIN_ABI = [
+  'function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64, uint64, bytes _data) returns (uint256 proposalId)',
+]
+
+const TOKEN_VOTING_ABI = ['function getVotingToken() view returns (address)', 'function token() view returns (address)']
+
+/**
+ * Deploys a fresh DAO on a forked anvil following the Aragon FE flow:
+ *   1. createDao with only the Admin plugin (deployer = admin).
+ *   2. Through Admin auto-execute, grant PSP root + grant deployer APPLY_INSTALLATION on PSP.
+ *   3. Prepare + apply TokenVoting (build 4, plain GovernanceERC20 with 1M minted to deployer).
+ *   4. Self-delegate deployer + mine so the proposal snapshot sees the voting power.
+ */
+export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
+  const provider = getAnvilProvider()
+
+  const deployer = ethers.Wallet.createRandom().connect(provider)
+  await setBalance(deployer.address, 10n ** 19n)
+
+  // ───────────────── Step 1: createDao with Admin only ─────────────────
+  const adminInstallData = ethers.AbiCoder.defaultAbiCoder().encode(
+    ['address', 'tuple(address target, uint8 operation)'],
+    [deployer.address, { target: ethers.ZeroAddress, operation: 0 }],
+  )
+
+  const adminPluginInstallation = {
+    pluginSetupRef: {
+      versionTag: { release: ADMIN_RELEASE, build: ADMIN_BUILD },
+      pluginSetupRepo: ADMIN_REPO,
+    },
+    data: adminInstallData,
+  }
+
+  const daoSettings = {
+    trustedForwarder: ethers.ZeroAddress,
+    daoURI: '',
+    subdomain: '',
+    metadata: '0x',
+  }
+
+  const factory = new ethers.Contract(DAO_FACTORY, DAO_FACTORY_ABI, deployer)
+  const createDaoTx = await factory.createDao(daoSettings, [adminPluginInstallation])
+  const createDaoReceipt = await createDaoTx.wait()
+
+  const daoRegistryInterface = new ethers.Interface(DAO_REGISTRY_ABI)
+  const daoRegisteredTopic = daoRegistryInterface.getEvent('DAORegistered')!.topicHash
+  const daoRegisteredLog = createDaoReceipt.logs.find((l: ethers.Log) => l.topics[0] === daoRegisteredTopic)
+  if (!daoRegisteredLog) throw new Error('TokenVotingDaoSetup: DAORegistered event not found')
+  const dao: string = daoRegistryInterface.parseLog(daoRegisteredLog)!.args.dao
+
+  const pspInterface = new ethers.Interface(PSP_ABI)
+  const installationAppliedTopic = pspInterface.getEvent('InstallationApplied')!.topicHash
+  const adminInstallLog = createDaoReceipt.logs.find(
+    (l: ethers.Log) => l.address.toLowerCase() === PSP.toLowerCase() && l.topics[0] === installationAppliedTopic,
+  )
+  if (!adminInstallLog) throw new Error('TokenVotingDaoSetup: Admin InstallationApplied not found')
+  const adminPlugin: string = pspInterface.parseLog(adminInstallLog)!.args.plugin
+  logger.info(`TokenVotingDaoSetup: dao=${dao} adminPlugin=${adminPlugin}`)
+
+  // ───────────────── Step 2: Admin auto-execute → grant PSP perms ─────────────────
+  const daoContract = new ethers.Contract(dao, DAO_ABI, provider)
+  const psp = new ethers.Contract(PSP, PSP_ABI, deployer)
+  const ROOT: string = await daoContract.ROOT_PERMISSION_ID()
+  const APPLY_INSTALLATION: string = await psp.APPLY_INSTALLATION_PERMISSION_ID()
+
+  const grantPspRootData = daoContract.interface.encodeFunctionData('grant', [dao, PSP, ROOT])
+  const grantApplyToDeployerData = daoContract.interface.encodeFunctionData('grant', [
+    PSP,
+    deployer.address,
+    APPLY_INSTALLATION,
+  ])
+
+  const adminContract = new ethers.Contract(adminPlugin, ADMIN_ABI, deployer)
+  const adminTx = await adminContract.createProposal(
+    '0x',
+    [
+      { to: dao, value: 0n, data: grantPspRootData },
+      { to: dao, value: 0n, data: grantApplyToDeployerData },
+    ],
+    0,
+    0,
+    '0x',
+  )
+  await adminTx.wait()
+  logger.info('TokenVotingDaoSetup: Admin executed PSP permission grants')
+
+  // ───────────────── Step 3: PSP prepare + apply TokenVoting ─────────────────
+  const tvInstallData = ethers.AbiCoder.defaultAbiCoder().encode(
+    [
+      'tuple(uint8 votingMode, uint32 supportThreshold, uint32 minParticipation, uint64 minDuration, uint256 minProposerVotingPower)',
+      'tuple(address addr, string name, string symbol)',
+      'tuple(address[] receivers, uint256[] amounts, bool ensureDelegationOnMint)',
+      'tuple(address target, uint8 operation)',
+      'uint256',
+      'bytes',
+      'address[]',
+    ],
+    [
+      { votingMode: 1, supportThreshold: 500_000, minParticipation: 0, minDuration: 3600, minProposerVotingPower: 0 },
+      { addr: ethers.ZeroAddress, name: 'Test', symbol: 'TEST' },
+      { receivers: [deployer.address], amounts: [10n ** 24n], ensureDelegationOnMint: false },
+      { target: dao, operation: 0 },
+      0,
+      '0x',
+      [],
+    ],
+  )
+
+  const pluginSetupRef = {
+    versionTag: { release: TOKEN_VOTING_RELEASE, build: TOKEN_VOTING_BUILD },
+    pluginSetupRepo: TOKEN_VOTING_REPO,
+  }
+
+  const prepared = await psp.prepareInstallation.staticCall(dao, { pluginSetupRef, data: tvInstallData })
+  const tokenVoting: string = prepared.plugin
+  const helpers: string[] = Array.from(prepared.preparedSetupData.helpers as string[])
+  const permissions = (prepared.preparedSetupData.permissions as ethers.Result[]).map(p => ({
+    operation: Number(p[0]),
+    where: p[1] as string,
+    who: p[2] as string,
+    condition: p[3] as string,
+    permissionId: p[4] as string,
+  }))
+  await (await psp.prepareInstallation(dao, { pluginSetupRef, data: tvInstallData })).wait()
+  logger.info(`TokenVotingDaoSetup: TokenVoting prepared at ${tokenVoting}`)
+
+  const helpersHash = ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(['address[]'], [helpers]))
+  await (
+    await psp.applyInstallation(dao, {
+      pluginSetupRef,
+      plugin: tokenVoting,
+      permissions,
+      helpersHash,
+    })
+  ).wait()
+  logger.info('TokenVotingDaoSetup: TokenVoting applied')
+
+  // ───────────────── Step 4: read token, self-delegate, mine ─────────────────
+  const tvContract = new ethers.Contract(tokenVoting, TOKEN_VOTING_ABI, provider)
+  let token: string
+  try {
+    token = await tvContract.getVotingToken()
+  } catch {
+    token = await tvContract.token()
+  }
+  logger.info(`TokenVotingDaoSetup: token=${token}`)
+
+  const tokenContract = new ethers.Contract(token, ['function delegate(address)'], deployer)
+  await (await tokenContract.delegate(deployer.address)).wait()
+
+  await mine(2, 1)
+
+  return {
+    dao,
+    tokenVoting,
+    token,
+    deployer: deployer.address,
+    deployerWallet: deployer,
+  }
+}

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -1,5 +1,5 @@
 import { Models } from '@dbModels'
-import { type HexAddress, type IMemberExtraParams, NetworksEnum } from '@types'
+import { type HexAddress, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import { resetFork } from '../helpers/anvilRpc'
 import { getAnvilProvider } from '../helpers/constants'

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -1,5 +1,5 @@
 import { Models } from '@dbModels'
-import { type HexAddress, NetworksEnum } from '@types'
+import { type HexAddress, type IMemberExtraParams, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import { resetFork } from '../helpers/anvilRpc'
 import { getAnvilProvider } from '../helpers/constants'
@@ -7,6 +7,7 @@ import { startServices, stopServices, waitForIndexerCatchup } from '../helpers/s
 import { runErc20DelegationActivity } from '../setups/erc20DelegationActivity'
 import { setupTokenVotingDao } from '../setups/tokenVotingDaoSetup'
 import type { Erc20DelegationActivityResult, TokenVotingDaoDeployment } from '../types/tokenVotingFixture'
+import MemberController from '@api/controllers/member'
 
 const NETWORK = NetworksEnum.ethereumMainnet
 const FORK_BLOCK = 24541643 // same as governanceRewards.spec.ts
@@ -29,21 +30,40 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
         { amount: 100_000n * 10n ** 18n }, // holder0
         { amount: 50_000n * 10n ** 18n }, // holder1
         { amount: 25_000n * 10n ** 18n }, // holder2
+        { amount: 80_000n * 10n ** 18n }, // holder3
+        { amount: 30_000n * 10n ** 18n }, // holder4
+        { amount: 60_000n * 10n ** 18n }, // holder5
       ],
-      // memberA receives from holder0 + holder1, holder0 then re-delegates to memberC.
-      // memberB receives from holder2.
-      // Expected end state: memberA -> [holder1], memberB -> [holder2], memberC -> [holder0].
       delegations: [
         { fromHolder: 0, to: 'memberA' },
         { fromHolder: 1, to: 'memberA' },
         { fromHolder: 2, to: 'memberB' },
-        { fromHolder: 0, to: 'memberC' }, // re-delegation — latest event wins
+        { fromHolder: 3, to: 'memberA' },
+        { fromHolder: 4, to: 'memberA' },
+        { fromHolder: 5, to: 'memberB' },
+        { fromHolder: 0, to: 'memberC' },
       ],
     })
 
     const latestBlock = await getAnvilProvider().getBlockNumber()
     await startServices(startBlock)
     await waitForIndexerCatchup(latestBlock, 180_000)
+
+    const targets = [activity.members.memberA, activity.members.memberB, activity.members.memberC]
+    const start = Date.now()
+    let found = 0
+    while (Date.now() - start < 30_000) {
+      found = await Models.TokenMember.countDocuments({
+        network: NETWORK,
+        tokenAddress: dep.token,
+        memberAddress: { $in: targets },
+      })
+      if (found === targets.length) break
+      await new Promise(r => setTimeout(r, 200))
+    }
+    if (found !== targets.length) {
+      throw new Error(`TokenMember rows not persisted within 30s: expected ${targets.length}, found ${found}`)
+    }
   })
 
   after(() => stopServices())
@@ -64,7 +84,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
     )
   })
 
-  it('findDelegatorsForMember(memberA): only holder1 remains after holder0 re-delegation', async () => {
+  it('findDelegatorsForMember(memberA): all 3 active delegators present after holder0 re-delegated away', async () => {
     const result = await Models.LogDelegateChanged.findDelegatorsForMember(
       dep.token as HexAddress,
       NETWORK,
@@ -72,21 +92,25 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       { sort: 'votingPower', order: 'desc' },
     )
 
-    expect(result.data, 'memberA should have exactly 1 delegator after re-delegation').to.have.lengthOf(1)
-    expect(result.data[0].address).to.equal(activity.holders[1].address)
-    // KNOWN LIMITATION: delegators' own TokenMember.votingPower is always '0' in realistic ERC20Votes flow
-    // because they delegated their VP away. The "amount delegated" intent of BE-202 is currently NOT
-    // captured by the aggregation. The TokenMember.votingPower of the *delegate target* (memberA) is
-    // what holds the total delegated VP — asserted separately below.
-    expect(result.data[0].votingPower).to.equal('0')
+    expect(result.data, 'memberA should have 3 delegators after holder0 re-delegated to memberC').to.have.lengthOf(3)
 
-    const matching = activity.delegations.find(
-      d => d.from === activity.holders[1].address && d.to === activity.members.memberA,
-    )
-    expect(matching, 'expected matching holder1 -> memberA delegation in activity').to.exist
-    expect(result.data[0].transactionHash).to.equal(matching!.transactionHash)
-    expect(result.data[0].blockNumber).to.equal(matching!.blockNumber)
-    expect(result.data[0].blockTimestamp).to.equal(matching!.blockTimestamp)
+    const addrs = result.data.map(d => d.address)
+    expect(addrs).to.include.members([
+      activity.holders[1].address,
+      activity.holders[3].address,
+      activity.holders[4].address,
+    ])
+    expect(addrs).to.not.include(activity.holders[0].address) // re-delegated away
+    for (const row of result.data) expect(row.votingPower).to.equal('0')
+
+    // Per-row tx/block/timestamp must match the matching delegation in activity for each holder.
+    for (const row of result.data) {
+      const matching = activity.delegations.find(d => d.from === row.address && d.to === activity.members.memberA)
+      expect(matching, `expected delegation row in activity for ${row.address}`).to.exist
+      expect(row.transactionHash).to.equal(matching!.transactionHash)
+      expect(row.blockNumber).to.equal(matching!.blockNumber)
+      expect(row.blockTimestamp).to.equal(matching!.blockTimestamp)
+    }
   })
 
   it('findDelegatorsForMember(memberC): holder0 with re-delegation event metadata', async () => {
@@ -99,9 +123,8 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
 
     expect(result.data, 'memberC should have exactly 1 delegator (holder0 after re-delegation)').to.have.lengthOf(1)
     expect(result.data[0].address).to.equal(activity.holders[0].address)
-    expect(result.data[0].votingPower).to.equal('0') // see KNOWN LIMITATION above
+    expect(result.data[0].votingPower).to.equal('0')
 
-    // Must match the LATEST delegation event (holder0 -> memberC), not the original holder0 -> memberA.
     const reDelegation = activity.delegations.find(
       d => d.from === activity.holders[0].address && d.to === activity.members.memberC,
     )
@@ -111,7 +134,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
     expect(result.data[0].blockTimestamp).to.equal(reDelegation!.blockTimestamp)
   })
 
-  it('findDelegatorsForMember(memberB): single holder2 row', async () => {
+  it('findDelegatorsForMember(memberB): both holder2 and holder5 present', async () => {
     const result = await Models.LogDelegateChanged.findDelegatorsForMember(
       dep.token as HexAddress,
       NETWORK,
@@ -119,44 +142,70 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       { sort: 'votingPower', order: 'desc' },
     )
 
-    expect(result.data, 'memberB should have exactly 1 delegator').to.have.lengthOf(1)
-    expect(result.data[0].address).to.equal(activity.holders[2].address)
-    expect(result.data[0].votingPower).to.equal('0') // see KNOWN LIMITATION above
+    expect(result.data).to.have.lengthOf(2)
+    const addrs = result.data.map(d => d.address)
+    expect(addrs).to.include.members([activity.holders[2].address, activity.holders[5].address])
 
-    const matching = activity.delegations.find(
-      d => d.from === activity.holders[2].address && d.to === activity.members.memberB,
-    )
-    expect(matching, 'expected matching holder2 -> memberB delegation in activity').to.exist
-    expect(result.data[0].transactionHash).to.equal(matching!.transactionHash)
-    expect(result.data[0].blockNumber).to.equal(matching!.blockNumber)
-    expect(result.data[0].blockTimestamp).to.equal(matching!.blockTimestamp)
+    for (const row of result.data) {
+      const matching = activity.delegations.find(d => d.from === row.address && d.to === activity.members.memberB)
+      expect(matching, `expected delegation row in activity for ${row.address}`).to.exist
+      expect(row.transactionHash).to.equal(matching!.transactionHash)
+      expect(row.blockNumber).to.equal(matching!.blockNumber)
+      expect(row.blockTimestamp).to.equal(matching!.blockTimestamp)
+    }
   })
 
-  it('pagination: pageSize=1 against memberA returns single row + correct totals', async () => {
-    // memberA has exactly 1 active delegator (holder1) after holder0's re-delegation.
-    // This asserts the pagination envelope (totalRecords, totalPages, data length).
+  it('pagination: pageSize=2 against memberA returns 2 rows on page 1, 1 row on page 2, no overlap', async () => {
+    const page1 = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberA as HexAddress,
+      { sort: 'votingPower', order: 'desc', page: 1, pageSize: 2 },
+    )
+    const page2 = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberA as HexAddress,
+      { sort: 'votingPower', order: 'desc', page: 2, pageSize: 2 },
+    )
+
+    expect(page1.data).to.have.lengthOf(2)
+    expect(page2.data).to.have.lengthOf(1)
+    expect(page1.metadata.totalRecords).to.equal(3)
+    expect(page1.metadata.totalPages).to.equal(2)
+    expect(page1.metadata.page).to.equal(1)
+    expect(page2.metadata.page).to.equal(2)
+
+    const overlap = page1.data.map(r => r.address).filter(a => page2.data.some(r => r.address === a))
+    expect(overlap, 'no delegator should appear on both pages').to.be.empty
+
+    const combined = [...page1.data, ...page2.data].map(r => r.address)
+    expect(combined).to.have.members([
+      activity.holders[1].address,
+      activity.holders[3].address,
+      activity.holders[4].address,
+    ])
+
+    expect(page1.metadata.totalVotingPower).to.equal((160_000n * 10n ** 18n).toString())
+    expect(page2.metadata.totalVotingPower).to.equal((160_000n * 10n ** 18n).toString())
+  })
+
+  it('pagination: page beyond range returns empty data with consistent totals', async () => {
     const result = await Models.LogDelegateChanged.findDelegatorsForMember(
       dep.token as HexAddress,
       NETWORK,
       activity.members.memberA as HexAddress,
-      { sort: 'votingPower', order: 'desc', pageSize: 1 },
+      { sort: 'votingPower', order: 'desc', page: 99, pageSize: 2 },
     )
 
-    expect(result.data).to.have.lengthOf(1)
-    expect(result.metadata.totalRecords).to.equal(1)
-    expect(result.metadata.totalPages).to.equal(1)
-    expect(result.metadata.pageSize).to.equal(1)
-    expect(result.metadata.page).to.equal(1)
+    expect(result.data).to.have.lengthOf(0)
+    expect(result.metadata.totalVotingPower).to.equal((160_000n * 10n ** 18n).toString())
   })
 
   it('TokenMember rows for delegate targets reflect total VP delegated to each', async () => {
-    // After all delegations + re-delegation:
-    //   memberA receives holder1's 50K (holder0 re-delegated to memberC)
-    //   memberB receives holder2's 25K
-    //   memberC receives holder0's 100K (after re-delegation)
     const cases: Array<{ member: string; expected: bigint }> = [
-      { member: activity.members.memberA, expected: 50_000n * 10n ** 18n },
-      { member: activity.members.memberB, expected: 25_000n * 10n ** 18n },
+      { member: activity.members.memberA, expected: 160_000n * 10n ** 18n },
+      { member: activity.members.memberB, expected: 85_000n * 10n ** 18n },
       { member: activity.members.memberC, expected: 100_000n * 10n ** 18n },
     ]
 
@@ -173,8 +222,8 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
 
   it('metadata.totalVotingPower equals each TokenMember.votingPower across pages', async () => {
     const cases: Array<{ member: string; expected: bigint }> = [
-      { member: activity.members.memberA, expected: 50_000n * 10n ** 18n },
-      { member: activity.members.memberB, expected: 25_000n * 10n ** 18n },
+      { member: activity.members.memberA, expected: 160_000n * 10n ** 18n },
+      { member: activity.members.memberB, expected: 85_000n * 10n ** 18n },
       { member: activity.members.memberC, expected: 100_000n * 10n ** 18n },
     ]
 
@@ -187,5 +236,53 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       )
       expect(result.metadata.totalVotingPower, `totalVotingPower for ${member}`).to.equal(expected.toString())
     }
+  })
+
+  it('MemberController.getDelegatorsForMember (memberA, multi-delegator) returns all 3 with correct wrapper total', async () => {
+    const result = await MemberController.getDelegatorsForMember(
+      activity.members.memberA as HexAddress,
+      { page: 1, pageSize: 10, sort: 'votingPower', order: 'desc' },
+      { network: NETWORK, pluginAddress: dep.tokenVoting as HexAddress },
+      {},
+    )
+
+    expect(result.data).to.have.lengthOf(3)
+    expect(result.data.map(d => d.address)).to.have.members([
+      activity.holders[1].address,
+      activity.holders[3].address,
+      activity.holders[4].address,
+    ])
+    for (const row of result.data) {
+      expect(row.transactionHash).to.exist
+      expect(row.blockNumber).to.be.a('number')
+      expect(row.blockTimestamp).to.be.a('number')
+    }
+    expect(result.metadata.totalRecords).to.equal(3)
+    expect(result.metadata.totalVotingPower).to.equal((160_000n * 10n ** 18n).toString())
+  })
+
+  it('querying an address with no delegators returns empty data + totalVotingPower="0"', async () => {
+    const orphan = '0x1111111111111111111111111111111111111111' as HexAddress
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(dep.token as HexAddress, NETWORK, orphan, {
+      sort: 'votingPower',
+      order: 'desc',
+    })
+
+    expect(result.data).to.have.lengthOf(0)
+    expect(result.metadata.totalRecords).to.equal(0)
+    expect(result.metadata.totalVotingPower).to.equal('0')
+  })
+
+  it('deployer self-delegation is queryable as their own delegator', async () => {
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      dep.deployer as HexAddress,
+      { sort: 'votingPower', order: 'desc' },
+    )
+
+    expect(result.data).to.have.lengthOf(1)
+    expect(result.data[0].address).to.equal(dep.deployer)
+    expect(result.metadata.totalVotingPower).to.equal((1_000_000n * 10n ** 18n).toString())
   })
 })

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -1,0 +1,191 @@
+import { Models } from '@dbModels'
+import { type HexAddress, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { resetFork } from '../helpers/anvilRpc'
+import { getAnvilProvider } from '../helpers/constants'
+import { startServices, stopServices, waitForIndexerCatchup } from '../helpers/services'
+import { runErc20DelegationActivity } from '../setups/erc20DelegationActivity'
+import { setupTokenVotingDao } from '../setups/tokenVotingDaoSetup'
+import type { Erc20DelegationActivityResult, TokenVotingDaoDeployment } from '../types/tokenVotingFixture'
+
+const NETWORK = NetworksEnum.ethereumMainnet
+const FORK_BLOCK = 24541643 // same as governanceRewards.spec.ts
+
+describe.skip('TokenVoting Delegators API — anvil ERC20 fixture', function () {
+  this.timeout(600_000)
+  this.slow(0)
+
+  let dep: TokenVotingDaoDeployment
+  let activity: Erc20DelegationActivityResult
+
+  before(async () => {
+    await resetFork(FORK_BLOCK)
+    const startBlock = await getAnvilProvider().getBlockNumber()
+
+    dep = await setupTokenVotingDao()
+
+    activity = await runErc20DelegationActivity(dep, {
+      holders: [
+        { amount: 100_000n * 10n ** 18n }, // holder0
+        { amount: 50_000n * 10n ** 18n }, // holder1
+        { amount: 25_000n * 10n ** 18n }, // holder2
+      ],
+      // memberA receives from holder0 + holder1, holder0 then re-delegates to memberC.
+      // memberB receives from holder2.
+      // Expected end state: memberA -> [holder1], memberB -> [holder2], memberC -> [holder0].
+      delegations: [
+        { fromHolder: 0, to: 'memberA' },
+        { fromHolder: 1, to: 'memberA' },
+        { fromHolder: 2, to: 'memberB' },
+        { fromHolder: 0, to: 'memberC' }, // re-delegation — latest event wins
+      ],
+    })
+
+    const latestBlock = await getAnvilProvider().getBlockNumber()
+    await startServices(startBlock)
+    await waitForIndexerCatchup(latestBlock, 180_000)
+  })
+
+  after(() => stopServices())
+
+  it('indexes the Plugin row with the deployed token address', async () => {
+    const plugin = await Models.Plugin.findOne({ network: NETWORK, address: dep.tokenVoting })
+    expect(plugin, `Plugin ${dep.tokenVoting} not found`).to.exist
+    expect(plugin!.tokenAddress).to.equal(dep.token)
+  })
+
+  it('indexes one LogDelegateChanged per delegate() call (incl. deployer self-delegate)', async () => {
+    const logs = await Models.LogDelegateChanged.find({
+      network: NETWORK,
+      tokenAddress: dep.token,
+    })
+    expect(logs.length, `expected ${activity.delegations.length + 1} delegate-changed logs`).to.equal(
+      activity.delegations.length + 1,
+    )
+  })
+
+  it('findDelegatorsForMember(memberA): only holder1 remains after holder0 re-delegation', async () => {
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberA as HexAddress,
+      { sort: 'votingPower', order: 'desc' },
+    )
+
+    expect(result.data, 'memberA should have exactly 1 delegator after re-delegation').to.have.lengthOf(1)
+    expect(result.data[0].address).to.equal(activity.holders[1].address)
+    // KNOWN LIMITATION: delegators' own TokenMember.votingPower is always '0' in realistic ERC20Votes flow
+    // because they delegated their VP away. The "amount delegated" intent of BE-202 is currently NOT
+    // captured by the aggregation. The TokenMember.votingPower of the *delegate target* (memberA) is
+    // what holds the total delegated VP — asserted separately below.
+    expect(result.data[0].votingPower).to.equal('0')
+
+    const matching = activity.delegations.find(
+      d => d.from === activity.holders[1].address && d.to === activity.members.memberA,
+    )
+    expect(matching, 'expected matching holder1 -> memberA delegation in activity').to.exist
+    expect(result.data[0].transactionHash).to.equal(matching!.transactionHash)
+    expect(result.data[0].blockNumber).to.equal(matching!.blockNumber)
+    expect(result.data[0].blockTimestamp).to.equal(matching!.blockTimestamp)
+  })
+
+  it('findDelegatorsForMember(memberC): holder0 with re-delegation event metadata', async () => {
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberC as HexAddress,
+      { sort: 'votingPower', order: 'desc' },
+    )
+
+    expect(result.data, 'memberC should have exactly 1 delegator (holder0 after re-delegation)').to.have.lengthOf(1)
+    expect(result.data[0].address).to.equal(activity.holders[0].address)
+    expect(result.data[0].votingPower).to.equal('0') // see KNOWN LIMITATION above
+
+    // Must match the LATEST delegation event (holder0 -> memberC), not the original holder0 -> memberA.
+    const reDelegation = activity.delegations.find(
+      d => d.from === activity.holders[0].address && d.to === activity.members.memberC,
+    )
+    expect(reDelegation, 'expected matching holder0 -> memberC re-delegation in activity').to.exist
+    expect(result.data[0].transactionHash).to.equal(reDelegation!.transactionHash)
+    expect(result.data[0].blockNumber).to.equal(reDelegation!.blockNumber)
+    expect(result.data[0].blockTimestamp).to.equal(reDelegation!.blockTimestamp)
+  })
+
+  it('findDelegatorsForMember(memberB): single holder2 row', async () => {
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberB as HexAddress,
+      { sort: 'votingPower', order: 'desc' },
+    )
+
+    expect(result.data, 'memberB should have exactly 1 delegator').to.have.lengthOf(1)
+    expect(result.data[0].address).to.equal(activity.holders[2].address)
+    expect(result.data[0].votingPower).to.equal('0') // see KNOWN LIMITATION above
+
+    const matching = activity.delegations.find(
+      d => d.from === activity.holders[2].address && d.to === activity.members.memberB,
+    )
+    expect(matching, 'expected matching holder2 -> memberB delegation in activity').to.exist
+    expect(result.data[0].transactionHash).to.equal(matching!.transactionHash)
+    expect(result.data[0].blockNumber).to.equal(matching!.blockNumber)
+    expect(result.data[0].blockTimestamp).to.equal(matching!.blockTimestamp)
+  })
+
+  it('pagination: pageSize=1 against memberA returns single row + correct totals', async () => {
+    // memberA has exactly 1 active delegator (holder1) after holder0's re-delegation.
+    // This asserts the pagination envelope (totalRecords, totalPages, data length).
+    const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+      dep.token as HexAddress,
+      NETWORK,
+      activity.members.memberA as HexAddress,
+      { sort: 'votingPower', order: 'desc', pageSize: 1 },
+    )
+
+    expect(result.data).to.have.lengthOf(1)
+    expect(result.metadata.totalRecords).to.equal(1)
+    expect(result.metadata.totalPages).to.equal(1)
+    expect(result.metadata.pageSize).to.equal(1)
+    expect(result.metadata.page).to.equal(1)
+  })
+
+  it('TokenMember rows for delegate targets reflect total VP delegated to each', async () => {
+    // After all delegations + re-delegation:
+    //   memberA receives holder1's 50K (holder0 re-delegated to memberC)
+    //   memberB receives holder2's 25K
+    //   memberC receives holder0's 100K (after re-delegation)
+    const cases: Array<{ member: string; expected: bigint }> = [
+      { member: activity.members.memberA, expected: 50_000n * 10n ** 18n },
+      { member: activity.members.memberB, expected: 25_000n * 10n ** 18n },
+      { member: activity.members.memberC, expected: 100_000n * 10n ** 18n },
+    ]
+
+    for (const { member, expected } of cases) {
+      const tokenMember = await Models.TokenMember.findOne({
+        network: NETWORK,
+        tokenAddress: dep.token,
+        memberAddress: member,
+      })
+      expect(tokenMember, `TokenMember row missing for delegate target ${member}`).to.exist
+      expect(tokenMember!.votingPower).to.equal(expected.toString())
+    }
+  })
+
+  it('metadata.totalVotingPower equals each TokenMember.votingPower across pages', async () => {
+    const cases: Array<{ member: string; expected: bigint }> = [
+      { member: activity.members.memberA, expected: 50_000n * 10n ** 18n },
+      { member: activity.members.memberB, expected: 25_000n * 10n ** 18n },
+      { member: activity.members.memberC, expected: 100_000n * 10n ** 18n },
+    ]
+
+    for (const { member, expected } of cases) {
+      const result = await Models.LogDelegateChanged.findDelegatorsForMember(
+        dep.token as HexAddress,
+        NETWORK,
+        member as HexAddress,
+        { sort: 'votingPower', order: 'desc', pageSize: 1 },
+      )
+      expect(result.metadata.totalVotingPower, `totalVotingPower for ${member}`).to.equal(expected.toString())
+    }
+  })
+})

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -11,7 +11,7 @@ import type { Erc20DelegationActivityResult, TokenVotingDaoDeployment } from '..
 const NETWORK = NetworksEnum.ethereumMainnet
 const FORK_BLOCK = 24541643 // same as governanceRewards.spec.ts
 
-describe.only('TokenVoting Delegators API — anvil ERC20 fixture', function () {
+describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
   this.timeout(600_000)
   this.slow(0)
 

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -11,7 +11,7 @@ import type { Erc20DelegationActivityResult, TokenVotingDaoDeployment } from '..
 const NETWORK = NetworksEnum.ethereumMainnet
 const FORK_BLOCK = 24541643 // same as governanceRewards.spec.ts
 
-describe.skip('TokenVoting Delegators API — anvil ERC20 fixture', function () {
+describe.only('TokenVoting Delegators API — anvil ERC20 fixture', function () {
   this.timeout(600_000)
   this.slow(0)
 

--- a/test/integration/types/tokenVotingFixture.ts
+++ b/test/integration/types/tokenVotingFixture.ts
@@ -1,0 +1,39 @@
+import type { ethers } from 'ethers'
+
+export interface TokenVotingDaoDeployment {
+  dao: string
+  tokenVoting: string
+  token: string
+  deployer: string
+  deployerWallet: ethers.HDNodeWallet
+}
+
+export interface HolderSpec {
+  amount: bigint
+}
+
+export type DelegationTarget = 'memberA' | 'memberB' | 'memberC'
+
+export interface DelegationSpec {
+  fromHolder: number // index into holders[]
+  to: DelegationTarget
+}
+
+export interface Erc20DelegationActivityConfig {
+  holders: HolderSpec[]
+  delegations: DelegationSpec[]
+}
+
+export interface ResolvedErc20Delegation {
+  from: string
+  to: string
+  transactionHash: string
+  blockNumber: number
+  blockTimestamp: number
+}
+
+export interface Erc20DelegationActivityResult {
+  holders: ethers.HDNodeWallet[]
+  members: { memberA: string; memberB: string; memberC: string }
+  delegations: ResolvedErc20Delegation[]
+}

--- a/test/unit/models/schema/lock.spec.ts
+++ b/test/unit/models/schema/lock.spec.ts
@@ -1027,6 +1027,9 @@ describe('Model: Lock', () => {
           delegateReceiverAddress: TARGET,
           amount: '1000000000000000000',
           epochStartAt: 1640995100,
+          blockNumber: 100,
+          blockTimestamp: 1000,
+          transactionHash: '0xowner1',
         }),
       )
       await Models.Lock.create(
@@ -1035,6 +1038,9 @@ describe('Model: Lock', () => {
           delegateReceiverAddress: TARGET,
           amount: '3000000000000000000',
           epochStartAt: 1640995000,
+          blockNumber: 110,
+          blockTimestamp: 1100,
+          transactionHash: '0xowner2',
         }),
       )
 
@@ -1049,18 +1055,31 @@ describe('Model: Lock', () => {
       expect(result.data).to.have.lengthOf(2)
       expect(result.data[0].address).to.equal(OWNER_2)
       expect(result.data[0].ens).to.be.null
+      expect(result.data[0].transactionHash).to.equal('0xowner2')
+      expect(result.data[0].blockNumber).to.equal(110)
+      expect(result.data[0].blockTimestamp).to.equal(1100)
       expect(result.data[1].address).to.equal(OWNER_1)
       expect(result.data[1].ens).to.equal('owner1.eth')
+      expect(result.data[1].transactionHash).to.equal('0xowner1')
+      expect(result.data[1].blockNumber).to.equal(100)
+      expect(result.data[1].blockTimestamp).to.equal(1000)
       expect(result.metadata.totalRecords).to.equal(2)
+      // totalVotingPower = sum across all rows
+      expect(result.metadata.totalVotingPower).to.equal(
+        (BigInt(result.data[0].votingPower) + BigInt(result.data[1].votingPower)).toString(),
+      )
     })
 
-    it('sums multiple active locks from the same owner into one entry', async () => {
+    it('sums multiple active locks from the same owner into one entry and surfaces the latest event', async () => {
       await Models.Lock.create(
         makeLock({
           memberAddress: OWNER_1,
           delegateReceiverAddress: TARGET,
           amount: '1000000000000000000',
           epochStartAt: 1640995100,
+          blockNumber: 100,
+          blockTimestamp: 1000,
+          transactionHash: '0xfirst',
         }),
       )
       await Models.Lock.create(
@@ -1069,6 +1088,9 @@ describe('Model: Lock', () => {
           delegateReceiverAddress: TARGET,
           amount: '2000000000000000000',
           epochStartAt: 1640995100,
+          blockNumber: 200,
+          blockTimestamp: 2000,
+          transactionHash: '0xlatest',
         }),
       )
 
@@ -1083,6 +1105,9 @@ describe('Model: Lock', () => {
       expect(result.data).to.have.lengthOf(1)
       expect(result.data[0].address).to.equal(OWNER_1)
       expect(Number(result.data[0].votingPower)).to.be.greaterThan(0)
+      expect(result.data[0].transactionHash).to.equal('0xlatest')
+      expect(result.data[0].blockNumber).to.equal(200)
+      expect(result.data[0].blockTimestamp).to.equal(2000)
     })
 
     it('excludes withdrawn and exited locks', async () => {

--- a/test/unit/models/schema/logDelegateChanged.spec.ts
+++ b/test/unit/models/schema/logDelegateChanged.spec.ts
@@ -413,6 +413,14 @@ describe('Model: LogDelegateChanged', () => {
     })
 
     it('should return delegators with voting power sorted desc', async () => {
+      // Seed BOB's TokenMember row so the wrapper-level totalVotingPower lookup hits.
+      await Models.TokenMember.create({
+        memberAddress: BOB,
+        tokenAddress: TOKEN_ADDRESS,
+        network: NETWORK,
+        votingPower: '8000',
+      })
+
       const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, BOB, {
         sort: 'votingPower',
         order: 'desc',
@@ -422,16 +430,26 @@ describe('Model: LogDelegateChanged', () => {
       expect(result.data[0].address).to.equal(ALICE)
       expect(result.data[0].votingPower).to.equal('5000')
       expect(result.data[0].ens).to.equal('alice.eth')
+      expect(result.data[0].transactionHash).to.equal('0xfd1')
+      expect(result.data[0].blockNumber).to.equal(100)
+      expect(result.data[0].blockTimestamp).to.equal(1000)
       expect(result.data[1].address).to.equal(JORDAN)
       expect(result.data[1].votingPower).to.equal('3000')
+      expect(result.data[1].transactionHash).to.equal('0xfd2')
+      expect(result.data[1].blockNumber).to.equal(110)
+      expect(result.data[1].blockTimestamp).to.equal(1100)
       expect(result.metadata.totalRecords).to.equal(2)
+      expect(result.metadata.totalVotingPower).to.equal('8000')
     })
 
     it('should return empty when no delegators', async () => {
-      const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, ALICE)
+      // Query an address with no TokenMember row so totalVotingPower defaults to '0'.
+      const orphan = '0x9999999999999999999999999999999999999999'
+      const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, orphan)
 
       expect(result.data).to.have.lengthOf(0)
       expect(result.metadata.totalRecords).to.equal(0)
+      expect(result.metadata.totalVotingPower).to.equal('0')
     })
 
     it('should respect re-delegation (latest record wins)', async () => {
@@ -448,12 +466,28 @@ describe('Model: LogDelegateChanged', () => {
         transactionIndex: 0,
         logIndex: 0,
       })
+      // JORDAN re-confirms delegation to BOB in a later block
+      await Models.LogDelegateChanged.create({
+        network: NETWORK,
+        tokenAddress: TOKEN_ADDRESS,
+        delegator: JORDAN,
+        fromDelegate: BOB,
+        toDelegate: BOB,
+        blockNumber: 210,
+        blockTimestamp: 2100,
+        transactionHash: '0xfd4',
+        transactionIndex: 0,
+        logIndex: 0,
+      })
 
       const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, BOB)
 
-      // Only JORDAN still delegates to BOB
+      // Only JORDAN still delegates to BOB, surfacing the latest event's tx/block/timestamp
       expect(result.data).to.have.lengthOf(1)
       expect(result.data[0].address).to.equal(JORDAN)
+      expect(result.data[0].transactionHash).to.equal('0xfd4')
+      expect(result.data[0].blockNumber).to.equal(210)
+      expect(result.data[0].blockTimestamp).to.equal(2100)
     })
 
     it('should paginate results', async () => {

--- a/test/unit/services/aragon-api/controllers/member.spec.ts
+++ b/test/unit/services/aragon-api/controllers/member.spec.ts
@@ -664,7 +664,6 @@ describe('Controller: Member', () => {
       const extraParams = {
         network: rawPlugin.network,
         pluginAddress: rawPlugin.address,
-        tokenAddress: rawPlugin.tokenAddress,
       }
       const paginationParams = { page: 1, pageSize: 10 }
       const mockResult = {


### PR DESCRIPTION
## 📝 Summary

This pull request introduces enhancements to the voting power and delegation APIs, primarily by enriching the returned data with blockchain context (transaction hash, block number, and timestamp) and exposing the total voting power in API responses. It also includes test and setup improvements for integration with Aragon DAOs and token voting plugins.

**API Enhancements:**

* The voting power and delegation endpoints now return additional blockchain context for each record: `transactionHash`, `blockNumber`, and `blockTimestamp`. This provides more transparency and traceability for each voting power entry or delegation. [[1]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840R444-R451) [[2]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840R499-R538) [[3]](diffhunk://#diff-a031c85a59034146a9e58d0afca55b94a1773f71146bf30311c9a8964b510315R121-R123) [[4]](diffhunk://#diff-a031c85a59034146a9e58d0afca55b94a1773f71146bf30311c9a8964b510315R228-R249) [[5]](diffhunk://#diff-56da1d200f822734c9b66206597b6cec9911d1ad396057f270a6f346ea0a95f4R112-R114)
* The API pagination metadata now includes a `totalVotingPower` field, making it easier for clients to display the total voting power across all records in a paginated result. [[1]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840R547) [[2]](diffhunk://#diff-a031c85a59034146a9e58d0afca55b94a1773f71146bf30311c9a8964b510315R258) [[3]](diffhunk://#diff-6c14874a4f3f3e60445b22378de3daf4990ef802cdd8add321dbe738b1f972b8R165)

**Codebase and Test Improvements:**

* Integration test setups have been expanded with new helpers for deploying token voting DAOs and simulating ERC20 delegation activities, facilitating more comprehensive end-to-end testing. [[1]](diffhunk://#diff-b226b0e829a8a492d572bcd9b4599386d10666f4dc11179229721d4426e7d481R1-R85) [[2]](diffhunk://#diff-065ad326afe1cad4586f37f846e472885c7d778b196ed6769be34d59646f2b05R1-R201)
* Test helpers have been updated to stub additional methods from the EVM explorer client, ensuring deterministic and isolated test runs. [[1]](diffhunk://#diff-47764c8d993a9235bb9eb4794f6e80218af4ca3dadbca907a536598888308c16R4) [[2]](diffhunk://#diff-47764c8d993a9235bb9eb4794f6e80218af4ca3dadbca907a536598888308c16R46-R52)

**Schema and Validation Adjustments:**

* The `tokenAddress` parameter has been removed from certain member-related API schemas and routers, likely to streamline the API and rely on implicit context or other parameters. [[1]](diffhunk://#diff-6c7169568c6c54c4639a1f1b1969eb28b84eaf69905e5eb6538a52336e3e69d9L74) [[2]](diffhunk://#diff-8abac3e5ec2e7752cf26779040b960c3815cad43d73cddf6212b36270ca05e3fL102)

**Other Minor Changes:**

* Minor import and assertion adjustments in model files to support the above changes.

These changes collectively improve the API's transparency, data richness, and testability, especially for clients tracking voting power and delegation events in Aragon DAOs.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [x] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
