### PR TITLE
fix(proxyToken): set default decimals to 0 for token information

### DIFF
--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -175,11 +175,11 @@ export const ProxyToken = {
         rawToken.underlying = await Web3Helper.getUnderlying(tokenAddress, network)
       }
 
-      if (!rawToken.name && tokenTypeInfo.hasName) {
+      if (tokenTypeInfo.hasName) {
         rawToken.name = await Web3Helper.getTokenName(tokenAddress, network)
       }
 
-      if (!rawToken.symbol && tokenTypeInfo.hasSymbol) {
+      if (tokenTypeInfo.hasSymbol) {
         rawToken.symbol = await Web3Helper.getTokenSymbol(tokenAddress, network)
       }
 
@@ -193,7 +193,7 @@ export const ProxyToken = {
         }
       }
 
-      if (!rawToken.decimals && tokenTypeInfo.hasDecimals) {
+      if (tokenTypeInfo.hasDecimals) {
         rawToken.decimals = await Web3Helper.getTokenDecimals(tokenAddress, network)
       }
 

--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -94,26 +94,34 @@ export const ProxyToken = {
     }
     const isTestnet = CoinGeckoHelper.isTestNetwork(network)
 
-    const coinGeckoTokenInfo =
-      isTestnet && tokenTypeInfo.type !== ITokenType.native
-        ? null
-        : (await CoinGeckoHelper.getToken(wrappedToken!, network)) || null
-
-    let escrowTotalSupply: string | null = null
-    if (tokenTypeInfo.type === ITokenType.escrowAdapter) {
-      escrowTotalSupply = await GovernanceVeHelper.getVePastTotalSupply(tokenAddress, network)
+    const defaultTokenInfo = {
+      name: '',
+      symbol: '',
+      decimals: undefined as number | undefined,
+      totalSupply: '0',
+      logo: '',
+      priceUsd: '0',
     }
+
+    const shouldFetchCoinGecko = !isTestnet || tokenTypeInfo.type === ITokenType.native
+    const fetchedTokenInfo = shouldFetchCoinGecko ? await CoinGeckoHelper.getToken(wrappedToken!, network) : null
+    const coinGeckoTokenInfo = fetchedTokenInfo || defaultTokenInfo
+
+    const escrowTotalSupply =
+      tokenTypeInfo.type === ITokenType.escrowAdapter
+        ? await GovernanceVeHelper.getVePastTotalSupply(tokenAddress, network)
+        : null
 
     return {
       address: wrappedToken!,
       network,
       type: tokenTypeInfo.type,
-      name: coinGeckoTokenInfo?.name || '',
-      symbol: coinGeckoTokenInfo?.symbol || '',
-      decimals: coinGeckoTokenInfo?.decimals || 0,
-      totalSupply: escrowTotalSupply ?? coinGeckoTokenInfo?.totalSupply ?? '0',
-      logo: coinGeckoTokenInfo?.logo || '',
-      priceUsd: coinGeckoTokenInfo?.priceUsd || '0',
+      name: coinGeckoTokenInfo.name,
+      symbol: coinGeckoTokenInfo.symbol,
+      decimals: coinGeckoTokenInfo.decimals,
+      totalSupply: escrowTotalSupply ?? coinGeckoTokenInfo.totalSupply,
+      logo: coinGeckoTokenInfo.logo,
+      priceUsd: coinGeckoTokenInfo.priceUsd,
       underlying: tokenTypeInfo.type === ITokenType.escrowAdapter ? wrappedToken : undefined,
     }
   },

--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -98,8 +98,8 @@ export const ProxyToken = {
       name: '',
       symbol: '',
       decimals: undefined as number | undefined,
-      totalSupply: '0',
       logo: '',
+      totalSupply: '0',
       priceUsd: '0',
     }
 

--- a/src/modules/proxyToken.ts
+++ b/src/modules/proxyToken.ts
@@ -110,7 +110,7 @@ export const ProxyToken = {
       type: tokenTypeInfo.type,
       name: coinGeckoTokenInfo?.name || '',
       symbol: coinGeckoTokenInfo?.symbol || '',
-      decimals: coinGeckoTokenInfo?.decimals || 18,
+      decimals: coinGeckoTokenInfo?.decimals || 0,
       totalSupply: escrowTotalSupply ?? coinGeckoTokenInfo?.totalSupply ?? '0',
       logo: coinGeckoTokenInfo?.logo || '',
       priceUsd: coinGeckoTokenInfo?.priceUsd || '0',

--- a/test/unit/modules/proxyToken.spec.ts
+++ b/test/unit/modules/proxyToken.spec.ts
@@ -682,7 +682,7 @@ describe('Modules: ProxyToken', () => {
     })
 
     it('should return null if existing token is marked as spam', async () => {
-      const tokenAddress = '0x123456789abcdef'
+      const tokenAddress = ethers.getAddress('0x27bD848507c2173Bffb1c00a63Ba6714b1bacFBd')
       const network = NetworksEnum.ethereumMainnet
 
       const spamToken = {

--- a/test/unit/modules/proxyToken.spec.ts
+++ b/test/unit/modules/proxyToken.spec.ts
@@ -374,7 +374,6 @@ describe('Modules: ProxyToken', () => {
         type: ITokenType.ERC20,
         name: 'Test Token',
         symbol: 'TEST',
-        decimals: 18,
         totalSupply: '1000000',
         logo: 'test-logo',
         priceUsd: '1.5',
@@ -538,6 +537,18 @@ describe('Modules: ProxyToken', () => {
   })
 
   describe('createNewToken', () => {
+    let getTokenNameStub: sinon.SinonStub
+    let getTokenSymbolStub: sinon.SinonStub
+    let getTokenDecimalsStub: sinon.SinonStub
+
+    beforeEach(() => {
+      // On-chain reads are unconditional in createNewToken — default-stub them so
+      // tests don't hit the real ethers impl. Tests override per-stub via .resolves().
+      getTokenNameStub = sandbox.stub(Web3Helper, 'getTokenName').resolves('')
+      getTokenSymbolStub = sandbox.stub(Web3Helper, 'getTokenSymbol').resolves('')
+      getTokenDecimalsStub = sandbox.stub(Web3Helper, 'getTokenDecimals').resolves(0)
+    })
+
     it('should create a new token with all fields populated', async () => {
       const tokenAddress = '0x123456789abcdef'
       const network = NetworksEnum.ethereumMainnet
@@ -575,6 +586,9 @@ describe('Modules: ProxyToken', () => {
       sandbox.stub(ProxyToken, 'wrapTokenDetails').resolves(tokenDetails)
       sandbox.stub(ProxyToken, 'checkPluginMintAuthorizationIsDao').resolves(true)
       sandbox.stub(Web3Helper, 'getUnderlying').resolves('0xunderlying')
+      getTokenNameStub.resolves('Test Token')
+      getTokenSymbolStub.resolves('TEST')
+      getTokenDecimalsStub.resolves(18)
       sandbox.stub(Web3Utils, 'isWhitelistedToken').returns(true)
       sandbox.stub(ProxyWeb3Provider, 'fetchContractCreation').resolves({
         blockNumber: 123456,
@@ -1004,7 +1018,7 @@ describe('Modules: ProxyToken', () => {
       sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
       sandbox.stub(TokenUtils, 'isTokenSyncable').resolves(true)
 
-      const getTokenNameStub = sandbox.stub(Web3Helper, 'getTokenName').resolves('Fetched Name')
+      getTokenNameStub.resolves('Fetched Name')
 
       const createStub = sandbox.stub(Models.Token, 'create').resolves({
         id: 'token-123',
@@ -1059,7 +1073,7 @@ describe('Modules: ProxyToken', () => {
       sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
       sandbox.stub(TokenUtils, 'isTokenSyncable').resolves(true)
 
-      const getTokenSymbolStub = sandbox.stub(Web3Helper, 'getTokenSymbol').resolves('FETCHED')
+      getTokenSymbolStub.resolves('FETCHED')
 
       const createStub = sandbox.stub(Models.Token, 'create').resolves({
         id: 'token-123',
@@ -1114,7 +1128,7 @@ describe('Modules: ProxyToken', () => {
       sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
       sandbox.stub(TokenUtils, 'isTokenSyncable').resolves(true)
 
-      const getTokenDecimalsStub = sandbox.stub(Web3Helper, 'getTokenDecimals').resolves(8)
+      getTokenDecimalsStub.resolves(8)
 
       const createStub = sandbox.stub(Models.Token, 'create').resolves({
         id: 'token-123',
@@ -1517,6 +1531,9 @@ describe('Modules: ProxyToken', () => {
       sandbox.stub(ProxyToken, 'checkPluginMintAuthorizationIsDao').resolves(false)
       sandbox.stub(CoinGeckoHelper, 'isTestNetwork').returns(false)
       sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
+      getTokenNameStub.resolves('CoinGecko Token')
+      getTokenSymbolStub.resolves('CGT')
+      getTokenDecimalsStub.resolves(18)
       sandbox.stub(ProxyWeb3Provider, 'fetchContractCreation').resolves({
         blockNumber: 123,
         transactionHash: '0xtx',


### PR DESCRIPTION
## 📝 Summary

This pull request refactors how token metadata is fetched and handled in the `ProxyToken` module, making on-chain reads for token name, symbol, and decimals unconditional and improving test reliability. The changes ensure that token metadata is always fetched directly from the blockchain when possible, and the test suite is updated to properly stub these on-chain calls.

**ProxyToken module improvements:**

* Refactored token metadata fetching logic in `ProxyToken.getToken` to always attempt on-chain reads for name, symbol, and decimals, regardless of whether values exist from other sources. This ensures more accurate and up-to-date token information. [[1]](diffhunk://#diff-f4088d67a713249aebe545697586129ddbfc1d2b59c2bf51232f1e235597c9caL170-R182) [[2]](diffhunk://#diff-f4088d67a713249aebe545697586129ddbfc1d2b59c2bf51232f1e235597c9caL188-R196)
* Improved fallback handling for CoinGecko token info by introducing a `defaultTokenInfo` object, ensuring that missing fields are handled gracefully and defaults are consistently applied.

**Testing and reliability improvements:**

* Updated unit tests in `proxyToken.spec.ts` to always stub `Web3Helper.getTokenName`, `getTokenSymbol`, and `getTokenDecimals` in the `createNewToken` tests, preventing accidental real network calls and making test outcomes more predictable. [[1]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faR540-R551) [[2]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faR589-R591) [[3]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faL1007-R1021) [[4]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faL1062-R1076) [[5]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faL1117-R1131) [[6]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faR1534-R1536)
* Adjusted test data and assertions to align with the new unconditional on-chain read logic, and fixed a test address to use a checksummed format for consistency. [[1]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faL377) [[2]](diffhunk://#diff-45e0463c1002b22611cc9cd735458288c88808bd6d39cecb332c482a88a675faL685-R699)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
