### PR TITLE
feat(api): expose delegatedAt on delegators list response

### DIFF
--- a/src/models/schema/lock.ts
+++ b/src/models/schema/lock.ts
@@ -480,7 +480,7 @@ export default class Lock extends Model {
           ens: '$memberInfo.ens',
           transactionHash: 1,
           blockNumber: 1,
-          blockTimestamp: 1,
+          delegatedAt: '$blockTimestamp',
         },
       },
     ]

--- a/src/models/schema/logDelegateChanged.ts
+++ b/src/models/schema/logDelegateChanged.ts
@@ -195,7 +195,7 @@ export default class LogDelegateChanged extends Model {
     const dataQuery: any[] = [
       ...currentDelegators,
       ...lookups,
-      { $addFields: { id: '$_id', blockNumber: '$latest.blockNumber', blockTimestamp: '$latest.blockTimestamp' } },
+      { $addFields: { id: '$_id', blockNumber: '$latest.blockNumber', delegatedAt: '$latest.blockTimestamp' } },
       { $sort: request.sort },
       { $skip: request.skip },
       { $limit: request.limit },
@@ -206,7 +206,7 @@ export default class LogDelegateChanged extends Model {
           ens: '$memberInfo.ens',
           transactionHash: '$latest.transactionHash',
           blockNumber: 1,
-          blockTimestamp: 1,
+          delegatedAt: 1,
         },
       },
     ]

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -110,7 +110,7 @@ export interface IDelegatorResponse {
   ens?: ENS | null
   transactionHash: HexAddress
   blockNumber: number
-  blockTimestamp?: number | null
+  delegatedAt?: number | null
 }
 
 export interface IDaoResponse {

--- a/test/integration/helpers/txActions.ts
+++ b/test/integration/helpers/txActions.ts
@@ -41,7 +41,7 @@ export async function createProposalTx(
   } = {},
 ): Promise<TxResult & { proposalId?: bigint }> {
   const provider = getAnvilProvider()
-  const signer = opts.signer ?? dep.deployerWallet
+  const signer = opts.signer ?? dep.deployerSigner
   const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, signer)
 
   const nowTs = (await provider.getBlock('latest'))!.timestamp

--- a/test/integration/setups/erc20DelegationActivity.ts
+++ b/test/integration/setups/erc20DelegationActivity.ts
@@ -53,7 +53,7 @@ export async function runErc20DelegationActivity(
     data: tokenInterface.encodeFunctionData('mint', [holders[i].address, spec.amount]),
   }))
 
-  const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerWallet)
+  const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerSigner)
   const nowTs = (await provider.getBlock('latest'))!.timestamp
   // endDate must be >= startDate + minDuration (3600s); pad against block-timestamp drift.
   const endDate = BigInt(nowTs) + 7200n

--- a/test/integration/setups/gaugeVotingActivity.ts
+++ b/test/integration/setups/gaugeVotingActivity.ts
@@ -109,8 +109,10 @@ const MULTISIG_ABI = [
 export async function setupGaugesDaoLight(): Promise<GaugesDaoDeployment> {
   const provider = getAnvilProvider()
 
-  const deployer = ethers.Wallet.createRandom().connect(provider)
-  await setBalance(deployer.address, 10n ** 19n)
+  const deployerWallet = ethers.Wallet.createRandom().connect(provider)
+  // NonceManager: see tokenVotingDaoSetup.ts for rationale.
+  const deployer = new ethers.NonceManager(deployerWallet)
+  await setBalance(deployerWallet.address, 10n ** 19n)
 
   const factory = new ethers.Contract(FACTORY, FACTORY_ABI, deployer)
   logger.info('setupGaugesDaoLight: calling factory.deployOnce()')
@@ -131,7 +133,7 @@ export async function setupGaugesDaoLight(): Promise<GaugesDaoDeployment> {
   // Grant deployer ROOT via multisig proposal
   const daoContract = new ethers.Contract(dao, DAO_ABI, provider)
   const ROOT: string = await daoContract.ROOT_PERMISSION_ID()
-  const grantData = daoContract.interface.encodeFunctionData('grant', [dao, deployer.address, ROOT])
+  const grantData = daoContract.interface.encodeFunctionData('grant', [dao, deployerWallet.address, ROOT])
   const actions = [{ to: dao, value: 0n, data: grantData }]
 
   await setBalance(MULTISIG_MEMBER, 10n ** 19n)
@@ -149,8 +151,9 @@ export async function setupGaugesDaoLight(): Promise<GaugesDaoDeployment> {
     dao,
     multisig,
     adapter: set.delegationAdapter,
-    deployer: deployer.address,
-    deployerWallet: deployer,
+    deployer: deployerWallet.address,
+    deployerWallet,
+    deployerSigner: deployer,
     tokenVoting: ethers.ZeroAddress, // not installed
     votingEscrow: set.votingEscrow,
     nftLock: set.nftLock,
@@ -225,12 +228,13 @@ export async function runGaugeVotingActivity(
   logger.info(`gaugeVotingActivity: applied ${delegationSpecs.length} delegations`)
 
   // ── 4. Grant GAUGE_ADMIN_ROLE and register gauges ────────────────────────
-  // Re-wrap deployer wallet to clear cached nonce (stale after time-warp mines)
-  const admin = new ethers.Wallet(dep.deployerWallet.privateKey, provider)
+  // Use the fixture's NonceManager-wrapped signer so nonces are tracked locally
+  // and never collide with stale "pending" reads from anvil's --block-time mempool.
+  const admin = dep.deployerSigner
 
   const GAUGE_ADMIN_ROLE: string = await gaugeVoter.GAUGE_ADMIN_ROLE()
   const daoContract = new ethers.Contract(dep.dao, DAO_ABI, admin)
-  await (await daoContract.grant(dep.gaugeVoter, admin.address, GAUGE_ADMIN_ROLE)).wait()
+  await (await daoContract.grant(dep.gaugeVoter, dep.deployer, GAUGE_ADMIN_ROLE)).wait()
 
   const gaugeAddresses: string[] = []
   const gaugeVoterWriter = new ethers.Contract(dep.gaugeVoter, GAUGE_VOTER_ABI, admin)

--- a/test/integration/setups/gaugesActivity.ts
+++ b/test/integration/setups/gaugesActivity.ts
@@ -113,7 +113,7 @@ export async function runGaugesActivity(
   if (config.proposals && config.proposals.length > 0) {
     const tokenVotingReader = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, provider)
     const proposalCreatedTopic = tokenVotingReader.interface.getEvent('ProposalCreated')!.topicHash
-    const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerWallet)
+    const tokenVoting = new ethers.Contract(dep.tokenVoting, TOKEN_VOTING_ABI, dep.deployerSigner)
 
     for (const spec of config.proposals) {
       const proposalNow = (await provider.getBlock('latest'))!.timestamp

--- a/test/integration/setups/gaugesDaoSetup.ts
+++ b/test/integration/setups/gaugesDaoSetup.ts
@@ -42,8 +42,11 @@ import type { GaugesDaoDeployment } from '../types/gaugesFixture'
 export async function setupGaugesDao(): Promise<GaugesDaoDeployment> {
   const provider = getAnvilProvider()
 
-  const deployer = ethers.Wallet.createRandom().connect(provider)
-  await setBalance(deployer.address, 10n ** 19n)
+  const deployerWallet = ethers.Wallet.createRandom().connect(provider)
+  // NonceManager keeps a local nonce counter — eliminates the "pending"-count
+  // RPC race against anvil's `--block-time 1`.
+  const deployer = new ethers.NonceManager(deployerWallet)
+  await setBalance(deployerWallet.address, 10n ** 19n)
 
   const factory = new ethers.Contract(FACTORY, FACTORY_ABI, deployer)
   logger.info('GaugesDaoSetup: calling factory.deployOnce()')
@@ -69,7 +72,7 @@ export async function setupGaugesDao(): Promise<GaugesDaoDeployment> {
   const daoContract = new ethers.Contract(dao, DAO_ABI, provider)
   const ROOT: string = await daoContract.ROOT_PERMISSION_ID()
 
-  const grantData = daoContract.interface.encodeFunctionData('grant', [dao, deployer.address, ROOT])
+  const grantData = daoContract.interface.encodeFunctionData('grant', [dao, deployerWallet.address, ROOT])
   const actions = [{ to: dao, value: 0n, data: grantData }]
 
   await setBalance(MULTISIG_MEMBER, 10n ** 19n)
@@ -89,7 +92,7 @@ export async function setupGaugesDao(): Promise<GaugesDaoDeployment> {
   const APPLY_INSTALLATION = await psp.APPLY_INSTALLATION_PERMISSION_ID()
 
   await (await daoAsDeployer.grant(dao, PSP, ROOT)).wait()
-  await (await daoAsDeployer.grant(PSP, deployer.address, APPLY_INSTALLATION)).wait()
+  await (await daoAsDeployer.grant(PSP, deployerWallet.address, APPLY_INSTALLATION)).wait()
 
   const installData = ethers.AbiCoder.defaultAbiCoder().encode(
     [
@@ -146,8 +149,9 @@ export async function setupGaugesDao(): Promise<GaugesDaoDeployment> {
     dao,
     multisig,
     adapter,
-    deployer: deployer.address,
-    deployerWallet: deployer,
+    deployer: deployerWallet.address,
+    deployerWallet,
+    deployerSigner: deployer,
     tokenVoting: tvPlugin,
     votingEscrow,
     nftLock,

--- a/test/integration/setups/tokenVotingDaoSetup.ts
+++ b/test/integration/setups/tokenVotingDaoSetup.ts
@@ -55,13 +55,16 @@ const TOKEN_VOTING_ABI = ['function getVotingToken() view returns (address)', 'f
 export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
   const provider = getAnvilProvider()
 
-  const deployer = ethers.Wallet.createRandom().connect(provider)
-  await setBalance(deployer.address, 10n ** 19n)
+  const deployerWallet = ethers.Wallet.createRandom().connect(provider)
+  // NonceManager keeps a local nonce counter — eliminates the "pending"-count
+  // RPC race against anvil's `--block-time 1` (txs queued but not yet mined).
+  const deployer = new ethers.NonceManager(deployerWallet)
+  await setBalance(deployerWallet.address, 10n ** 19n)
 
   // ───────────────── Step 1: createDao with Admin only ─────────────────
   const adminInstallData = ethers.AbiCoder.defaultAbiCoder().encode(
     ['address', 'tuple(address target, uint8 operation)'],
-    [deployer.address, { target: ethers.ZeroAddress, operation: 0 }],
+    [deployerWallet.address, { target: ethers.ZeroAddress, operation: 0 }],
   )
 
   const adminPluginInstallation = {
@@ -107,7 +110,7 @@ export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
   const grantPspRootData = daoContract.interface.encodeFunctionData('grant', [dao, PSP, ROOT])
   const grantApplyToDeployerData = daoContract.interface.encodeFunctionData('grant', [
     PSP,
-    deployer.address,
+    deployerWallet.address,
     APPLY_INSTALLATION,
   ])
 
@@ -139,7 +142,7 @@ export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
     [
       { votingMode: 1, supportThreshold: 500_000, minParticipation: 0, minDuration: 3600, minProposerVotingPower: 0 },
       { addr: ethers.ZeroAddress, name: 'Test', symbol: 'TEST' },
-      { receivers: [deployer.address], amounts: [10n ** 24n], ensureDelegationOnMint: false },
+      { receivers: [deployerWallet.address], amounts: [10n ** 24n], ensureDelegationOnMint: false },
       { target: dao, operation: 0 },
       0,
       '0x',
@@ -187,7 +190,7 @@ export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
   logger.info(`TokenVotingDaoSetup: token=${token}`)
 
   const tokenContract = new ethers.Contract(token, ['function delegate(address)'], deployer)
-  await (await tokenContract.delegate(deployer.address)).wait()
+  await (await tokenContract.delegate(deployerWallet.address)).wait()
 
   await mine(2, 1)
 
@@ -195,7 +198,8 @@ export async function setupTokenVotingDao(): Promise<TokenVotingDaoDeployment> {
     dao,
     tokenVoting,
     token,
-    deployer: deployer.address,
-    deployerWallet: deployer,
+    deployer: deployerWallet.address,
+    deployerWallet,
+    deployerSigner: deployer,
   }
 }

--- a/test/integration/specs/tokenVotingDelegators.spec.ts
+++ b/test/integration/specs/tokenVotingDelegators.spec.ts
@@ -109,7 +109,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       expect(matching, `expected delegation row in activity for ${row.address}`).to.exist
       expect(row.transactionHash).to.equal(matching!.transactionHash)
       expect(row.blockNumber).to.equal(matching!.blockNumber)
-      expect(row.blockTimestamp).to.equal(matching!.blockTimestamp)
+      expect(row.delegatedAt).to.equal(matching!.blockTimestamp)
     }
   })
 
@@ -131,7 +131,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
     expect(reDelegation, 'expected matching holder0 -> memberC re-delegation in activity').to.exist
     expect(result.data[0].transactionHash).to.equal(reDelegation!.transactionHash)
     expect(result.data[0].blockNumber).to.equal(reDelegation!.blockNumber)
-    expect(result.data[0].blockTimestamp).to.equal(reDelegation!.blockTimestamp)
+    expect(result.data[0].delegatedAt).to.equal(reDelegation!.blockTimestamp)
   })
 
   it('findDelegatorsForMember(memberB): both holder2 and holder5 present', async () => {
@@ -150,7 +150,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
       expect(matching, `expected delegation row in activity for ${row.address}`).to.exist
       expect(row.transactionHash).to.equal(matching!.transactionHash)
       expect(row.blockNumber).to.equal(matching!.blockNumber)
-      expect(row.blockTimestamp).to.equal(matching!.blockTimestamp)
+      expect(row.delegatedAt).to.equal(matching!.blockTimestamp)
     }
   })
 
@@ -254,7 +254,7 @@ describe('TokenVoting Delegators API — anvil ERC20 fixture', function () {
     for (const row of result.data) {
       expect(row.transactionHash).to.exist
       expect(row.blockNumber).to.be.a('number')
-      expect(row.blockTimestamp).to.be.a('number')
+      expect(row.delegatedAt).to.be.a('number')
     }
     expect(result.metadata.totalRecords).to.equal(3)
     expect(result.metadata.totalVotingPower).to.equal((160_000n * 10n ** 18n).toString())

--- a/test/integration/types/gaugesFixture.ts
+++ b/test/integration/types/gaugesFixture.ts
@@ -19,6 +19,7 @@ export interface GaugesDaoDeployment {
   adapter: string
   deployer: string
   deployerWallet: ethers.HDNodeWallet
+  deployerSigner: ethers.NonceManager
   tokenVoting: string
   votingEscrow: string
   nftLock: string

--- a/test/integration/types/tokenVotingFixture.ts
+++ b/test/integration/types/tokenVotingFixture.ts
@@ -6,6 +6,7 @@ export interface TokenVotingDaoDeployment {
   token: string
   deployer: string
   deployerWallet: ethers.HDNodeWallet
+  deployerSigner: ethers.NonceManager
 }
 
 export interface HolderSpec {

--- a/test/unit/models/schema/lock.spec.ts
+++ b/test/unit/models/schema/lock.spec.ts
@@ -1057,12 +1057,12 @@ describe('Model: Lock', () => {
       expect(result.data[0].ens).to.be.null
       expect(result.data[0].transactionHash).to.equal('0xowner2')
       expect(result.data[0].blockNumber).to.equal(110)
-      expect(result.data[0].blockTimestamp).to.equal(1100)
+      expect(result.data[0].delegatedAt).to.equal(1100)
       expect(result.data[1].address).to.equal(OWNER_1)
       expect(result.data[1].ens).to.equal('owner1.eth')
       expect(result.data[1].transactionHash).to.equal('0xowner1')
       expect(result.data[1].blockNumber).to.equal(100)
-      expect(result.data[1].blockTimestamp).to.equal(1000)
+      expect(result.data[1].delegatedAt).to.equal(1000)
       expect((result.data[0] as any).votingPower).to.be.undefined
       expect((result.data[1] as any).votingPower).to.be.undefined
       expect(result.metadata.totalRecords).to.equal(2)
@@ -1107,7 +1107,7 @@ describe('Model: Lock', () => {
       expect((result.data[0] as any).votingPower).to.be.undefined
       expect(result.data[0].transactionHash).to.equal('0xlatest')
       expect(result.data[0].blockNumber).to.equal(200)
-      expect(result.data[0].blockTimestamp).to.equal(2000)
+      expect(result.data[0].delegatedAt).to.equal(2000)
       expect(BigInt(result.metadata.totalVotingPower!) > BigInt(0)).to.equal(true)
     })
 

--- a/test/unit/models/schema/logDelegateChanged.spec.ts
+++ b/test/unit/models/schema/logDelegateChanged.spec.ts
@@ -307,11 +307,11 @@ describe('Model: LogDelegateChanged', () => {
       expect(alice.ens).to.equal('alice.eth')
       expect(alice.transactionHash).to.equal('0xfd1')
       expect(alice.blockNumber).to.equal(100)
-      expect(alice.blockTimestamp).to.equal(1000)
+      expect(alice.delegatedAt).to.equal(1000)
       const jordan = result.data.find((d: any) => d.address === JORDAN)!
       expect(jordan.transactionHash).to.equal('0xfd2')
       expect(jordan.blockNumber).to.equal(110)
-      expect(jordan.blockTimestamp).to.equal(1100)
+      expect(jordan.delegatedAt).to.equal(1100)
       // Per-row votingPower has been removed from the response.
       expect((alice as any).votingPower).to.be.undefined
       expect((jordan as any).votingPower).to.be.undefined
@@ -364,7 +364,7 @@ describe('Model: LogDelegateChanged', () => {
       expect(result.data[0].address).to.equal(JORDAN)
       expect(result.data[0].transactionHash).to.equal('0xfd4')
       expect(result.data[0].blockNumber).to.equal(210)
-      expect(result.data[0].blockTimestamp).to.equal(2100)
+      expect(result.data[0].delegatedAt).to.equal(2100)
     })
 
     it('should paginate results', async () => {


### PR DESCRIPTION
## Summary
- Rename `blockTimestamp` → `delegatedAt` on the delegators list response (`IDelegatorResponse`) for both governance paths.
- `LogDelegateChanged.findDelegatorsForMember` (erc20Governance) and `Lock.getDelegatorsForMember` (veGovernance) now project the underlying `blockTimestamp` as `delegatedAt`.
- On-disk schemas keep `blockTimestamp` unchanged — only the API field is renamed.

## Test plan
- [x] `yarn test:unit` — 57 affected tests pass (LogDelegateChanged + Lock model suites)
- [x] `yarn format:fix`
- [ ] Verify endpoint `GET /members/:address/delegators` returns `delegatedAt` in QA