### PR TITLE
fix(campaign): ensure stale reward IDs are preserved during payout processing

### DIFF
--- a/src/handlers/capitalDistributorHandler.ts
+++ b/src/handlers/capitalDistributorHandler.ts
@@ -372,17 +372,24 @@ export const CapitalDistributorHandler = {
 
       const rewardOps = validEvents.flatMap(({ parsedEvent, info }) => {
         const { campaignId, recipient, amount } = parsedEvent.args
-        const rewardId = `${network}-${info.address}-${campaignId}-${recipient}`
+        const campaignIdStr = campaignId.toString()
+        const rewardId = `${network}-${info.address}-${campaignIdStr}-${recipient}`
+        const rewardKey = {
+          pluginAddress: info.address,
+          network,
+          campaignId: campaignIdStr,
+          userAddress: recipient,
+        }
         return [
           {
             updateOne: {
-              filter: { id: rewardId },
+              filter: rewardKey,
               update: {
                 $setOnInsert: {
                   id: rewardId,
                   pluginAddress: info.address,
                   network,
-                  campaignId: campaignId.toString(),
+                  campaignId: campaignIdStr,
                   userAddress: recipient,
                   amount: amount.toString(),
                   totalClaimed: amount.toString(),
@@ -393,7 +400,7 @@ export const CapitalDistributorHandler = {
           },
           {
             updateOne: {
-              filter: { id: rewardId, 'claims.transactionHash': { $ne: info.transactionHash } },
+              filter: { ...rewardKey, 'claims.transactionHash': { $ne: info.transactionHash } },
               update: {
                 $push: {
                   claims: {

--- a/test/unit/handlers/capitalDistributorHandler.spec.ts
+++ b/test/unit/handlers/capitalDistributorHandler.spec.ts
@@ -1130,5 +1130,43 @@ describe('Handler: CapitalDistributor', () => {
         expect(error.message).to.equal('DB connection lost')
       }
     })
+
+    it('should not throw E11000 when reward exists with stale id from a draft campaignId', async () => {
+      const realCampaignId = '5'
+      const draftCampaignId = 'draft-uuid-abc123'
+      const recipient = '0xuser1234567890123456789012345678901234567890' as HexAddress
+      const staleId = `${batchNetwork}-${pluginAddress}-${draftCampaignId}-${recipient}`
+      await Models.CampaignReward.create({
+        id: staleId,
+        pluginAddress,
+        network: batchNetwork,
+        campaignId: realCampaignId,
+        userAddress: recipient,
+        amount: '1000000000000000000',
+        totalClaimed: '0',
+        claims: [],
+      } as any)
+
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        incrementClaimCount: sandbox.stub().resolves(),
+        addToTotalClaimed: sandbox.stub().resolves(),
+      } as any)
+
+      await CapitalDistributorHandler.payoutClaimedBatch([
+        makeClaimEvent({ campaignId: BigInt(realCampaignId), recipient }),
+      ])
+
+      const reward = await Models.CampaignReward.findOne({
+        pluginAddress,
+        network: batchNetwork,
+        campaignId: realCampaignId,
+        userAddress: recipient,
+      })
+      expect(reward).to.not.be.null
+      // `id` is intentionally NOT rewritten — stale id is preserved on existing rows.
+      expect(reward!.id).to.eq(staleId)
+      expect(reward!.claims).to.have.lengthOf(1)
+      expect(reward!.claims[0].claimedAmount).to.eq('1000000000000000000')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Cherry-pick of #1314 (merged to `main`) onto `development`.

`payoutClaimedBatch` was filtering its `bulkWrite` upserts by the synthetic `id` field. After a draft→real campaignId reconcile (`MerkleCampaignSet` → `reconcileDraftCampaignId`), the `id` string still embeds the old draft id, so the id-keyed filter misses the existing doc, the upsert tries to insert, and the compound unique index `pluginAddress_1_network_1_campaignId_1_userAddress_1` rejects it (E11000 loop in production).

## Fix

- Filter both upsert ops by the compound key `(pluginAddress, network, campaignId, userAddress)` — same approach the single-event `payoutClaimed` path already uses successfully.
- `id` stays in `$setOnInsert` so brand-new rows still receive one; existing rows are never touched.

No DB migration / data change required.

## Test plan

- [x] New regression test: seeds a `CampaignReward` with a stale draft-id, runs `payoutClaimedBatch`, asserts no E11000 + claim is pushed + existing `id` preserved.
- [x] Existing `payoutClaimedBatch` and `reconcileDraftCampaignId` tests still pass.
- [x] `yarn test:unit` — 69 / 69 passing.

## Related

- Hotfix to `main`: #1314