### PR TITLE
feat(governance): add governance reward start block configuration and resolve logic

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -687,7 +687,7 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
       GOVERNANCE_REWARD_START_BLOCKS: {
         ETHEREUM_MAINNET: utils.configParser(sourceConfig, 'array', 'REWARDS_GOVERNANCE_START_BLOCK_ETHEREUM_MAINNET', [
           '0xf204245b0B05E9A0780761E326552A569c1D6ceb',
-          '25044570',
+          '25044571',
         ]),
       },
     },

--- a/config/common.ts
+++ b/config/common.ts
@@ -684,6 +684,12 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
     REWARDS: {
       ALLOW_RETROACTIVE_REWARDS: utils.configParser(sourceConfig, 'bool', 'ALLOW_RETROACTIVE_REWARDS', true),
       ALLOW_EARLY_REWARD_GENERATION: utils.configParser(sourceConfig, 'bool', 'ALLOW_EARLY_REWARD_GENERATION', true),
+      GOVERNANCE_REWARD_START_BLOCKS: {
+        ETHEREUM_MAINNET: utils.configParser(sourceConfig, 'array', 'REWARDS_GOVERNANCE_START_BLOCK_ETHEREUM_MAINNET', [
+          '0xf204245b0B05E9A0780761E326552A569c1D6ceb',
+          '25044570',
+        ]),
+      },
     },
   }
 }

--- a/src/modules/governanceRewards.ts
+++ b/src/modules/governanceRewards.ts
@@ -1,5 +1,7 @@
+import config from '@config'
 import { Models } from '@dbModels'
 import GovernanceVeHelper from '@helpers/governanceVe'
+import Utils from '@helpers/utils'
 import Web3BatchHelper from '@helpers/web3BatchHelper'
 import logger from '@logger'
 import { type HexAddress, NetworksEnum } from '@types'
@@ -56,11 +58,19 @@ class GovernanceRewards {
     if (!Number.isFinite(windowStart) || windowStart >= now) {
       return { error: 'Invalid or future lookbackDate' }
     }
-    const proposals = await Models.Proposal.find({
+    const proposalFilter: Record<string, any> = {
       pluginAddress: this.pluginAddress,
       network: this.network,
       endDate: { $gte: windowStart, $lte: now },
-    })
+    }
+
+    const startBlock = this.resolveStartBlock(plugin.daoAddress)
+    if (startBlock !== null) {
+      proposalFilter.blockNumber = { $gte: startBlock }
+      logger.info('Applying governance reward start block', llo({ daoAddress: plugin.daoAddress, startBlock }))
+    }
+
+    const proposals = await Models.Proposal.find(proposalFilter)
 
     // Step 3: No proposals → distribute pro-rata by current voting power to all active delegators
     if (proposals.length === 0) {
@@ -108,6 +118,28 @@ class GovernanceRewards {
     }
 
     return GovernanceRewards.distribute(weights, this.totalAmount)
+  }
+
+  /**
+   * Resolves a per-DAO start block from REWARDS.GOVERNANCE_REWARD_START_BLOCKS.
+   * Config shape per network key: [daoAddress, blockNumber] (CSV-parsed via configParser).
+   * Returns the block number only when the configured DAO matches the current plugin's DAO,
+   * otherwise null (no filter — does not affect other DAOs).
+   */
+  private resolveStartBlock(daoAddress: HexAddress): number | null {
+    const networkKey = Utils.networkToAragon(this.network)
+    if (!networkKey) return null
+
+    const configs = config.REWARDS.GOVERNANCE_REWARD_START_BLOCKS
+
+    const entry = configs[networkKey]
+    if (!Array.isArray(entry) || entry.length < 2) return null
+
+    const [configuredDao, blockStr] = entry
+    if (configuredDao !== daoAddress) return null
+
+    const blockNumber = Number(blockStr)
+    return Number.isFinite(blockNumber) && blockNumber > 0 ? blockNumber : null
   }
 
   /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -261,7 +261,7 @@ export interface IConfig {
     ALLOW_RETROACTIVE_REWARDS: boolean
     ALLOW_EARLY_REWARD_GENERATION: boolean
     GOVERNANCE_REWARD_START_BLOCKS: {
-      ETHEREUM_MAINNET: string
+      ETHEREUM_MAINNET: string[]
     }
   }
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -260,5 +260,8 @@ export interface IConfig {
   REWARDS: {
     ALLOW_RETROACTIVE_REWARDS: boolean
     ALLOW_EARLY_REWARD_GENERATION: boolean
+    GOVERNANCE_REWARD_START_BLOCKS: {
+      ETHEREUM_MAINNET: string
+    }
   }
 }

--- a/test/integration/helpers/anvilRpc.ts
+++ b/test/integration/helpers/anvilRpc.ts
@@ -3,17 +3,17 @@ import { getAnvilProvider, MAINNET_RPC } from './constants'
 
 const toHex = (n: bigint | number): string => `0x${BigInt(n).toString(16)}`
 
-/**
- * Reset the anvil fork to a specific block. The `anvil_reset` call hits the upstream RPC
- * (drpc.live / llama / whatever ETH_RPC_URL points at) which can transiently time out.
- * Retry with exponential backoff so a single flaky RPC response doesn't tank the suite.
- */
-export async function resetFork(blockNumber: number, attempts = 3): Promise<void> {
+// Known contract code on mainnet — used as a post-reset sanity probe so we
+// catch drpc serving an empty/stale fork before downstream callers blow up
+// with a confusing `estimateGas` revert.
+const POST_RESET_PROBE_ADDRESS = '0x246503df057A9a85E0144b6867a828c99676128B' // Aragon DAOFactory
+
+async function sendWithRetry(method: string, params: unknown[], attempts = 4): Promise<unknown> {
+  const provider = getAnvilProvider()
   let lastError: unknown
   for (let i = 0; i < attempts; i++) {
     try {
-      await getAnvilProvider().send('anvil_reset', [{ forking: { jsonRpcUrl: MAINNET_RPC, blockNumber } }])
-      return
+      return await provider.send(method, params)
     } catch (err) {
       lastError = err
       if (i === attempts - 1) break
@@ -24,32 +24,56 @@ export async function resetFork(blockNumber: number, attempts = 3): Promise<void
   throw lastError
 }
 
+/**
+ * Reset the anvil fork to a specific block. The `anvil_reset` call hits the upstream RPC
+ * (drpc.live / llama / whatever ETH_RPC_URL points at) which can transiently time out
+ * or return an inconsistent fork state. Retry with exponential backoff, and probe a
+ * known contract afterwards so callers don't race against a half-warm fork.
+ */
+export async function resetFork(blockNumber: number, attempts = 4): Promise<void> {
+  let lastError: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      await sendWithRetry('anvil_reset', [{ forking: { jsonRpcUrl: MAINNET_RPC, blockNumber } }], 1)
+      const code = await sendWithRetry('eth_getCode', [POST_RESET_PROBE_ADDRESS, 'latest'], 1)
+      if (typeof code === 'string' && code !== '0x') return
+      lastError = new Error(
+        `anvil_reset probe returned empty code for ${POST_RESET_PROBE_ADDRESS} — upstream RPC likely stale`,
+      )
+    } catch (err) {
+      lastError = err
+    }
+    if (i === attempts - 1) break
+    const backoffMs = 1000 * 2 ** i
+    await new Promise(r => setTimeout(r, backoffMs))
+  }
+  throw lastError
+}
+
 export async function setBalance(address: string, wei: bigint): Promise<void> {
-  await getAnvilProvider().send('anvil_setBalance', [address, toHex(wei)])
+  await sendWithRetry('anvil_setBalance', [address, toHex(wei)])
 }
 
 export async function impersonate(address: string): Promise<ethers.JsonRpcSigner> {
-  const provider = getAnvilProvider()
-  await provider.send('anvil_impersonateAccount', [address])
-  return provider.getSigner(address)
+  await sendWithRetry('anvil_impersonateAccount', [address])
+  return getAnvilProvider().getSigner(address)
 }
 
 export async function stopImpersonate(address: string): Promise<void> {
-  await getAnvilProvider().send('anvil_stopImpersonatingAccount', [address])
+  await sendWithRetry('anvil_stopImpersonatingAccount', [address])
 }
 
 export async function increaseTime(seconds: number | bigint): Promise<void> {
-  await getAnvilProvider().send('evm_increaseTime', [Number(seconds)])
+  await sendWithRetry('evm_increaseTime', [Number(seconds)])
 }
 
 export async function setNextBlockTimestamp(ts: number | bigint): Promise<void> {
-  await getAnvilProvider().send('evm_setNextBlockTimestamp', [Number(ts)])
+  await sendWithRetry('evm_setNextBlockTimestamp', [Number(ts)])
 }
 
 /** Mine `count` blocks via `anvil_mine`, optionally spaced by `intervalSeconds`. */
 export async function mine(count: number, intervalSeconds?: number): Promise<void> {
-  const provider = getAnvilProvider()
   const params: string[] = [toHex(count)]
   if (intervalSeconds !== undefined) params.push(toHex(intervalSeconds))
-  await provider.send('anvil_mine', params)
+  await sendWithRetry('anvil_mine', params)
 }

--- a/test/unit/modules/governanceRewards.spec.ts
+++ b/test/unit/modules/governanceRewards.spec.ts
@@ -92,9 +92,11 @@ describe('GovernanceRewards', () => {
   })
 
   describe('resolveStartBlock', () => {
-    const startBlocks = config.REWARDS.GOVERNANCE_REWARD_START_BLOCKS as unknown as Record<string, string[] | undefined>
     const ETH_KEY = 'ETHEREUM_MAINNET'
-    const originalEntry = startBlocks[ETH_KEY]
+
+    function setStartBlocks(value: unknown) {
+      sandbox.replace(config.REWARDS, 'GOVERNANCE_REWARD_START_BLOCKS', value as any)
+    }
 
     function makeInstance(network: NetworksEnum) {
       return new GovernanceRewards({
@@ -109,57 +111,54 @@ describe('GovernanceRewards', () => {
       return (instance as any).resolveStartBlock(dao)
     }
 
-    afterEach(() => {
-      if (originalEntry === undefined) delete startBlocks[ETH_KEY]
-      else startBlocks[ETH_KEY] = originalEntry
-    })
-
     it('should return the configured block when the dao matches', () => {
-      startBlocks[ETH_KEY] = [DAO, '25044570']
+      setStartBlocks({ [ETH_KEY]: [DAO, '25044570'] })
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(25044570)
     })
 
     it('should return null when the configured dao does not match', () => {
-      startBlocks[ETH_KEY] = ['0x0000000000000000000000000000000000000001', '25044570']
+      setStartBlocks({ [ETH_KEY]: ['0x0000000000000000000000000000000000000001', '25044570'] })
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(null)
     })
 
     it('should return null when the network has no entry', () => {
-      delete startBlocks[ETH_KEY]
+      setStartBlocks({})
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(null)
     })
 
     it('should return null when the entry has fewer than 2 items', () => {
-      startBlocks[ETH_KEY] = [DAO]
+      setStartBlocks({ [ETH_KEY]: [DAO] })
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(null)
     })
 
     it('should return null when the block number is not parseable', () => {
-      startBlocks[ETH_KEY] = [DAO, 'not-a-number']
+      setStartBlocks({ [ETH_KEY]: [DAO, 'not-a-number'] })
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(null)
     })
 
-    it('should return null when the block number is zero or negative', () => {
-      startBlocks[ETH_KEY] = [DAO, '0']
+    it('should return null when the block number is zero', () => {
+      setStartBlocks({ [ETH_KEY]: [DAO, '0'] })
       expect(resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)).to.equal(null)
+    })
 
-      startBlocks[ETH_KEY] = [DAO, '-1']
+    it('should return null when the block number is negative', () => {
+      setStartBlocks({ [ETH_KEY]: [DAO, '-1'] })
       expect(resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)).to.equal(null)
     })
 
     it('should return null when the entry is not an array', () => {
-      ;(startBlocks as any)[ETH_KEY] = '0xdao,25044570'
+      setStartBlocks({ [ETH_KEY]: '0xdao,25044570' })
       const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
       expect(result).to.equal(null)
     })
 
     it('should return null when looking up a network not in the map', () => {
-      startBlocks[ETH_KEY] = [DAO, '25044570']
+      setStartBlocks({ [ETH_KEY]: [DAO, '25044570'] })
       const result = resolve(makeInstance(NetworksEnum.ethereumSepolia), DAO)
       expect(result).to.equal(null)
     })
@@ -202,13 +201,13 @@ describe('GovernanceRewards', () => {
       })
     }
 
-    async function seedProposal(index: string, blockTimestamp: number, endDate: number) {
+    async function seedProposal(index: string, blockTimestamp: number, endDate: number, blockNumber = 200) {
       await Models.Proposal.create({
         id: `${NETWORK}-${PLUGIN}-${index}`,
         proposalIndex: index,
         pluginAddress: PLUGIN,
         network: NETWORK,
-        blockNumber: 200,
+        blockNumber,
         blockTimestamp,
         endDate,
         startDate: blockTimestamp,
@@ -386,6 +385,49 @@ describe('GovernanceRewards', () => {
       }).compute()
 
       expect(result).to.be.an('array').with.lengthOf(0)
+    })
+
+    it('should exclude proposals with blockNumber below the configured start block', async () => {
+      await seedPlugin()
+      stubEscrow()
+
+      // Sepolia is the NETWORK constant in this file; map -> aragon key
+      sandbox.replace(config.REWARDS, 'GOVERNANCE_REWARD_START_BLOCKS', {
+        ETHEREUM_SEPOLIA: [DAO, '200'],
+      } as any)
+
+      const proposalTs = Math.floor(Date.now() / 1000) - 86400
+      const endTs = Math.floor(Date.now() / 1000) - 3600
+      const lookbackDate = new Date((endTs - 172800) * 1000).toISOString()
+
+      // Below threshold: ALICE delegate votes — must be excluded
+      await seedProposal('prop-old', proposalTs, endTs, 150)
+      await seedVote('prop-old', ALICE, 0)
+
+      // Above threshold: CAROL delegate votes — must be included
+      await seedProposal('prop-new', proposalTs, endTs, 300)
+      await seedVote('prop-new', CAROL, 1)
+
+      await seedDelegation(ALICE, ['1'], 50)
+      await seedDelegation(CAROL, ['3'], 52)
+
+      sandbox.stub(Web3BatchHelper, 'getLockVotingPowerAtInBatch').resolves([
+        { tokenId: '1', votingPower: 600000000000000000000n },
+        { tokenId: '3', votingPower: 400000000000000000000n },
+      ])
+
+      const result = await new GovernanceRewards({
+        pluginAddress: PLUGIN,
+        network: NETWORK,
+        totalAmount: TOTAL,
+        lookbackDate,
+      }).compute()
+
+      // Only CAROL (above-threshold proposal participant) should be rewarded
+      expect(result).to.be.an('array').with.lengthOf(1)
+      const rewards = result as Array<{ address: string; amount: bigint }>
+      expect(rewards[0].address).to.equal(CAROL)
+      expect(rewards[0].amount).to.equal(TOTAL)
     })
   })
 })

--- a/test/unit/modules/governanceRewards.spec.ts
+++ b/test/unit/modules/governanceRewards.spec.ts
@@ -1,3 +1,4 @@
+import config from '@config'
 import { Models } from '@dbModels'
 import GovernanceVeHelper from '@helpers/governanceVe'
 import Web3BatchHelper from '@helpers/web3BatchHelper'
@@ -87,6 +88,80 @@ describe('GovernanceRewards', () => {
 
       expect(result[0].address).to.equal(ALICE)
       expect(result[0].amount).to.be.greaterThanOrEqual(result[1].amount as any)
+    })
+  })
+
+  describe('resolveStartBlock', () => {
+    const startBlocks = config.REWARDS.GOVERNANCE_REWARD_START_BLOCKS as unknown as Record<string, string[] | undefined>
+    const ETH_KEY = 'ETHEREUM_MAINNET'
+    const originalEntry = startBlocks[ETH_KEY]
+
+    function makeInstance(network: NetworksEnum) {
+      return new GovernanceRewards({
+        pluginAddress: PLUGIN,
+        network,
+        totalAmount: TOTAL,
+        lookbackDate: '2025-01-01T00:00:00.000Z',
+      })
+    }
+
+    function resolve(instance: GovernanceRewards, dao: string): number | null {
+      return (instance as any).resolveStartBlock(dao)
+    }
+
+    afterEach(() => {
+      if (originalEntry === undefined) delete startBlocks[ETH_KEY]
+      else startBlocks[ETH_KEY] = originalEntry
+    })
+
+    it('should return the configured block when the dao matches', () => {
+      startBlocks[ETH_KEY] = [DAO, '25044570']
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(25044570)
+    })
+
+    it('should return null when the configured dao does not match', () => {
+      startBlocks[ETH_KEY] = ['0x0000000000000000000000000000000000000001', '25044570']
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(null)
+    })
+
+    it('should return null when the network has no entry', () => {
+      delete startBlocks[ETH_KEY]
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(null)
+    })
+
+    it('should return null when the entry has fewer than 2 items', () => {
+      startBlocks[ETH_KEY] = [DAO]
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(null)
+    })
+
+    it('should return null when the block number is not parseable', () => {
+      startBlocks[ETH_KEY] = [DAO, 'not-a-number']
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(null)
+    })
+
+    it('should return null when the block number is zero or negative', () => {
+      startBlocks[ETH_KEY] = [DAO, '0']
+      expect(resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)).to.equal(null)
+
+      startBlocks[ETH_KEY] = [DAO, '-1']
+      expect(resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)).to.equal(null)
+    })
+
+    it('should return null when the entry is not an array', () => {
+      ;(startBlocks as any)[ETH_KEY] = '0xdao,25044570'
+      const result = resolve(makeInstance(NetworksEnum.ethereumMainnet), DAO)
+      expect(result).to.equal(null)
+    })
+
+    it('should return null when looking up a network not in the map', () => {
+      startBlocks[ETH_KEY] = [DAO, '25044570']
+      const result = resolve(makeInstance(NetworksEnum.ethereumSepolia), DAO)
+      expect(result).to.equal(null)
     })
   })
 


### PR DESCRIPTION
## 📝 Summary

This pull request introduces a configurable per-DAO start block for governance rewards, allowing the system to filter proposals based on a minimum block number for specific DAOs and networks. This ensures that only proposals after a specified block are considered for reward distribution. The change is configurable and includes comprehensive unit tests for the new logic.

**Governance rewards configuration and logic updates:**

* Added a new `GOVERNANCE_REWARD_START_BLOCKS` configuration to `REWARDS` in `config/common.ts` and updated the `IConfig` interface to support per-network DAO address and block number pairs. [[1]](diffhunk://#diff-e2ecc8e5133f2fbd80e6d9d5ae7dd923894f56b17f362af076a49b5aae96f492R687-R692) [[2]](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aR263-R265)
* Implemented the `resolveStartBlock` method in the `GovernanceRewards` class to determine the minimum proposal block for a DAO based on the configuration, and updated the proposal filtering logic to apply this block number when present. [[1]](diffhunk://#diff-1ceb168552cffb6d1173b6f5d8d96f3ecfd945f2ab6213a8f44ec691b4cd7572L59-R73) [[2]](diffhunk://#diff-1ceb168552cffb6d1173b6f5d8d96f3ecfd945f2ab6213a8f44ec691b4cd7572R123-R144)

**Testing:**

* Added comprehensive unit tests for the `resolveStartBlock` method, covering all edge cases and configuration scenarios.

**Imports and setup:**

* Added missing imports for `config` and `Utils` in both the module and test files. [[1]](diffhunk://#diff-1ceb168552cffb6d1173b6f5d8d96f3ecfd945f2ab6213a8f44ec691b4cd7572R1-R4) [[2]](diffhunk://#diff-5caa543e4cbca58309e046dfad8241131223a4249e4a08131fbb818a82dfde80R1)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
