### PR TITLE
feat(api): optimize delegators listing — two-pass log query + drop per-row VP math

### DIFF
--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -396,28 +396,39 @@ export default class Lock extends Model {
       slope: string
     }
   }): Promise<IPaginatedResult<IDelegatorResponse>> {
-    const request = ModelUtils.paginateAndSort({ ...paginationParams, sort: 'votingPower' })
+    const request = ModelUtils.paginateAndSort({ ...paginationParams, sort: 'blockNumber' })
     const currentPage = request.skip / request.limit + 1
 
+    const matchStage = {
+      $match: {
+        network,
+        tokenAddress,
+        delegateReceiverAddress: memberAddress,
+        'lockWithdraw.status': { $ne: true },
+        'lockExit.status': { $ne: true },
+      },
+    }
+
+    const preStageQuery: any[] = [
+      matchStage,
+      { $sort: { blockNumber: -1, blockTimestamp: -1 } },
+      {
+        $group: {
+          _id: '$memberAddress',
+          transactionHash: { $first: '$transactionHash' },
+          blockNumber: { $first: '$blockNumber' },
+          blockTimestamp: { $first: '$blockTimestamp' },
+        },
+      },
+    ]
+
     const baseQuery: any[] = [
+      matchStage,
       {
-        $match: {
-          network,
-          tokenAddress,
-          delegateReceiverAddress: memberAddress,
-          'lockWithdraw.status': { $ne: true },
-          'lockExit.status': { $ne: true },
-        },
+        $addFields: { activeTime: { $subtract: [settings.currentTime, '$epochStartAt'] } },
       },
       {
-        $addFields: {
-          activeTime: { $subtract: [settings.currentTime, '$epochStartAt'] },
-        },
-      },
-      {
-        $addFields: {
-          processedTime: { $min: ['$activeTime', settings.maxTime] },
-        },
+        $addFields: { processedTime: { $min: ['$activeTime', settings.maxTime] } },
       },
       {
         $addFields: {
@@ -436,47 +447,22 @@ export default class Lock extends Model {
       },
       {
         $addFields: {
-          rawVotingPower: {
-            $divide: [{ $add: ['$slopeComponent', '$biasComponent'] }, '$oneE18'],
-          },
+          rawVotingPower: { $divide: [{ $add: ['$slopeComponent', '$biasComponent'] }, '$oneE18'] },
         },
       },
-      { $sort: { blockNumber: -1, blockTimestamp: -1 } },
       {
         $group: {
           _id: '$memberAddress',
           votingPower: { $sum: '$rawVotingPower' },
-          transactionHash: { $first: '$transactionHash' },
-          blockNumber: { $first: '$blockNumber' },
-          blockTimestamp: { $first: '$blockTimestamp' },
         },
       },
     ]
 
     const dataQuery: any[] = [
-      ...baseQuery,
-      { $addFields: { id: '$_id' } }, // stable tie-break for paginateAndSort's secondary `id` key
-
+      ...preStageQuery,
       { $sort: request.sort },
       { $skip: request.skip },
       { $limit: request.limit },
-      {
-        $addFields: {
-          votingPowerString: {
-            $cond: {
-              if: { $eq: ['$votingPower', { $toDecimal: '0' }] },
-              then: '0',
-              else: {
-                $convert: {
-                  input: { $round: ['$votingPower', 0] },
-                  to: 'string',
-                  onError: { $toString: { $round: ['$votingPower', 0] } },
-                },
-              },
-            },
-          },
-        },
-      },
       {
         $lookup: {
           from: ICollectionNames.Member,
@@ -485,17 +471,12 @@ export default class Lock extends Model {
           as: 'memberInfo',
         },
       },
-      {
-        $addFields: {
-          memberInfo: { $arrayElemAt: ['$memberInfo', 0] },
-        },
-      },
+      { $addFields: { memberInfo: { $arrayElemAt: ['$memberInfo', 0] } } },
       {
         $project: {
           _id: 0,
           address: '$_id',
           ens: '$memberInfo.ens',
-          votingPower: '$votingPowerString',
           transactionHash: 1,
           blockNumber: 1,
           blockTimestamp: 1,
@@ -505,7 +486,7 @@ export default class Lock extends Model {
 
     const [data, totalRecords, totalVotingPowerAgg] = await Promise.all([
       this.aggregate(dataQuery).allowDiskUse(true),
-      this.aggregate([...baseQuery, { $count: 'totalRecords' }])
+      this.aggregate([...preStageQuery, { $count: 'totalRecords' }])
         .allowDiskUse(true)
         .then(results => (results[0] ? results[0].totalRecords : 0)),
       this.aggregate([

--- a/src/models/schema/logDelegateChanged.ts
+++ b/src/models/schema/logDelegateChanged.ts
@@ -222,7 +222,6 @@ export default class LogDelegateChanged extends Model {
           _id: 0,
           address: '$_id',
           ens: '$memberInfo.ens',
-          votingPower: { $ifNull: ['$tokenMember.votingPower', '0'] },
           transactionHash: 1,
           blockNumber: 1,
           blockTimestamp: 1,

--- a/src/modules/pairData.ts
+++ b/src/modules/pairData.ts
@@ -131,11 +131,6 @@ const PairDataModule = {
       }
     }
 
-    if (!extraParams?.tokenAddress && extraParams.pluginAddress) {
-      const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network!)
-      extraParams.tokenAddress = plugin?.tokenAddress ?? undefined
-    }
-
     if (extraParams?.lockManagerAddress && !extraParams.pluginAddress) {
       const plugin = await Models.Plugin.findOne(extraParams.lockManagerAddress, extraParams.network!)
       if (plugin) {

--- a/src/modules/pairData.ts
+++ b/src/modules/pairData.ts
@@ -131,6 +131,11 @@ const PairDataModule = {
       }
     }
 
+    if (!extraParams?.tokenAddress && extraParams.pluginAddress) {
+      const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network!)
+      extraParams.tokenAddress = plugin?.tokenAddress ?? undefined
+    }
+
     if (extraParams?.lockManagerAddress && !extraParams.pluginAddress) {
       const plugin = await Models.Plugin.findOne(extraParams.lockManagerAddress, extraParams.network!)
       if (plugin) {

--- a/src/services/aragon-api/controllers/member.ts
+++ b/src/services/aragon-api/controllers/member.ts
@@ -37,6 +37,9 @@ const MemberController = {
 
     const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network)
     assertExposable(plugin, ErrorKeyEnum.notFound)
+    // Derive tokenAddress from the plugin so downstream consumers (governance impls)
+    // that expect it on extraParams pick it up.
+    extraParams.tokenAddress ??= plugin.tokenAddress
 
     try {
       const governance = MemberGovernanceFactory.createFromPlugin(plugin)
@@ -77,9 +80,11 @@ const MemberController = {
       member.lastActive = activity.lastActivity
     }
 
-    if (extraParams.pluginAddress && extraParams.tokenAddress && extraParams.network) {
+    if (extraParams.pluginAddress && extraParams.network) {
       try {
         const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network)
+        // Derive tokenAddress from the plugin if the caller didn't pass it explicitly.
+        extraParams.tokenAddress ??= plugin?.tokenAddress
         if (plugin && member.metrics) {
           const governance = MemberGovernanceFactory.createFromPlugin(plugin)
           const delegationCounts = await governance.countDelegatorsForMembers([address])
@@ -139,6 +144,7 @@ const MemberController = {
 
     const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network)
     assertExposable(plugin, ErrorKeyEnum.notFound)
+    extraParams.tokenAddress ??= plugin.tokenAddress
 
     try {
       const governance = MemberGovernanceFactory.createFromPlugin(plugin)

--- a/src/services/aragon-api/controllers/member.ts
+++ b/src/services/aragon-api/controllers/member.ts
@@ -76,6 +76,7 @@ const MemberController = {
       member.firstActive = activity.firstActivity
       member.lastActive = activity.lastActivity
     }
+
     if (extraParams.pluginAddress && extraParams.tokenAddress && extraParams.network) {
       try {
         const plugin = await Models.Plugin.findByAddress(extraParams.pluginAddress, extraParams.network)

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -101,7 +101,8 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       activity.holders[4].address,
     ])
     expect(addrs).to.not.include(activity.holders[0].address) // re-delegated away
-    for (const row of result.data) expect(row.votingPower).to.equal('0')
+    // Per-row votingPower has been removed from the response.
+    for (const row of result.data) expect((row as any).votingPower).to.be.undefined
 
     // Per-row tx/block/timestamp must match the matching delegation in activity for each holder.
     for (const row of result.data) {
@@ -123,7 +124,8 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
 
     expect(result.data, 'memberC should have exactly 1 delegator (holder0 after re-delegation)').to.have.lengthOf(1)
     expect(result.data[0].address).to.equal(activity.holders[0].address)
-    expect(result.data[0].votingPower).to.equal('0')
+    // Per-row votingPower has been removed from the response.
+    expect((result.data[0] as any).votingPower).to.be.undefined
 
     const reDelegation = activity.delegations.find(
       d => d.from === activity.holders[0].address && d.to === activity.members.memberC,

--- a/test/unit/models/schema/lock.spec.ts
+++ b/test/unit/models/schema/lock.spec.ts
@@ -1063,11 +1063,11 @@ describe('Model: Lock', () => {
       expect(result.data[1].transactionHash).to.equal('0xowner1')
       expect(result.data[1].blockNumber).to.equal(100)
       expect(result.data[1].blockTimestamp).to.equal(1000)
+      expect((result.data[0] as any).votingPower).to.be.undefined
+      expect((result.data[1] as any).votingPower).to.be.undefined
       expect(result.metadata.totalRecords).to.equal(2)
-      // totalVotingPower = sum across all rows
-      expect(result.metadata.totalVotingPower).to.equal(
-        (BigInt(result.data[0].votingPower) + BigInt(result.data[1].votingPower)).toString(),
-      )
+      expect(result.metadata.totalVotingPower).to.be.a('string')
+      expect(BigInt(result.metadata.totalVotingPower!) > BigInt(0)).to.equal(true)
     })
 
     it('sums multiple active locks from the same owner into one entry and surfaces the latest event', async () => {
@@ -1104,10 +1104,11 @@ describe('Model: Lock', () => {
 
       expect(result.data).to.have.lengthOf(1)
       expect(result.data[0].address).to.equal(OWNER_1)
-      expect(Number(result.data[0].votingPower)).to.be.greaterThan(0)
+      expect((result.data[0] as any).votingPower).to.be.undefined
       expect(result.data[0].transactionHash).to.equal('0xlatest')
       expect(result.data[0].blockNumber).to.equal(200)
       expect(result.data[0].blockTimestamp).to.equal(2000)
+      expect(BigInt(result.metadata.totalVotingPower!) > BigInt(0)).to.equal(true)
     })
 
     it('excludes withdrawn and exited locks', async () => {
@@ -1163,7 +1164,7 @@ describe('Model: Lock', () => {
       expect(result.metadata.totalRecords).to.equal(0)
     })
 
-    it('returns zero voting power as "0" string', async () => {
+    it('returns "0" totalVotingPower in metadata when amount is zero', async () => {
       await Models.Lock.create(
         makeLock({
           memberAddress: OWNER_1,
@@ -1182,7 +1183,8 @@ describe('Model: Lock', () => {
       })
 
       expect(result.data).to.have.lengthOf(1)
-      expect(result.data[0].votingPower).to.equal('0')
+      expect((result.data[0] as any).votingPower).to.be.undefined
+      expect(result.metadata.totalVotingPower).to.equal('0')
     })
 
     it('returns empty paginated response when no locks exist for the member', async () => {

--- a/test/unit/models/schema/logDelegateChanged.spec.ts
+++ b/test/unit/models/schema/logDelegateChanged.spec.ts
@@ -412,8 +412,7 @@ describe('Model: LogDelegateChanged', () => {
       await Models.Member.create({ address: JORDAN, ens: null })
     })
 
-    it('should return delegators with voting power sorted desc', async () => {
-      // Seed BOB's TokenMember row so the wrapper-level totalVotingPower lookup hits.
+    it('should return delegators with ens, sorted', async () => {
       await Models.TokenMember.create({
         memberAddress: BOB,
         tokenAddress: TOKEN_ADDRESS,
@@ -421,23 +420,23 @@ describe('Model: LogDelegateChanged', () => {
         votingPower: '8000',
       })
 
-      const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, BOB, {
-        sort: 'votingPower',
-        order: 'desc',
-      })
+      const result = await Models.LogDelegateChanged.findDelegatorsForMember(TOKEN_ADDRESS, NETWORK, BOB)
 
       expect(result.data).to.have.lengthOf(2)
-      expect(result.data[0].address).to.equal(ALICE)
-      expect(result.data[0].votingPower).to.equal('5000')
-      expect(result.data[0].ens).to.equal('alice.eth')
-      expect(result.data[0].transactionHash).to.equal('0xfd1')
-      expect(result.data[0].blockNumber).to.equal(100)
-      expect(result.data[0].blockTimestamp).to.equal(1000)
-      expect(result.data[1].address).to.equal(JORDAN)
-      expect(result.data[1].votingPower).to.equal('3000')
-      expect(result.data[1].transactionHash).to.equal('0xfd2')
-      expect(result.data[1].blockNumber).to.equal(110)
-      expect(result.data[1].blockTimestamp).to.equal(1100)
+      const addresses = result.data.map((d: any) => d.address)
+      expect(addresses).to.include.members([ALICE, JORDAN])
+      const alice = result.data.find((d: any) => d.address === ALICE)!
+      expect(alice.ens).to.equal('alice.eth')
+      expect(alice.transactionHash).to.equal('0xfd1')
+      expect(alice.blockNumber).to.equal(100)
+      expect(alice.blockTimestamp).to.equal(1000)
+      const jordan = result.data.find((d: any) => d.address === JORDAN)!
+      expect(jordan.transactionHash).to.equal('0xfd2')
+      expect(jordan.blockNumber).to.equal(110)
+      expect(jordan.blockTimestamp).to.equal(1100)
+      // Per-row votingPower has been removed from the response.
+      expect((alice as any).votingPower).to.be.undefined
+      expect((jordan as any).votingPower).to.be.undefined
       expect(result.metadata.totalRecords).to.equal(2)
       expect(result.metadata.totalVotingPower).to.equal('8000')
     })

--- a/test/unit/modules/pairData.spec.ts
+++ b/test/unit/modules/pairData.spec.ts
@@ -237,17 +237,17 @@ describe('Modules:PairData', () => {
     })
 
     it('should not override pluginAddress when already provided with lockManagerAddress', async () => {
-      // This ensures lines 127-130 aren't executed when pluginAddress exists
       const extraParams = {
         lockManagerAddress: '0xLockManager',
         pluginAddress: '0xExistingPlugin',
         network: NetworksEnum.ethereumMainnet,
       } as any
-      const findOneStub = sandbox.stub(Models.Plugin, 'findOne')
+      const findOneStub = sandbox.stub(Models.Plugin, 'findOne').resolves(undefined)
 
       const result = await PairDataModule.pairFromExtraParams(extraParams)
 
-      expect(findOneStub.notCalled).to.be.true
+      const calledWithLockManager = findOneStub.getCalls().some(c => c.args[0] === '0xLockManager')
+      expect(calledWithLockManager).to.equal(false)
       expect(result.pluginAddress).to.equal('0xExistingPlugin')
     })
   })


### PR DESCRIPTION
## 📝 Summary


This pull request refactors how voting power is handled and returned in the API responses for locks and delegators. The main change is the removal of the per-row `votingPower` field from the data results, standardizing voting power reporting to only appear in metadata. Sorting and aggregation logic has also been updated, and tests have been adjusted accordingly. Additionally, there are improvements to how `tokenAddress` is derived from plugin information in some modules.

**API Response and Aggregation Refactor:**

* Removed the `votingPower` field from individual entries in the response data for both `Lock` and `LogDelegateChanged` models; voting power is now reported only in the `metadata.totalVotingPower` field. [[1]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840L488-L498) [[2]](diffhunk://#diff-a031c85a59034146a9e58d0afca55b94a1773f71146bf30311c9a8964b510315L225) [[3]](diffhunk://#diff-6bbdf5e105b225e9a915744ee15cc1067112ff869d7d16a8f1e27b8f629c953eL415-R439) [[4]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fR1066-R1070) [[5]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fL1107-R1111) [[6]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fL1185-R1187)
* Changed aggregation queries to group and sort by `blockNumber` instead of `votingPower`, and adjusted the aggregation pipeline to align with the new response structure. [[1]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840L399-R431) [[2]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840L439-L479) [[3]](diffhunk://#diff-aea3cddbafab6b3bfc794da6ce8936a269a8c62d615cfb69634739fbdfa22840L508-R489)

**Test Updates:**

* Updated unit tests to expect the absence of per-row `votingPower` and to verify that `metadata.totalVotingPower` is a string and correct. Also clarified test descriptions to reflect the new response format. [[1]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fR1066-R1070) [[2]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fL1107-R1111) [[3]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fL1166-R1167) [[4]](diffhunk://#diff-f76d723d706ed3e952dcd92327d8f142bc8e0459b50b86f1c67f8a238353134fL1185-R1187) [[5]](diffhunk://#diff-6bbdf5e105b225e9a915744ee15cc1067112ff869d7d16a8f1e27b8f629c953eL415-R439)

**Parameter Handling Improvements:**

* Improved logic in `pairData.ts` to derive `tokenAddress` from a plugin when only `pluginAddress` is provided in `extraParams`.
* Ensured that `findOne` is not called when both `lockManagerAddress` and `pluginAddress` are present, with corresponding test updates.

**Minor Code Cleanups:**

* Small formatting and whitespace adjustments for consistency.

These changes standardize the way voting power is reported and simplify the API responses, making the data model more consistent and easier to maintain.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
