### PR TITLE
feat(ipfs): add support for Pinata public gateway and enhance metadata fetch logic

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -563,6 +563,14 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
       DWEB_GATEWAY_URI: (
         utils.configParser(sourceConfig, 'string', 'IPFS_DWEB_GATEWAY_URI', 'https://dweb.link/ipfs') as string
       ).replace(/\/+$/, ''),
+      PINATA_PUBLIC_GATEWAY_URI: (
+        utils.configParser(
+          sourceConfig,
+          'string',
+          'IPFS_PINATA_PUBLIC_GATEWAY_URI',
+          'https://gateway.pinata.cloud/ipfs',
+        ) as string
+      ).replace(/\/+$/, ''),
     },
 
     RETRY_REQUEST: {

--- a/src/modules/ipfs.ts
+++ b/src/modules/ipfs.ts
@@ -68,6 +68,15 @@ const IPFSModule = {
       })
     }
 
+    // fallback to Pinata's public gateway (unauthenticated, serves content not pinned by our org)
+    if (!data && getRemainingTimeout() > 0) {
+      data = await IPFSModule._fetchMetadataPinataPublic(cid, {
+        retries: opts?.retries,
+        delay: opts?.delay,
+        timeout: getRemainingTimeout(),
+      })
+    }
+
     if (data?.avatar?.path) {
       data.avatar = data.avatar.path
     }
@@ -92,6 +101,10 @@ const IPFSModule = {
     return IPFSModule._fetchFromGateway(cid, config.IPFS.DWEB_GATEWAY_URI, opts)
   },
 
+  _fetchMetadataPinataPublic: async (cid: string, opts?: { retries?: number; delay?: number; timeout?: number }) => {
+    return IPFSModule._fetchFromGateway(cid, config.IPFS.PINATA_PUBLIC_GATEWAY_URI, opts)
+  },
+
   _fetchFromGateway: async (
     cid: string,
     gatewayUri: string,
@@ -112,13 +125,11 @@ const IPFSModule = {
             })
 
             if (!response.ok) {
-              // Skip retry on permanent client errors (4xx), except 408/429 which are transient
-              if (
-                response.status >= 400 &&
-                response.status < 500 &&
-                response.status !== 408 &&
-                response.status !== 429
-              ) {
+              const isPermanent4xx =
+                response.status >= 400 && response.status < 500 && response.status !== 408 && response.status !== 429
+              const isGatewayDown = response.status === 502 || response.status === 503 || response.status === 504
+
+              if (isPermanent4xx || isGatewayDown) {
                 return null
               }
               throw new Error(`HTTP error! Status: ${response.status}`)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -182,6 +182,7 @@ export interface IConfig {
     METADATA_REFETCH_INTERVAL_MS: number
     PUBLIC_GATEWAY_URI: string
     DWEB_GATEWAY_URI: string
+    PINATA_PUBLIC_GATEWAY_URI: string
   }
 
   RETRY_REQUEST: {

--- a/test/unit/modules/ipfs.spec.ts
+++ b/test/unit/modules/ipfs.spec.ts
@@ -167,7 +167,7 @@ describe('Modules: IPFS', () => {
         const stubFetch = sandbox
           .stub(global, 'fetch')
           .onFirstCall()
-          .resolves({ ok: false, status: 503 } as any)
+          .resolves({ ok: false, status: 500 } as any)
           .onSecondCall()
           .resolves({ ok: true, json: async () => expectedMetadata } as any)
 
@@ -175,6 +175,31 @@ describe('Modules: IPFS', () => {
 
         expect(result).to.deep.equal(expectedMetadata)
         expect(stubFetch.calledTwice).to.be.true
+      } finally {
+        config.IPFS.METADATA_FETCH_RETRY = metadatafetchretry
+        config.IPFS.METADATA_FETCH_DELAY = metadatafetchdelay
+      }
+    })
+
+    it('should return null without retrying on gateway-down statuses (502/503/504)', async () => {
+      const metadatafetchretry = config.IPFS.METADATA_FETCH_RETRY
+      const metadatafetchdelay = config.IPFS.METADATA_FETCH_DELAY
+
+      try {
+        config.IPFS.METADATA_FETCH_RETRY = 3
+        config.IPFS.METADATA_FETCH_DELAY = 0
+
+        const stubFetch = sandbox.stub(global, 'fetch')
+
+        for (const status of [502, 503, 504]) {
+          stubFetch.resetHistory()
+          stubFetch.resolves({ ok: false, status } as any)
+
+          const result = await IPFSModule._fetchMetadataDweb('cid')
+
+          expect(result).to.be.null
+          expect(stubFetch.callCount, `status ${status} should not retry`).to.eq(1)
+        }
       } finally {
         config.IPFS.METADATA_FETCH_RETRY = metadatafetchretry
         config.IPFS.METADATA_FETCH_DELAY = metadatafetchdelay
@@ -226,11 +251,31 @@ describe('Modules: IPFS', () => {
       sandbox.stub(PinataHelper, 'getData').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadata').resolves(null)
       const stubFetchMetadataDweb = sandbox.stub(IPFSModule, '_fetchMetadataDweb').resolves(expectedMetadata)
+      const stubFetchMetadataPinataPublic = sandbox.stub(IPFSModule, '_fetchMetadataPinataPublic')
 
       const result = await IPFSModule.fetchMetadata(cidV0)
 
       expect(stubFetchMetadataDweb.calledOnce).to.be.true
       expect(stubFetchMetadataDweb.firstCall.args[0]).to.eq('QmRQuyzUN2EBJAj1cD5WujkrDRhNByD46t4ZorMuvTbuGM')
+      expect(stubFetchMetadataPinataPublic.called).to.be.false
+      expect(result).to.deep.equal(expectedMetadata)
+    })
+
+    it('should fallback to public Pinata gateway when Pinata, ipfs.io and dweb.link all fail', async function () {
+      const cidV0 = 'ipfs://QmRQuyzUN2EBJAj1cD5WujkrDRhNByD46t4ZorMuvTbuGM'
+      const expectedMetadata = { name: 'Example from public Pinata' }
+
+      sandbox.stub(PinataHelper, 'getData').resolves(null)
+      sandbox.stub(IPFSModule, '_fetchMetadata').resolves(null)
+      sandbox.stub(IPFSModule, '_fetchMetadataDweb').resolves(null)
+      const stubFetchMetadataPinataPublic = sandbox
+        .stub(IPFSModule, '_fetchMetadataPinataPublic')
+        .resolves(expectedMetadata)
+
+      const result = await IPFSModule.fetchMetadata(cidV0)
+
+      expect(stubFetchMetadataPinataPublic.calledOnce).to.be.true
+      expect(stubFetchMetadataPinataPublic.firstCall.args[0]).to.eq('QmRQuyzUN2EBJAj1cD5WujkrDRhNByD46t4ZorMuvTbuGM')
       expect(result).to.deep.equal(expectedMetadata)
     })
 
@@ -301,6 +346,7 @@ describe('Modules: IPFS', () => {
       sandbox.stub(PinataHelper, 'getData').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadata').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadataDweb').resolves(null)
+      sandbox.stub(IPFSModule, '_fetchMetadataPinataPublic').resolves(null)
       const onFetchFailedStub = sandbox.stub().resolves()
 
       const result = await IPFSModule.fetchMetadata(cidV0, { onFetchFailed: onFetchFailedStub })
@@ -328,6 +374,7 @@ describe('Modules: IPFS', () => {
       sandbox.stub(PinataHelper, 'getData').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadata').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadataDweb').resolves(null)
+      sandbox.stub(IPFSModule, '_fetchMetadataPinataPublic').resolves(null)
       const onFetchFailedStub = sandbox.stub().rejects(new Error('Callback error'))
       const loggerErrorStub = sandbox.stub(logger, 'error')
 
@@ -344,6 +391,7 @@ describe('Modules: IPFS', () => {
       sandbox.stub(PinataHelper, 'getData').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadata').resolves(null)
       sandbox.stub(IPFSModule, '_fetchMetadataDweb').resolves(null)
+      sandbox.stub(IPFSModule, '_fetchMetadataPinataPublic').resolves(null)
 
       // Should not throw when callback is not provided
       const result = await IPFSModule.fetchMetadata(cidV0)
@@ -361,6 +409,7 @@ describe('Modules: IPFS', () => {
         const stubPinataGetData = sandbox.stub(PinataHelper, 'getData')
         const stubFetchMetadata = sandbox.stub(IPFSModule, '_fetchMetadata')
         const stubFetchMetadataDweb = sandbox.stub(IPFSModule, '_fetchMetadataDweb')
+        const stubFetchMetadataPinataPublic = sandbox.stub(IPFSModule, '_fetchMetadataPinataPublic')
 
         const result = await IPFSModule.fetchMetadata(cidV0)
 
@@ -368,6 +417,7 @@ describe('Modules: IPFS', () => {
         expect(stubPinataGetData.called).to.be.false
         expect(stubFetchMetadata.called).to.be.false
         expect(stubFetchMetadataDweb.called).to.be.false
+        expect(stubFetchMetadataPinataPublic.called).to.be.false
       } finally {
         config.IPFS.METADATA_FETCH_TOTAL_TIMEOUT = totalTimeout
       }


### PR DESCRIPTION
## 📝 Summary

This pull request enhances the IPFS metadata fetching logic by introducing a fallback to Pinata's public gateway and improving error handling for gateway-down scenarios. It also updates the configuration and adds comprehensive unit tests to ensure the new logic works as intended.

**IPFS Gateway Fallback Improvements:**

- Added support for using Pinata's public IPFS gateway (`https://gateway.pinata.cloud/ipfs`) as a final fallback when other gateways (Pinata, ipfs.io, dweb.link) fail to return metadata. This is configurable via `PINATA_PUBLIC_GATEWAY_URI`. [[1]](diffhunk://#diff-e2ecc8e5133f2fbd80e6d9d5ae7dd923894f56b17f362af076a49b5aae96f492R566-R573) [[2]](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aR185) [[3]](diffhunk://#diff-1527348c7f1562d83b6b00e937a1c408cda54d2020ce004fd9f4c59679e13c2bR71-R79) [[4]](diffhunk://#diff-1527348c7f1562d83b6b00e937a1c408cda54d2020ce004fd9f4c59679e13c2bR104-R107)

**Error Handling Enhancements:**

- Modified the retry logic in `_fetchFromGateway` to immediately return `null` (without retrying) on gateway-down HTTP statuses (502, 503, 504), in addition to existing handling for permanent 4xx errors.

**Unit Test Coverage:**

- Added and updated unit tests to verify:
  - The fallback to Pinata's public gateway works correctly when all other gateways fail.
  - Gateway-down statuses (502/503/504) do not trigger retries.
  - The new logic integrates smoothly with existing error and callback handling. [[1]](diffhunk://#diff-7c80467943cf8365d9374845bf0bf1bdf0615a9decfd21c1ae82c89d463ee91bR349) [[2]](diffhunk://#diff-7c80467943cf8365d9374845bf0bf1bdf0615a9decfd21c1ae82c89d463ee91bR377) [[3]](diffhunk://#diff-7c80467943cf8365d9374845bf0bf1bdf0615a9decfd21c1ae82c89d463ee91bR394) [[4]](diffhunk://#diff-7c80467943cf8365d9374845bf0bf1bdf0615a9decfd21c1ae82c89d463ee91bR412-R420)
  - Adjusted an existing test to use a 500 status instead of 503 to align with the new gateway-down logic.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
