### PR TITLE
fix(campaign): persist totalClaimed on existing reward docs in payoutClaimedBatch

### DIFF
--- a/src/handlers/capitalDistributorHandler.ts
+++ b/src/handlers/capitalDistributorHandler.ts
@@ -410,6 +410,9 @@ export const CapitalDistributorHandler = {
                     blockTimestamp: timestamps.get(info.blockNumber) || 0,
                   },
                 },
+                $set: {
+                  totalClaimed: amount.toString(),
+                },
               },
             },
           },

--- a/test/unit/handlers/capitalDistributorHandler.spec.ts
+++ b/test/unit/handlers/capitalDistributorHandler.spec.ts
@@ -1168,5 +1168,66 @@ describe('Handler: CapitalDistributor', () => {
       expect(reward!.claims).to.have.lengthOf(1)
       expect(reward!.claims[0].claimedAmount).to.eq('1000000000000000000')
     })
+
+    it('should populate totalClaimed and claim record on a pre-seeded empty reward', async () => {
+      const campaignId = '7'
+      const recipient = '0xuser5555555555555555555555555555555555aaaa' as HexAddress
+      const txHash = '0xfeed01feed01feed01feed01feed01feed01feed01feed01feed01feed01feed' as HexAddress
+      const blockNumber = 200
+      const blockTimestamp = 1700000000
+      const amount = '1000000000000000000'
+
+      const seededId = Models.CampaignReward.getEntityId({
+        pluginAddress,
+        network: batchNetwork,
+        campaignId,
+        userAddress: recipient,
+      })
+      await Models.CampaignReward.create({
+        id: seededId,
+        pluginAddress,
+        network: batchNetwork,
+        campaignId,
+        userAddress: recipient,
+        amount,
+        totalClaimed: '0',
+        claims: [],
+      } as any)
+
+      sandbox.stub(Models.Campaign, 'findCampaignById').resolves({
+        incrementClaimCount: sandbox.stub().resolves(),
+        addToTotalClaimed: sandbox.stub().resolves(),
+      } as any)
+
+      await CapitalDistributorHandler.payoutClaimedBatch([
+        makeClaimEvent({
+          campaignId: BigInt(campaignId),
+          recipient,
+          transactionHash: txHash,
+          blockNumber,
+          timestampEntries: [[blockNumber, blockTimestamp]],
+        }),
+      ])
+
+      const reward = await Models.CampaignReward.findOne({
+        pluginAddress,
+        network: batchNetwork,
+        campaignId,
+        userAddress: recipient,
+      })
+      expect(reward).to.not.be.null
+      expect(reward!.id).to.eq(seededId)
+      expect(reward!.pluginAddress).to.eq(pluginAddress)
+      expect(reward!.network).to.eq(batchNetwork)
+      expect(reward!.campaignId).to.eq(campaignId)
+      expect(reward!.userAddress).to.eq(recipient)
+      expect(reward!.amount).to.eq(amount)
+      expect(reward!.totalClaimed).to.eq(amount)
+      expect(reward!.claims).to.have.lengthOf(1)
+      expect(reward!.claims[0].claimedAmount).to.eq(amount)
+      expect(reward!.claims[0].transactionHash).to.eq(txHash)
+      expect(reward!.claims[0].blockNumber).to.eq(blockNumber)
+      expect(reward!.claims[0].blockTimestamp).to.eq(blockTimestamp)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1315 (E11000 hotfix). For pre-seeded `CampaignReward` docs (created by admin merkle upload via `bulkUpsertRewards` with `totalClaimed: '0'`), the previous `payoutClaimedBatch` only set `totalClaimed` via `\$setOnInsert`, which never fires on existing docs. Result: their `totalClaimed` stayed at `0` after a claim event, breaking `isFullyClaimed` and any downstream aggregation that relies on `totalClaimed`.

## Fix

Add `\$set: { totalClaimed: amount.toString() }` to the second op in the `bulkWrite`. This is safe because:

- The smart contract enforces a single claim per (campaign, user), so the `\$set` value is always the final value.
- The existing `'claims.transactionHash': { \$ne: tx }` filter still gates the op, so it fires exactly once per unique tx — idempotent on replay.

## Test plan

- [x] New unit test: seed an empty reward (`claims: []`, `totalClaimed: '0'`), call `payoutClaimedBatch`, assert all fields are populated correctly — `totalClaimed === amount`, `claims[0]` matches the event payload, identity fields preserved.
- [x] Existing E11000 regression test still passes.
- [x] `yarn test:unit` — all passing.
- [x] `yarn format:fix` clean.

## Related

- Hotfix loop fix to `main`: #1314
- Hotfix loop fix to `development`: #1315