### PR TITLE
fix(crawlers): reset crawling flag in finally to prevent stuck re-entry

### DIFF
--- a/src/modules/crawlers/blockchainLogCrawler.ts
+++ b/src/modules/crawlers/blockchainLogCrawler.ts
@@ -125,150 +125,151 @@ class BlockchainLogCrawler {
     }
 
     this.crawlSetting.crawling = true
-    let isExistingSync = true
-    if (this.crawlParams.logService) {
-      const { block, isExisting } = await this.getServiceStartBlock()
-      this.crawlSetting.filter.fromBlock = block || this.crawlSetting.filter.fromBlock
-      isExistingSync = isExisting
-    }
-
-    let currentBlock = await Web3Helper.getBlockNumber(this.crawlSetting.filter.fromBlock, this.crawlParams.network)
-    let latestBlock = await Web3Helper.getBlockNumber(this.crawlSetting.filter.toBlock, this.crawlParams.network)
-    latestBlock = this.getOffsetToBlockNumber(latestBlock)
-
-    const rawLogs: IFormattedLog[] = []
-    let allLogs: Log[] = []
-
-    if (isExistingSync && currentBlock === latestBlock) {
-      this.crawlSetting.crawling = false
-      return rawLogs
-    }
-
-    logger.verbose(
-      'Starting crawling logs',
-      llo({
-        ...this.parseCrawlerInfoLog(),
-        currentBlock,
-        latestBlock,
-      }),
-    )
-
-    this.crawlParams.strategy = this.getStrategyBySituation(currentBlock, latestBlock)
-
-    let retryCount = 0
-    while (await this.updateAndCheckConditions(currentBlock, latestBlock)) {
-      this.crawlSetting.runCount++
-
-      if (retryCount >= 1 && this.crawlParams.strategy === ICrawStrategy.getLogsWithoutTopics) {
-        this.crawlParams.strategy = ICrawStrategy.getLogsByBatch
+    try {
+      let isExistingSync = true
+      if (this.crawlParams.logService) {
+        const { block, isExisting } = await this.getServiceStartBlock()
+        this.crawlSetting.filter.fromBlock = block || this.crawlSetting.filter.fromBlock
+        isExistingSync = isExisting
       }
 
-      try {
-        const result: any = await this.getLogsByStrategy(currentBlock, latestBlock)
+      let currentBlock = await Web3Helper.getBlockNumber(this.crawlSetting.filter.fromBlock, this.crawlParams.network)
+      let latestBlock = await Web3Helper.getBlockNumber(this.crawlSetting.filter.toBlock, this.crawlParams.network)
+      latestBlock = this.getOffsetToBlockNumber(latestBlock)
 
-        const toBlock = result.toBlock
-        allLogs = result.logs
+      const rawLogs: IFormattedLog[] = []
+      let allLogs: Log[] = []
 
-        if (this.crawlSetting.shutdown) break
+      if (isExistingSync && currentBlock === latestBlock) {
+        return rawLogs
+      }
 
-        this.crawlSetting.nbTotal += allLogs.length
-        const sortedLogs = this.logProcessingEngine.sortLogs(allLogs)
+      logger.verbose(
+        'Starting crawling logs',
+        llo({
+          ...this.parseCrawlerInfoLog(),
+          currentBlock,
+          latestBlock,
+        }),
+      )
 
-        if (sortedLogs.length === 0) {
+      this.crawlParams.strategy = this.getStrategyBySituation(currentBlock, latestBlock)
+
+      let retryCount = 0
+      while (await this.updateAndCheckConditions(currentBlock, latestBlock)) {
+        this.crawlSetting.runCount++
+
+        if (retryCount >= 1 && this.crawlParams.strategy === ICrawStrategy.getLogsWithoutTopics) {
+          this.crawlParams.strategy = ICrawStrategy.getLogsByBatch
+        }
+
+        try {
+          const result: any = await this.getLogsByStrategy(currentBlock, latestBlock)
+
+          const toBlock = result.toBlock
+          allLogs = result.logs
+
+          if (this.crawlSetting.shutdown) break
+
+          this.crawlSetting.nbTotal += allLogs.length
+          const sortedLogs = this.logProcessingEngine.sortLogs(allLogs)
+
+          if (sortedLogs.length === 0) {
+            logger.verbose(
+              'Processing log',
+              llo({
+                ...this.parseCrawlerInfoLog(),
+                blockNumber: toBlock,
+                fromBlock: currentBlock,
+                strategy: this.crawlParams.strategy,
+                toBlock,
+                latestBlock,
+              }),
+            )
+          } else if (!this.crawlParams.skipLogProcessing) {
+            const parallelConfig = this.getParallelConfig(sortedLogs.length)
+
+            this.logProcessingEngine.updateTotalCount(sortedLogs.length)
+
+            const context = {
+              fromBlock: currentBlock,
+              toBlock,
+              latestBlock,
+            }
+
+            if (parallelConfig.enable) {
+              parallelConfig.useBatch
+                ? await this.logProcessingEngine.processLogsParallelBatch(
+                    sortedLogs,
+                    context,
+                    parallelConfig,
+                    this.crawlParams.strategy,
+                  )
+                : await this.logProcessingEngine.processLogsParallel(
+                    sortedLogs,
+                    context,
+                    parallelConfig,
+                    this.crawlParams.strategy,
+                    Array.isArray(this.crawlParams.address)
+                      ? this.crawlParams.address.join(',')
+                      : this.crawlParams.address,
+                    this.crawlParams.logService || undefined,
+                  )
+            } else {
+              await this.logProcessingEngine.processLogs(
+                sortedLogs,
+                context,
+                this.crawlParams.strategy,
+                Array.isArray(this.crawlParams.address) ? this.crawlParams.address.join(',') : this.crawlParams.address,
+                this.crawlParams.logService || undefined,
+              )
+            }
+
+            const stats = this.logProcessingEngine.getProcessingStats()
+            this.crawlSetting.nbSuccess = stats.nbSuccess
+            this.crawlSetting.nbError = stats.nbError
+            this.crawlSetting.nbTotal = stats.nbTotal
+            this.crawlSetting.lastSync = stats.lastSync
+          } else {
+            sortedLogs?.map(log => rawLogs.push(this.logProcessingEngine.formatLog(log)))
+          }
+
+          if (this.crawlParams.logService && !this.crawlParams.skipLogProcessing) {
+            await this.onSaveProgress(toBlock)
+          }
+
+          if (this.crawlSetting.shutdown) break
+          currentBlock = toBlock + 1
+
+          const newBatchSize = this.adaptiveBatchManager.resetForNextRange()
+          this.crawlSetting.batchSize = newBatchSize
           logger.verbose(
-            'Processing log',
+            'Reset batch size for next range',
             llo({
               ...this.parseCrawlerInfoLog(),
-              blockNumber: toBlock,
-              fromBlock: currentBlock,
-              strategy: this.crawlParams.strategy,
-              toBlock,
+              newBatchSize,
+              currentBlock,
               latestBlock,
             }),
           )
-        } else if (!this.crawlParams.skipLogProcessing) {
-          const parallelConfig = this.getParallelConfig(sortedLogs.length)
 
-          this.logProcessingEngine.updateTotalCount(sortedLogs.length)
-
-          const context = {
-            fromBlock: currentBlock,
-            toBlock,
-            latestBlock,
-          }
-
-          if (parallelConfig.enable) {
-            parallelConfig.useBatch
-              ? await this.logProcessingEngine.processLogsParallelBatch(
-                  sortedLogs,
-                  context,
-                  parallelConfig,
-                  this.crawlParams.strategy,
-                )
-              : await this.logProcessingEngine.processLogsParallel(
-                  sortedLogs,
-                  context,
-                  parallelConfig,
-                  this.crawlParams.strategy,
-                  Array.isArray(this.crawlParams.address)
-                    ? this.crawlParams.address.join(',')
-                    : this.crawlParams.address,
-                  this.crawlParams.logService || undefined,
-                )
-          } else {
-            await this.logProcessingEngine.processLogs(
-              sortedLogs,
-              context,
-              this.crawlParams.strategy,
-              Array.isArray(this.crawlParams.address) ? this.crawlParams.address.join(',') : this.crawlParams.address,
-              this.crawlParams.logService || undefined,
-            )
-          }
-
-          const stats = this.logProcessingEngine.getProcessingStats()
-          this.crawlSetting.nbSuccess = stats.nbSuccess
-          this.crawlSetting.nbError = stats.nbError
-          this.crawlSetting.nbTotal = stats.nbTotal
-          this.crawlSetting.lastSync = stats.lastSync
-        } else {
-          sortedLogs?.map(log => rawLogs.push(this.logProcessingEngine.formatLog(log)))
+          if (currentBlock >= latestBlock) break
+        } catch (error) {
+          retryCount++
+          await this.handleErrors(error)
+          if (this.crawlParams.stopOnError && this.crawlSetting.shutdown) break
         }
-
-        if (this.crawlParams.logService && !this.crawlParams.skipLogProcessing) {
-          await this.onSaveProgress(toBlock)
-        }
-
-        if (this.crawlSetting.shutdown) break
-        currentBlock = toBlock + 1
-
-        const newBatchSize = this.adaptiveBatchManager.resetForNextRange()
-        this.crawlSetting.batchSize = newBatchSize
-        logger.verbose(
-          'Reset batch size for next range',
-          llo({
-            ...this.parseCrawlerInfoLog(),
-            newBatchSize,
-            currentBlock,
-            latestBlock,
-          }),
-        )
-
-        if (currentBlock >= latestBlock) break
-      } catch (error) {
-        retryCount++
-        await this.handleErrors(error)
-        if (this.crawlParams.stopOnError && this.crawlSetting.shutdown) break
       }
-    }
 
-    if (this.crawlParams.skipLogProcessing) {
+      if (this.crawlParams.skipLogProcessing) {
+        return rawLogs
+      }
+
+      if (!this.crawlParams.filterLogs) {
+        logger.verbose('Finished crawling logs', llo({ ...this.parseCrawlerInfoLog() }))
+      }
+    } finally {
       this.crawlSetting.crawling = false
-      return rawLogs
-    }
-
-    this.crawlSetting.crawling = false
-    if (!this.crawlParams.filterLogs) {
-      logger.verbose('Finished crawling logs', llo({ ...this.parseCrawlerInfoLog() }))
     }
   }
 

--- a/test/unit/modules/blockchainLogCrawler.spec.ts
+++ b/test/unit/modules/blockchainLogCrawler.spec.ts
@@ -135,6 +135,68 @@ describe('Module: blockchainLogCrawler', () => {
       }
     })
 
+    it('should reset crawling flag and allow re-entry when getServiceStartBlock throws', async () => {
+      const crawler = new BlockchainLogCrawler(crawlerConfig)
+
+      sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns(mockProvider as any)
+
+      const getServiceStartBlockStub = sandbox
+        .stub(crawler, 'getServiceStartBlock')
+        .onFirstCall()
+        .rejects(new Error("Socket 'secureConnect' timed out after 30001ms (connectTimeoutMS: 30000)"))
+        .onSecondCall()
+        .resolves({ block: 100, isExisting: true })
+
+      sandbox.stub(Web3Helper, 'getBlockNumber').onFirstCall().resolves(100).onSecondCall().resolves(100)
+
+      try {
+        await crawler.crawl()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        expect((error as Error).message).to.contain("Socket 'secureConnect' timed out")
+      }
+
+      // Flag must be cleared by `finally` so the next scheduler tick can re-enter.
+      expect(crawler['crawlSetting'].crawling).to.be.false
+
+      // Second tick succeeds — must not throw 'Already crawling'.
+      const result = await crawler.crawl()
+      expect(result).to.deep.equal([])
+      expect(crawler['crawlSetting'].crawling).to.be.false
+      expect(getServiceStartBlockStub.calledTwice).to.be.true
+    })
+
+    it('should clear crawling flag after a normal completed run', async () => {
+      const crawler = new BlockchainLogCrawler({
+        ...crawlerConfig,
+        logService: null,
+        events: [
+          {
+            topic: '0xTopic',
+            event: 'Test',
+            config: [{ abi: [{ name: 'Test', type: 'event' }], handler: sandbox.stub().resolves() }],
+          },
+        ],
+      })
+
+      sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns(mockProvider as any)
+      sandbox.stub(Web3Helper, 'getBlockNumber').onFirstCall().resolves(100).onSecondCall().resolves(200)
+      sandbox.stub(crawler, 'getStrategyBySituation').returns(ICrawStrategy.getLogsByBatch)
+      sandbox.stub(crawler, 'getOffsetToBlockNumber').callsFake((block: number) => block)
+      sandbox.stub(Web3Utils, 'parseLog').returns({ name: 'Test', args: {} } as any)
+      sandbox.stub(Web3Utils, 'parseInfoLog').returns({} as any)
+
+      sandbox
+        .stub(crawler, 'getLogsByStrategy')
+        .resolves({ logs: [{ transactionHash: '0x1', blockNumber: 101, transactionIndex: 1 }] as any, toBlock: 200 })
+
+      sandbox.stub(crawler, 'updateAndCheckConditions').onFirstCall().resolves(true).onSecondCall().resolves(false)
+
+      await crawler.crawl()
+
+      expect(crawler['crawlSetting'].crawling).to.be.false
+    })
+
     it('should return early if current block equals latest block on continuous sync', async () => {
       const crawler = new BlockchainLogCrawler(crawlerConfig)
 
@@ -3629,8 +3691,8 @@ describe('Module: blockchainLogCrawler', () => {
         expect(error.message).to.include('Crawl failed')
       }
 
-      // Verify crawling state remains true (error occurred before it could be reset)
-      expect(crawler.crawlSetting.crawling).to.be.true
+      // Verify crawling state is reset by `finally` so the next tick can re-enter.
+      expect(crawler.crawlSetting.crawling).to.be.false
     })
   })
 


### PR DESCRIPTION
## Summary
- `crawl()` set `crawlSetting.crawling = true` but only cleared it on success paths, so any throw before/around the inner try (e.g. `getServiceStartBlock`, `Web3Helper.getBlockNumber`) left the flag stuck `true`.
- Once stuck, every subsequent `poolingCrawler` tick re-entered, hit the guard, and threw `Already crawling` — observed ~3,035 errors/24h on `indexer-citrea-mainnet` after a Mongo blip on 2026-05-05 12:15 UTC, until the service was restarted at 18:39 UTC.
- Wrap `crawl()` body in `try { ... } finally { crawling = false }`; remove the three explicit resets. Any throw now guarantees the guard is released.

Linear: BE-223

## Test plan
- [ ] Force a throw from `getServiceStartBlock` (e.g. simulate Mongo timeout) → next tick should NOT throw `Already crawling`.
- [ ] Normal crawl run completes and flag is cleared.
- [ ] Monitor `indexer-citrea-mainnet` error count post-deploy.