### PR TITLE
fix(migration): backfill Lock blockTimestamp via batched eth_getBlockByNumber per network

### DIFF
--- a/src/migrations/20260508082351-backfillLockBlockTimestamp.ts
+++ b/src/migrations/20260508082351-backfillLockBlockTimestamp.ts
@@ -1,0 +1,101 @@
+import { Models } from '@dbModels'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
+import logger from '@logger'
+import { type IMigration, type NetworksEnum } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: backfillLockBlockTimestamp' })
+
+const BLOCKS_PER_RPC_BATCH = 100
+const WRITE_BATCH_SIZE = 1000
+
+const filter = { $or: [{ blockTimestamp: null }, { blockTimestamp: { $exists: false } }] }
+
+const chunk = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+const buildTimestampMap = async (network: NetworksEnum, blocks: number[]): Promise<Map<number, number>> => {
+  const merged = new Map<number, number>()
+  for (const batch of chunk(blocks, BLOCKS_PER_RPC_BATCH)) {
+    const fetched = await Web3BatchHelper.getBlocksTimestamps(batch, network)
+    for (const [bn, ts] of fetched) merged.set(bn, ts)
+  }
+  return merged
+}
+
+const backfillNetwork = async (network: NetworksEnum): Promise<{ updated: number; skipped: number }> => {
+  const blocks = (await Models.Lock.distinct('blockNumber', { ...filter, network })) as number[]
+  if (blocks.length === 0) return { updated: 0, skipped: 0 }
+
+  const start = Date.now()
+  const tsMap = await buildTimestampMap(network, blocks)
+  logger.info(
+    'Fetched timestamps',
+    llo({ network, blocks: blocks.length, resolved: tsMap.size, ms: Date.now() - start }),
+  )
+
+  let ops: any[] = []
+  let updated = 0
+  let skipped = 0
+  for (const [blockNumber, blockTimestamp] of tsMap) {
+    ops.push({
+      updateMany: {
+        filter: { ...filter, network, blockNumber },
+        update: { $set: { blockTimestamp } },
+      },
+    })
+
+    if (ops.length >= WRITE_BATCH_SIZE) {
+      const result = await Models.Lock.bulkWrite(ops, { ordered: false })
+      updated += result.modifiedCount ?? 0
+      ops = []
+    }
+  }
+
+  if (ops.length) {
+    const result = await Models.Lock.bulkWrite(ops, { ordered: false })
+    updated += result.modifiedCount ?? 0
+  }
+
+  skipped = blocks.length - tsMap.size
+  return { updated, skipped }
+}
+
+export const backfillLockBlockTimestampMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: '20260508082351-backfillLockBlockTimestamp' }))
+
+    try {
+      const networks = (await Models.Lock.distinct('network', filter)) as NetworksEnum[]
+      logger.info('Networks with null blockTimestamp locks', llo({ count: networks.length, networks }))
+
+      let totalUpdated = 0
+      let totalSkipped = 0
+
+      for (const network of networks) {
+        const { updated, skipped } = await backfillNetwork(network)
+        totalUpdated += updated
+        totalSkipped += skipped
+        logger.info('Network backfill done', llo({ network, updated, skipped }))
+      }
+
+      logger.info(
+        'Migration completed successfully',
+        llo({
+          migration: '20260508082351-backfillLockBlockTimestamp',
+          totalUpdated,
+          totalSkipped,
+        }),
+      )
+    } catch (error) {
+      logger.error('Migration failed', llo({ migration: '20260508082351-backfillLockBlockTimestamp', error }))
+      throw error
+    }
+  },
+
+  stop: async () => {},
+}
+
+export default backfillLockBlockTimestampMigration

--- a/test/unit/migrations/20260508082351-backfillLockBlockTimestamp.spec.ts
+++ b/test/unit/migrations/20260508082351-backfillLockBlockTimestamp.spec.ts
@@ -1,0 +1,157 @@
+import { Models } from '@dbModels'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
+import backfillLockBlockTimestampMigration from '@src/migrations/20260508082351-backfillLockBlockTimestamp'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+describe('migration: backfillLockBlockTimestamp', () => {
+  let sandbox: SinonSandbox
+
+  let counter = 0
+  const uid = (prefix: string) => `${prefix}-${++counter}`
+
+  const seedLock = async (overrides: Partial<Record<string, any>>) =>
+    Models.Lock.collection.insertOne({
+      id: uid('lock'),
+      escrowAddress: '0xescrowaddress',
+      tokenAddress: '0xtokenaddress',
+      nftAddress: '0xnftaddress',
+      exitQueueAddress: '0xexitqueueaddress',
+      tokenId: '1',
+      amount: '1000000000000000000',
+      epochStartAt: 1700000000,
+      totalLocked: '1000000000000000000',
+      transactionHash: '0xtxhash',
+      transactionIndex: 0,
+      logIndex: 0,
+      memberAddress: '0xmemberaddress',
+      ...overrides,
+    } as any)
+
+  const fetchLockById = async (id: string) => Models.Lock.collection.findOne({ id })
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  it('backfills blockTimestamp for null rows using the timestamp map per network', async () => {
+    const id1 = uid('lock')
+    const id2 = uid('lock')
+    await seedLock({ id: id1, network: NetworksEnum.ethereumMainnet, blockNumber: 100, blockTimestamp: null })
+    await seedLock({ id: id2, network: NetworksEnum.ethereumMainnet, blockNumber: 200, blockTimestamp: null })
+
+    const stub = sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps')
+    stub
+      .withArgs(
+        sinon.match((arg: number[]) => arg.includes(100) && arg.includes(200)),
+        NetworksEnum.ethereumMainnet,
+      )
+      .resolves(
+        new Map([
+          [100, 1700000100],
+          [200, 1700000200],
+        ]),
+      )
+
+    await backfillLockBlockTimestampMigration.start()
+
+    const lock1 = await fetchLockById(id1)
+    const lock2 = await fetchLockById(id2)
+    expect(lock1?.blockTimestamp).to.eq(1700000100)
+    expect(lock2?.blockTimestamp).to.eq(1700000200)
+  })
+
+  it('does not touch locks that already have a blockTimestamp', async () => {
+    const id = uid('lock')
+    await seedLock({ id, network: NetworksEnum.ethereumMainnet, blockNumber: 100, blockTimestamp: 1690000000 })
+
+    const stub = sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map())
+
+    await backfillLockBlockTimestampMigration.start()
+
+    const lock = await fetchLockById(id)
+    expect(lock?.blockTimestamp).to.eq(1690000000)
+    expect(stub.called).to.be.false
+  })
+
+  it('processes locks across multiple networks independently', async () => {
+    const idEth = uid('lock')
+    const idPeaq = uid('lock')
+    await seedLock({ id: idEth, network: NetworksEnum.ethereumMainnet, blockNumber: 50, blockTimestamp: null })
+    await seedLock({ id: idPeaq, network: NetworksEnum.peaqMainnet, blockNumber: 75, blockTimestamp: null })
+
+    const stub = sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps')
+    stub.withArgs(sinon.match.array, NetworksEnum.ethereumMainnet).resolves(new Map([[50, 1700050000]]))
+    stub.withArgs(sinon.match.array, NetworksEnum.peaqMainnet).resolves(new Map([[75, 1700075000]]))
+
+    await backfillLockBlockTimestampMigration.start()
+
+    const lockEth = await fetchLockById(idEth)
+    const lockPeaq = await fetchLockById(idPeaq)
+    expect(lockEth?.blockTimestamp).to.eq(1700050000)
+    expect(lockPeaq?.blockTimestamp).to.eq(1700075000)
+  })
+
+  it('shares one timestamp across all locks at the same blockNumber', async () => {
+    const idA = uid('lock')
+    const idB = uid('lock')
+    await seedLock({
+      id: idA,
+      network: NetworksEnum.ethereumMainnet,
+      blockNumber: 500,
+      tokenId: 'A',
+      blockTimestamp: null,
+    })
+    await seedLock({
+      id: idB,
+      network: NetworksEnum.ethereumMainnet,
+      blockNumber: 500,
+      tokenId: 'B',
+      blockTimestamp: null,
+    })
+
+    sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map([[500, 1700500000]]))
+
+    await backfillLockBlockTimestampMigration.start()
+
+    const lockA = await fetchLockById(idA)
+    const lockB = await fetchLockById(idB)
+    expect(lockA?.blockTimestamp).to.eq(1700500000)
+    expect(lockB?.blockTimestamp).to.eq(1700500000)
+  })
+
+  it('leaves blockTimestamp null when the RPC batch returns no entry for that block', async () => {
+    const id = uid('lock')
+    await seedLock({ id, network: NetworksEnum.ethereumMainnet, blockNumber: 999, blockTimestamp: null })
+
+    sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map())
+
+    await backfillLockBlockTimestampMigration.start()
+
+    const lock = await fetchLockById(id)
+    expect(lock?.blockTimestamp).to.be.null
+  })
+
+  it('is idempotent: re-running does not change anything after the first pass', async () => {
+    const id = uid('lock')
+    await seedLock({ id, network: NetworksEnum.ethereumMainnet, blockNumber: 700, blockTimestamp: null })
+
+    const stub = sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map([[700, 1700700000]]))
+
+    await backfillLockBlockTimestampMigration.start()
+    const after1 = await fetchLockById(id)
+
+    await backfillLockBlockTimestampMigration.start()
+    const after2 = await fetchLockById(id)
+
+    expect(after1?.blockTimestamp).to.eq(1700700000)
+    expect(after2?.blockTimestamp).to.eq(1700700000)
+    expect(stub.callCount).to.eq(1)
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #1318 (which fixes the bug going forward). This migration backfills the historical `Lock` documents that were created with `blockTimestamp: null` because the deposit/split single-event flow never persisted the timestamp.

## Approach

Per network:
1. Get distinct `blockNumber` values where `blockTimestamp` is null (or the field is missing).
2. Fetch timestamps via `Web3BatchHelper.getBlocksTimestamps` in chunks of 100 (one batched JSON-RPC call per chunk).
3. Build a `blockNumber → timestamp` map.
4. Bulk-write `updateMany` ops keyed on `(network, blockNumber, blockTimestamp: null)` so all locks at the same block are healed in a single op.

If the RPC batch fails to resolve some blocks, they are left null and reported as `skipped` — re-running picks them up.

## Test plan

- [x] Backfills null rows using a stubbed `Web3BatchHelper.getBlocksTimestamps` map.
- [x] Skips locks that already have a `blockTimestamp` (no RPC call).
- [x] Processes networks independently with per-network maps.
- [x] Shares one timestamp across all locks at the same `blockNumber`.
- [x] Leaves `blockTimestamp: null` when the RPC batch returns no entry for that block.
- [x] Idempotent on re-runs (second invocation makes zero RPC calls and modifies nothing).
- [x] `yarn test:unit` clean. `yarn format:fix` clean.

## Related

- Forward-fix: #1318