### PR TITLE
feat(rates): on-chain DEX quoter via JuiceSwap on Citrea (BE-205)

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -468,6 +468,8 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
       ROUTESCAN_MIN_TIME: utils.configParser(sourceConfig, 'number', 'BOTTLENECK_ROUTESCAN_MIN_TIME', 2000),
       CHILIZ_MAX_CONCURRENT: utils.configParser(sourceConfig, 'number', 'BOTTLENECK_CHILIZ_MAX_CONCURRENT', 1),
       CHILIZ_MIN_TIME: utils.configParser(sourceConfig, 'number', 'BOTTLENECK_CHILIZ_MIN_TIME', 5000),
+      DEX_QUOTER_MAX_CONCURRENT: utils.configParser(sourceConfig, 'number', 'BOTTLENECK_DEX_QUOTER_MAX_CONCURRENT', 5),
+      DEX_QUOTER_MIN_TIME: utils.configParser(sourceConfig, 'number', 'BOTTLENECK_DEX_QUOTER_MIN_TIME', 200),
     },
 
     MONGO_DB: {

--- a/config/common.ts
+++ b/config/common.ts
@@ -540,6 +540,22 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
       ),
     },
 
+    // Per-network DEX quoter wiring. Not env-overridable — addresses are
+    // protocol-specific and change via PR. Add new entries when integrating
+    // additional DEXs or networks.
+    DEX_QUOTERS: {
+      [NetworksEnum.citreaMainnet]: [
+        {
+          name: 'juiceswap',
+          kind: 'uniswapV3',
+          router: '0x565eD3D57fe40f78A46f348C220121AE093c3cF8',
+          quoter: '0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425',
+          wrappedNative: '0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d',
+          feeTiers: [100, 500, 3000, 10000],
+        },
+      ],
+    },
+
     IPFS: {
       METADATA_FETCH_RETRY: utils.configParser(sourceConfig, 'number', 'IPFS_METADATA_FETCH_RETRY', 2),
       METADATA_FETCH_DELAY: utils.configParser(sourceConfig, 'number', 'IPFS_METADATA_FETCH_DELAY', 500),

--- a/src/artifacts/UniswapV2Router.ts
+++ b/src/artifacts/UniswapV2Router.ts
@@ -1,0 +1,19 @@
+// Minimal Router02 ABI fragment for view-only price probes against any
+// Uniswap V2 (or fork) deployment. Quotes via `getAmountsOut` are pure view;
+// no state mutation.
+// Reference: https://docs.uniswap.org/contracts/v2/reference/smart-contracts/router-02#getamountsout
+export const UniswapV2Router = {
+  contractName: 'UniswapV2Router',
+  abi: [
+    {
+      inputs: [
+        { internalType: 'uint256', name: 'amountIn', type: 'uint256' },
+        { internalType: 'address[]', name: 'path', type: 'address[]' },
+      ],
+      name: 'getAmountsOut',
+      outputs: [{ internalType: 'uint256[]', name: 'amounts', type: 'uint256[]' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ],
+} as const

--- a/src/artifacts/UniswapV3QuoterV2.ts
+++ b/src/artifacts/UniswapV3QuoterV2.ts
@@ -1,0 +1,33 @@
+// Minimal QuoterV2 ABI fragment used for read-only `eth_call` / `callStatic`
+// price probes against any Uniswap V3 (or fork) deployment.
+// Reference: https://docs.uniswap.org/contracts/v3/reference/periphery/lens/QuoterV2
+export const UniswapV3QuoterV2 = {
+  contractName: 'UniswapV3QuoterV2',
+  abi: [
+    {
+      inputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'tokenIn', type: 'address' },
+            { internalType: 'address', name: 'tokenOut', type: 'address' },
+            { internalType: 'uint256', name: 'amountIn', type: 'uint256' },
+            { internalType: 'uint24', name: 'fee', type: 'uint24' },
+            { internalType: 'uint160', name: 'sqrtPriceLimitX96', type: 'uint160' },
+          ],
+          internalType: 'struct IQuoterV2.QuoteExactInputSingleParams',
+          name: 'params',
+          type: 'tuple',
+        },
+      ],
+      name: 'quoteExactInputSingle',
+      outputs: [
+        { internalType: 'uint256', name: 'amountOut', type: 'uint256' },
+        { internalType: 'uint160', name: 'sqrtPriceX96After', type: 'uint160' },
+        { internalType: 'uint32', name: 'initializedTicksCrossed', type: 'uint32' },
+        { internalType: 'uint256', name: 'gasEstimate', type: 'uint256' },
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+  ],
+} as const

--- a/src/helpers/tokenUtils.ts
+++ b/src/helpers/tokenUtils.ts
@@ -1,3 +1,4 @@
+import config from '@config'
 import { Models } from '@dbModels'
 import CoinGeckoHelper from '@helpers/coinGecko'
 import Web3Helper from '@helpers/web3'
@@ -23,12 +24,20 @@ const TokenUtils = {
     return null
   },
 
-  shouldSkipFetch: (token: Partial<Token>, tokenRate: { priceUsd: string }): boolean =>
-    (!token.symbol ||
-      token.isGovernance ||
-      token.type === ITokenType.unknown ||
-      CoinGeckoHelper.isTestNetwork(token.network!)) &&
-    tokenRate.priceUsd === '0',
+  shouldSkipFetch: (token: Partial<Token>, tokenRate: { priceUsd: string }): boolean => {
+    // Networks with an on-chain DEX quoter have a viable pricing source even
+    // when CoinGecko returns nothing, so don't mark these tokens as skip.
+    if (token.network && config.DEX_QUOTERS[token.network]?.length) {
+      return false
+    }
+    return (
+      (!token.symbol ||
+        !!token.isGovernance ||
+        token.type === ITokenType.unknown ||
+        CoinGeckoHelper.isTestNetwork(token.network!)) &&
+      tokenRate.priceUsd === '0'
+    )
+  },
 
   getNextFetchRateDelay: (failCount: number): number => {
     const schedule = [

--- a/src/modules/bottleneck.ts
+++ b/src/modules/bottleneck.ts
@@ -14,6 +14,7 @@ class BottleneckModule {
   static routeScanLimiters: { [key in NetworksEnum]?: Bottleneck } = {}
   static chilizLimiters: { [key in NetworksEnum]?: Bottleneck } = {}
   static duneLimiters: { [key in NetworksEnum]?: Bottleneck } = {}
+  static dexQuoterLimiters: { [key in NetworksEnum]?: Bottleneck } = {}
   static tenderlyLimiter: Bottleneck | null = null
 
   static getNodeLimiter(network: NetworksEnum) {
@@ -24,6 +25,18 @@ class BottleneckModule {
       })
     }
     return this.nodeLimiters[network]
+  }
+
+  // Dedicated limiter for the on-chain DEX quoter so rate-fetch RPC traffic
+  // doesn't compete with the indexer for slots on the shared node limiter.
+  static getDexQuoterLimiter(network: NetworksEnum) {
+    if (!this.dexQuoterLimiters[network]) {
+      this.dexQuoterLimiters[network] = new Bottleneck({
+        maxConcurrent: config.BOTTLENECK.DEX_QUOTER_MAX_CONCURRENT,
+        minTime: config.BOTTLENECK.DEX_QUOTER_MIN_TIME,
+      })
+    }
+    return this.dexQuoterLimiters[network]
   }
 
   static getNodeTransferLimiter(network: NetworksEnum) {

--- a/src/modules/dexQuoter.ts
+++ b/src/modules/dexQuoter.ts
@@ -43,7 +43,7 @@ async function readErc20Decimals(network: NetworksEnum, tokenAddress: HexAddress
     const provider = ProviderModule.getAnyRpcProvider(network)
     if (!provider) return null
     const contract = new Contract(tokenAddress, ERC20.abi, provider)
-    const raw = await BottleneckModule.getNodeLimiter(network).schedule(async () => contract.decimals())
+    const raw = await BottleneckModule.getDexQuoterLimiter(network).schedule(async () => contract.decimals())
     const value = Number(raw)
     if (!Number.isInteger(value) || value < 0 || value > 36) return null
     return value
@@ -79,7 +79,7 @@ async function quoteV3(
   for (const fee of dex.feeTiers) {
     try {
       // QuoterV2 mutates state and reverts at the end with the quote — call statically.
-      const result = await BottleneckModule.getNodeLimiter(network).schedule(async () =>
+      const result = await BottleneckModule.getDexQuoterLimiter(network).schedule(async () =>
         quoter.quoteExactInputSingle.staticCall({
           tokenIn,
           tokenOut,
@@ -112,7 +112,7 @@ async function quoteV2(
 
   try {
     const router = new Contract(dex.router, UniswapV2Router.abi, provider)
-    const amounts = await BottleneckModule.getNodeLimiter(network).schedule(async () =>
+    const amounts = await BottleneckModule.getDexQuoterLimiter(network).schedule(async () =>
       router.getAmountsOut(amountIn, [tokenIn, tokenOut]),
     )
     const out = BigInt(amounts[amounts.length - 1])

--- a/src/modules/dexQuoter.ts
+++ b/src/modules/dexQuoter.ts
@@ -38,11 +38,19 @@ export interface IRateInNativeQuote extends IDexQuote {
   wrappedNative: HexAddress
 }
 
-async function readErc20Decimals(network: NetworksEnum, tokenAddress: HexAddress): Promise<number> {
-  const provider = ProviderModule.getAnyRpcProvider(network)
-  const contract = new Contract(tokenAddress, ERC20.abi, provider)
-  const raw = await BottleneckModule.getNodeLimiter(network).schedule(async () => contract.decimals())
-  return Number(raw)
+async function readErc20Decimals(network: NetworksEnum, tokenAddress: HexAddress): Promise<number | null> {
+  try {
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    if (!provider) return null
+    const contract = new Contract(tokenAddress, ERC20.abi, provider)
+    const raw = await BottleneckModule.getNodeLimiter(network).schedule(async () => contract.decimals())
+    const value = Number(raw)
+    if (!Number.isInteger(value) || value < 0 || value > 36) return null
+    return value
+  } catch (error) {
+    logger.warn('Failed to read ERC20 decimals', llo({ network, tokenAddress, error }))
+    return null
+  }
 }
 
 async function quoteV3(
@@ -57,7 +65,15 @@ async function quoteV3(
   }
 
   const provider = ProviderModule.getAnyRpcProvider(network)
-  const quoter = new Contract(dex.quoter, UniswapV3QuoterV2.abi, provider)
+  if (!provider) return null
+
+  let quoter: Contract
+  try {
+    quoter = new Contract(dex.quoter, UniswapV3QuoterV2.abi, provider)
+  } catch (error) {
+    logger.warn('Failed to construct V3 quoter', llo({ network, dex: dex.name, error }))
+    return null
+  }
 
   let best: bigint | null = null
   for (const fee of dex.feeTiers) {
@@ -92,9 +108,10 @@ async function quoteV2(
   amountIn: bigint,
 ): Promise<bigint | null> {
   const provider = ProviderModule.getAnyRpcProvider(network)
-  const router = new Contract(dex.router, UniswapV2Router.abi, provider)
+  if (!provider) return null
 
   try {
+    const router = new Contract(dex.router, UniswapV2Router.abi, provider)
     const amounts = await BottleneckModule.getNodeLimiter(network).schedule(async () =>
       router.getAmountsOut(amountIn, [tokenIn, tokenOut]),
     )
@@ -118,7 +135,15 @@ const DexQuoterModule = {
       return null
     }
 
-    const amountIn = params.amountIn ?? 10n ** BigInt(await readErc20Decimals(network, tokenIn))
+    let amountIn = params.amountIn
+    if (amountIn === undefined) {
+      const decimals = await readErc20Decimals(network, tokenIn)
+      if (decimals === null) {
+        logger.warn('Cannot derive default amountIn — unable to read tokenIn decimals', llo({ network, tokenIn }))
+        return null
+      }
+      amountIn = 10n ** BigInt(decimals)
+    }
 
     for (const dex of dexes) {
       const out =
@@ -138,8 +163,10 @@ const DexQuoterModule = {
   /**
    * Returns the indicative price of `tokenAddress` denominated in the chain's
    * wrapped-native token (e.g. WBTC on Citrea, WETH on Ethereum) for one whole
-   * unit of the input token. The wrapped-native address comes from the first
-   * configured DEX entry — all DEXs on a network must share the same wrapper.
+   * unit of the input token. The wrapped-native address is taken from the
+   * first configured DEX entry; DEXs that declare a different `wrappedNative`
+   * are ignored with a warning so a misconfigured entry can't silently quote
+   * against the wrong denominator.
    */
   async getRateInNative(params: IGetRateInNativeParams): Promise<IRateInNativeQuote | null> {
     const { network, tokenAddress } = params
@@ -148,8 +175,22 @@ const DexQuoterModule = {
       return null
     }
     const { wrappedNative } = dexes[0]
+    const mismatched = dexes.filter(d => d.wrappedNative.toLowerCase() !== wrappedNative.toLowerCase())
+    if (mismatched.length) {
+      logger.warn(
+        'Ignoring DEX entries with mismatched wrappedNative',
+        llo({
+          network,
+          expected: wrappedNative,
+          mismatched: mismatched.map(d => ({ name: d.name, wrappedNative: d.wrappedNative })),
+        }),
+      )
+    }
 
     const tokenDecimals = await readErc20Decimals(network, tokenAddress)
+    if (tokenDecimals === null) {
+      return null
+    }
     const amountIn = 10n ** BigInt(tokenDecimals)
 
     const quote = await DexQuoterModule.getQuote({ network, tokenIn: tokenAddress, tokenOut: wrappedNative, amountIn })

--- a/src/modules/dexQuoter.ts
+++ b/src/modules/dexQuoter.ts
@@ -1,0 +1,164 @@
+import { ERC20 } from '@artifacts/ERC20'
+import { UniswapV2Router } from '@artifacts/UniswapV2Router'
+import { UniswapV3QuoterV2 } from '@artifacts/UniswapV3QuoterV2'
+import config from '@config'
+import logger from '@logger'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+import { type HexAddress, type IDexQuoterConfig, type NetworksEnum } from '@types'
+import { Contract } from 'ethers'
+
+const llo = logger.logMeta.bind(null, { service: 'dex-quoter' })
+
+export interface IGetQuoteParams {
+  network: NetworksEnum
+  tokenIn: HexAddress
+  tokenOut: HexAddress
+  /** Defaults to one whole input token (10 ** decimals(tokenIn)). */
+  amountIn?: bigint
+}
+
+export interface IGetRateInNativeParams {
+  network: NetworksEnum
+  tokenAddress: HexAddress
+}
+
+export interface IDexQuote {
+  /** Amount of `tokenOut` (in its smallest unit) returned for `amountIn` of `tokenIn`. */
+  amountOut: bigint
+  /** Original `amountIn` echoed back so the caller can compute a unit price without recomputing it. */
+  amountIn: bigint
+  /** Identifier of the DEX that produced the quote (matches `IDexQuoterConfig.name`). */
+  dex: string
+}
+
+export interface IRateInNativeQuote extends IDexQuote {
+  tokenDecimals: number
+  /** Address of the wrapped-native token used as the quote denominator. */
+  wrappedNative: HexAddress
+}
+
+async function readErc20Decimals(network: NetworksEnum, tokenAddress: HexAddress): Promise<number> {
+  const provider = ProviderModule.getAnyRpcProvider(network)
+  const contract = new Contract(tokenAddress, ERC20.abi, provider)
+  const raw = await BottleneckModule.getNodeLimiter(network).schedule(async () => contract.decimals())
+  return Number(raw)
+}
+
+async function quoteV3(
+  network: NetworksEnum,
+  dex: IDexQuoterConfig,
+  tokenIn: HexAddress,
+  tokenOut: HexAddress,
+  amountIn: bigint,
+): Promise<bigint | null> {
+  if (!dex.quoter || !dex.feeTiers?.length) {
+    return null
+  }
+
+  const provider = ProviderModule.getAnyRpcProvider(network)
+  const quoter = new Contract(dex.quoter, UniswapV3QuoterV2.abi, provider)
+
+  let best: bigint | null = null
+  for (const fee of dex.feeTiers) {
+    try {
+      // QuoterV2 mutates state and reverts at the end with the quote — call statically.
+      const result = await BottleneckModule.getNodeLimiter(network).schedule(async () =>
+        quoter.quoteExactInputSingle.staticCall({
+          tokenIn,
+          tokenOut,
+          amountIn,
+          fee,
+          sqrtPriceLimitX96: 0n,
+        }),
+      )
+      const out = BigInt(result.amountOut ?? result[0])
+      if (out > 0n && (best === null || out > best)) {
+        best = out
+      }
+    } catch {
+      // Fee tier has no pool / no liquidity — try the next.
+    }
+  }
+
+  return best
+}
+
+async function quoteV2(
+  network: NetworksEnum,
+  dex: IDexQuoterConfig,
+  tokenIn: HexAddress,
+  tokenOut: HexAddress,
+  amountIn: bigint,
+): Promise<bigint | null> {
+  const provider = ProviderModule.getAnyRpcProvider(network)
+  const router = new Contract(dex.router, UniswapV2Router.abi, provider)
+
+  try {
+    const amounts = await BottleneckModule.getNodeLimiter(network).schedule(async () =>
+      router.getAmountsOut(amountIn, [tokenIn, tokenOut]),
+    )
+    const out = BigInt(amounts[amounts.length - 1])
+    return out > 0n ? out : null
+  } catch {
+    return null
+  }
+}
+
+const DexQuoterModule = {
+  /**
+   * Returns the indicative output amount for swapping `amountIn` of `tokenIn`
+   * for `tokenOut` on the given network, probing every configured DEX in
+   * order. Resolves to `null` when no configured DEX has a route.
+   */
+  async getQuote(params: IGetQuoteParams): Promise<IDexQuote | null> {
+    const { network, tokenIn, tokenOut } = params
+    const dexes = config.DEX_QUOTERS[network]
+    if (!dexes?.length) {
+      return null
+    }
+
+    const amountIn = params.amountIn ?? 10n ** BigInt(await readErc20Decimals(network, tokenIn))
+
+    for (const dex of dexes) {
+      const out =
+        dex.kind === 'uniswapV3'
+          ? await quoteV3(network, dex, tokenIn, tokenOut, amountIn)
+          : await quoteV2(network, dex, tokenIn, tokenOut, amountIn)
+      if (out !== null) {
+        logger.info('Quote resolved', llo({ network, tokenIn, tokenOut, dex: dex.name, amountOut: out.toString() }))
+        return { amountOut: out, amountIn, dex: dex.name }
+      }
+    }
+
+    logger.warn('No DEX produced a quote', llo({ network, tokenIn, tokenOut }))
+    return null
+  },
+
+  /**
+   * Returns the indicative price of `tokenAddress` denominated in the chain's
+   * wrapped-native token (e.g. WBTC on Citrea, WETH on Ethereum) for one whole
+   * unit of the input token. The wrapped-native address comes from the first
+   * configured DEX entry — all DEXs on a network must share the same wrapper.
+   */
+  async getRateInNative(params: IGetRateInNativeParams): Promise<IRateInNativeQuote | null> {
+    const { network, tokenAddress } = params
+    const dexes = config.DEX_QUOTERS[network]
+    if (!dexes?.length) {
+      return null
+    }
+    const { wrappedNative } = dexes[0]
+
+    const tokenDecimals = await readErc20Decimals(network, tokenAddress)
+    const amountIn = 10n ** BigInt(tokenDecimals)
+
+    const quote = await DexQuoterModule.getQuote({ network, tokenIn: tokenAddress, tokenOut: wrappedNative, amountIn })
+    if (!quote) {
+      return null
+    }
+
+    return { ...quote, tokenDecimals, wrappedNative }
+  },
+}
+
+export default DexQuoterModule

--- a/src/services/aragon-rates/fetchRates.ts
+++ b/src/services/aragon-rates/fetchRates.ts
@@ -10,6 +10,7 @@ import logger from '@logger'
 import type Token from '@models/schema/token'
 import DBCrawler from '@models/utils/crawler'
 import DbTx from '@modules/dbTx'
+import DexQuoterModule from '@modules/dexQuoter'
 import { EnumQueueName, ITokenType, NetworksEnum } from '@types'
 
 const llo = logger.logMeta.bind(null, { service: 'rates:FetchRates' })
@@ -22,6 +23,10 @@ export const FetchRates = {
     const startTime = Date.now()
     logger.verbose('Start FetchRates', llo({ startTime }))
 
+    // Networks with an on-chain DEX quoter are priced via DEX fallback even when
+    // skipFetchRate was set by an earlier CoinGecko-only run.
+    const dexNetworks = Object.keys(config.DEX_QUOTERS) as NetworksEnum[]
+
     const crawlerMainnet = new DBCrawler({
       model: Models.Token,
       onDocument: FetchRates.onMainnetDocument,
@@ -30,7 +35,7 @@ export const FetchRates = {
       },
       where: {
         $and: [
-          { skipFetchRate: { $ne: true } },
+          { $or: [{ skipFetchRate: { $ne: true } }, { network: { $in: dexNetworks } }] },
           { isSpam: { $ne: true } },
           { network: { $nin: [NetworksEnum.zksyncSepolia, NetworksEnum.ethereumSepolia] } },
           {
@@ -208,6 +213,36 @@ export const FetchRates = {
     }
   },
 
+  async getDexPriceUsd(token: Token): Promise<string | null> {
+    try {
+      const quote = await DexQuoterModule.getRateInNative({
+        network: token.network,
+        tokenAddress: token.address,
+      })
+      if (!quote) return null
+
+      const nativeToken = await Models.Token.findOne({
+        network: token.network,
+        type: ITokenType.native,
+      })
+      const nativePriceUsd = parseFloat(nativeToken?.priceUsd ?? '0')
+      if (!Number.isFinite(nativePriceUsd) || nativePriceUsd <= 0 || !nativeToken?.decimals) {
+        return null
+      }
+
+      // amountOut is denominated in the wrapped-native asset (e.g. WcBTC on
+      // Citrea), which shares decimals with the chain's native asset, so the
+      // native Token doc's decimals are the right scale here.
+      const priceInNative = Number(quote.amountOut) / 10 ** nativeToken.decimals
+      if (!Number.isFinite(priceInNative) || priceInNative <= 0) return null
+
+      return (priceInNative * nativePriceUsd).toString()
+    } catch (error) {
+      logger.warn('Failed to compute DEX USD price', llo({ error, address: token.address, network: token.network }))
+      return null
+    }
+  },
+
   async onMainnetDocument(token: Token) {
     try {
       const isNativeToken = token.type === ITokenType.native
@@ -218,16 +253,29 @@ export const FetchRates = {
             ? await Web3Helper.getTokenTotalSupply(token.address, token.network)
             : null
 
-      const coingeckoInfo = await CoinGeckoHelper.getToken(token.address, token.network)
+      // CoinGecko's per-token endpoint requires the network to be in its
+      // `networksMap`; for unsupported chains (e.g. Citrea) the ERC-20 call
+      // always fails, so skip it and go straight to the DEX. Native tokens use
+      // a different CoinGecko path (`/coins/{id}`) that works regardless.
+      const hasDexQuoter = !!config.DEX_QUOTERS[token.network]?.length
+      const coingeckoCanQueryToken = isNativeToken || !CoinGeckoHelper.isTestNetwork(token.network)
+
+      const coingeckoInfo = coingeckoCanQueryToken
+        ? await CoinGeckoHelper.getToken(token.address, token.network)
+        : false
+
+      const dexPriceUsd =
+        !coingeckoInfo && !isNativeToken && hasDexQuoter ? await FetchRates.getDexPriceUsd(token) : null
+      const hasRate = !!coingeckoInfo || dexPriceUsd !== null
 
       const failCount = (token.fetchRateFailCount || 0) + 1
 
       const rawTokenUpdate: Partial<Token> = {
         totalSupply: (totalSupply ?? token.totalSupply ?? '0').toString(),
-        priceUsd: coingeckoInfo ? coingeckoInfo.priceUsd : token.priceUsd,
+        priceUsd: coingeckoInfo ? coingeckoInfo.priceUsd : (dexPriceUsd ?? token.priceUsd),
         logo: coingeckoInfo ? coingeckoInfo.logo : token.logo,
-        fetchRateFailCount: coingeckoInfo ? 0 : failCount,
-        nextFetchRateAt: coingeckoInfo ? null : new Date(Date.now() + TokenUtils.getNextFetchRateDelay(failCount - 1)),
+        fetchRateFailCount: hasRate ? 0 : failCount,
+        nextFetchRateAt: hasRate ? null : new Date(Date.now() + TokenUtils.getNextFetchRateDelay(failCount - 1)),
       }
 
       if (

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -140,6 +140,8 @@ export interface IConfig {
     ROUTESCAN_MIN_TIME: number
     CHILIZ_MAX_CONCURRENT: number
     CHILIZ_MIN_TIME: number
+    DEX_QUOTER_MAX_CONCURRENT: number
+    DEX_QUOTER_MIN_TIME: number
   }
   MONGO_DB: {
     NAME: string

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,23 @@ interface ITokenData {
   network: NetworksEnum
 }
 
+export type IDexQuoterKind = 'uniswapV2' | 'uniswapV3'
+
+export interface IDexQuoterConfig {
+  /** Stable identifier used for logging and disambiguating multiple DEXs on the same network. */
+  name: string
+  /** Quoting protocol family. Determines which on-chain function is used. */
+  kind: IDexQuoterKind
+  /** Address of the swap router. Read by V2 quotes via getAmountsOut; informational for V3. */
+  router: HexAddress
+  /** Address of the V3 quoter (QuoterV2). Required when kind === 'uniswapV3'. */
+  quoter?: HexAddress
+  /** ERC-20 representation of the chain's native asset that pools price against (e.g. WETH, WcBTC). */
+  wrappedNative: HexAddress
+  /** V3 fee tiers (in 1e6 units) to probe in order. Only used when kind === 'uniswapV3'. */
+  feeTiers?: number[]
+}
+
 export interface IRawNodeConfig {
   ALCHEMY_API_KEY: string
   ARAGON_RPC: string
@@ -172,6 +189,8 @@ export interface IConfig {
   CONTRACTS: {
     ENS_REGISTRY: string
   }
+
+  DEX_QUOTERS: Partial<Record<NetworksEnum, IDexQuoterConfig[]>>
 
   IPFS: {
     METADATA_FETCH_RETRY: number

--- a/test/integration/specs/dexQuoter.spec.ts
+++ b/test/integration/specs/dexQuoter.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test for `DexQuoterModule.getRateInNative` against the live
+ * Citrea mainnet JuiceSwap V3 quoter.
+ *
+ * Required env (one of):
+ *   - NODES_CITREA_MAINNET_ARAGON_RPC=<https url>
+ *   - NODES_CITREA_MAINNET_DRPC_API_KEY=<key>
+ *   - NODES_CITREA_MAINNET_ALCHEMY_API_KEY=<key>
+ *
+ * The suite is `describe.skip(...)` because no token-with-liquidity has yet
+ * been confidently identified for Citrea / JuiceSwap V3 (see CITREA_TOKEN
+ * constant below). Replace that constant with a verified ERC-20 that has a
+ * pool against the configured wrappedNative on JuiceSwap, then drop the
+ * `.skip` to enable. The assertions remain volatility-resistant — only that
+ * the call returned a positive bigint, not an exact price.
+ *
+ * The suite also self-skips at runtime when none of the Citrea RPC
+ * credentials above are present, so locally-run integrations never fail
+ * loudly on missing env.
+ */
+import config from '@config'
+import DexQuoterModule from '@modules/dexQuoter'
+import ProviderModule from '@modules/provider'
+import { type HexAddress, IProviderType, NetworksEnum } from '@types'
+import { expect } from 'chai'
+
+const NETWORK = NetworksEnum.citreaMainnet
+const EXPECTED_WRAPPED_NATIVE = '0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d'
+
+// TODO: replace with a verified ERC-20 on Citrea mainnet that has a
+// JuiceSwap V3 pool against `EXPECTED_WRAPPED_NATIVE` (WCBTC). Candidates to
+// check on https://explorer.mainnet.citrea.xyz: ctUSD, USDC, GUSD, etc.
+// Once chosen, remove the `.skip` on the describe block below.
+const CITREA_TOKEN = '0x0000000000000000000000000000000000000000' as HexAddress
+
+function citreaRpcConfigured(): boolean {
+  const node = config.NODES?.CITREA_MAINNET
+  return Boolean(node?.ARAGON_RPC || node?.DRPC_API_KEY || node?.ALCHEMY_API_KEY)
+}
+
+async function ensureCitreaProvider(): Promise<void> {
+  // If something already populated the proxy (e.g. another suite called
+  // connectToAllNetworks), reuse it; otherwise wire from config so we hit
+  // the real RPC without depending on the global service bootstrap.
+  if (ProviderModule.getAnyRpcProvider(NETWORK)) return
+
+  const node = config.NODES?.CITREA_MAINNET
+  if (!node) return
+
+  if (node.ARAGON_RPC) {
+    await ProviderModule.connectToNetwork(NETWORK, {
+      providerType: IProviderType.ARAGON,
+      rpcEndpoint: node.ARAGON_RPC,
+      fromBlock: node.FROM_BLOCK,
+      confirmationBlocks: node.CONFIRMATION_BLOCKS,
+      intervalBlockTime: node.INTERVAL_BLOCK_TIME,
+    })
+    return
+  }
+
+  if (node.DRPC_API_KEY) {
+    await ProviderModule.connectToNetwork(NETWORK, {
+      providerType: IProviderType.DRPC,
+      drpcApiKey: node.DRPC_API_KEY,
+      fromBlock: node.FROM_BLOCK,
+      confirmationBlocks: node.CONFIRMATION_BLOCKS,
+      intervalBlockTime: node.INTERVAL_BLOCK_TIME,
+    })
+    return
+  }
+
+  if (node.ALCHEMY_API_KEY) {
+    await ProviderModule.connectToNetwork(NETWORK, {
+      providerType: IProviderType.ALCHEMY,
+      alchemyApiKey: node.ALCHEMY_API_KEY,
+      fromBlock: node.FROM_BLOCK,
+      confirmationBlocks: node.CONFIRMATION_BLOCKS,
+      intervalBlockTime: node.INTERVAL_BLOCK_TIME,
+    })
+  }
+}
+
+describe.skip('Module: dexQuoter — Citrea mainnet (live RPC)', function () {
+  this.timeout(300_000)
+  this.slow(0)
+
+  before(async function () {
+    if (!citreaRpcConfigured()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[dexQuoter integration] No Citrea RPC env var set ' +
+          '(NODES_CITREA_MAINNET_ARAGON_RPC / DRPC_API_KEY / ALCHEMY_API_KEY) — skipping suite.',
+      )
+      this.skip()
+    }
+    await ensureCitreaProvider()
+    if (!ProviderModule.getAnyRpcProvider(NETWORK)) {
+      // eslint-disable-next-line no-console
+      console.warn('[dexQuoter integration] Failed to instantiate Citrea provider — skipping suite.')
+      this.skip()
+    }
+  })
+
+  it('getRateInNative returns a positive quote denominated in wrappedNative', async () => {
+    const result = await DexQuoterModule.getRateInNative({
+      network: NETWORK,
+      tokenAddress: CITREA_TOKEN,
+    })
+
+    expect(result, 'getRateInNative returned null — token may have no JuiceSwap V3 pool').to.not.be.null
+    expect(result!.amountOut > 0n, `expected amountOut > 0, got ${result!.amountOut.toString()}`).to.be.true
+    expect(result!.dex).to.equal('juiceswap')
+    expect(result!.wrappedNative.toLowerCase()).to.equal(EXPECTED_WRAPPED_NATIVE.toLowerCase())
+    expect(result!.tokenDecimals, 'tokenDecimals must be a positive number').to.be.a('number').and.greaterThan(0)
+  })
+})

--- a/test/integration/specs/dexQuoter.spec.ts
+++ b/test/integration/specs/dexQuoter.spec.ts
@@ -2,21 +2,16 @@
  * Integration test for `DexQuoterModule.getRateInNative` against the live
  * Citrea mainnet JuiceSwap V3 quoter.
  *
- * Required env (one of):
- *   - NODES_CITREA_MAINNET_ARAGON_RPC=<https url>
- *   - NODES_CITREA_MAINNET_DRPC_API_KEY=<key>
- *   - NODES_CITREA_MAINNET_ALCHEMY_API_KEY=<key>
+ * Required env:
+ *   - CITREA_TEST_TOKEN_ADDRESS=<0x… an ERC-20 with a JuiceSwap V3 pool
+ *       against the configured wrappedNative (WcBTC, 0xDF240DC0…)>
+ *   - one of: NODES_CITREA_MAINNET_ARAGON_RPC | NODES_CITREA_MAINNET_DRPC_API_KEY
+ *       | NODES_CITREA_MAINNET_ALCHEMY_API_KEY
  *
- * The suite is `describe.skip(...)` because no token-with-liquidity has yet
- * been confidently identified for Citrea / JuiceSwap V3 (see CITREA_TOKEN
- * constant below). Replace that constant with a verified ERC-20 that has a
- * pool against the configured wrappedNative on JuiceSwap, then drop the
- * `.skip` to enable. The assertions remain volatility-resistant — only that
- * the call returned a positive bigint, not an exact price.
- *
- * The suite also self-skips at runtime when none of the Citrea RPC
- * credentials above are present, so locally-run integrations never fail
- * loudly on missing env.
+ * The suite runtime-skips when either piece of config is missing so a local
+ * `yarn test:integration` run never fails loudly on env. Assertions are
+ * volatility-resistant — only that the call returned a positive bigint, not
+ * an exact price.
  */
 import config from '@config'
 import DexQuoterModule from '@modules/dexQuoter'
@@ -27,11 +22,7 @@ import { expect } from 'chai'
 const NETWORK = NetworksEnum.citreaMainnet
 const EXPECTED_WRAPPED_NATIVE = '0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d'
 
-// TODO: replace with a verified ERC-20 on Citrea mainnet that has a
-// JuiceSwap V3 pool against `EXPECTED_WRAPPED_NATIVE` (WCBTC). Candidates to
-// check on https://explorer.mainnet.citrea.xyz: ctUSD, USDC, GUSD, etc.
-// Once chosen, remove the `.skip` on the describe block below.
-const CITREA_TOKEN = '0x0000000000000000000000000000000000000000' as HexAddress
+const CITREA_TOKEN = (process.env.CITREA_TEST_TOKEN_ADDRESS || '') as HexAddress
 
 function citreaRpcConfigured(): boolean {
   const node = config.NODES?.CITREA_MAINNET
@@ -80,11 +71,16 @@ async function ensureCitreaProvider(): Promise<void> {
   }
 }
 
-describe.skip('Module: dexQuoter — Citrea mainnet (live RPC)', function () {
+describe('Module: dexQuoter — Citrea mainnet (live RPC)', function () {
   this.timeout(300_000)
   this.slow(0)
 
   before(async function () {
+    if (!CITREA_TOKEN) {
+      // eslint-disable-next-line no-console
+      console.warn('[dexQuoter integration] CITREA_TEST_TOKEN_ADDRESS env var not set — skipping suite.')
+      this.skip()
+    }
     if (!citreaRpcConfigured()) {
       // eslint-disable-next-line no-console
       console.warn(

--- a/test/unit/helpers/tokenUtils.spec.ts
+++ b/test/unit/helpers/tokenUtils.spec.ts
@@ -101,6 +101,14 @@ describe('TokenUtils', () => {
       const tokenRate = { priceUsd: '10' }
       expect(TokenUtils.shouldSkipFetch(token, tokenRate)).to.be.false
     })
+
+    it('should return false when the network has a DEX quoter even with zero price', () => {
+      // Citrea is configured in config.DEX_QUOTERS by default, so it shouldn't be
+      // marked as skip — the rate fetcher can price it via the on-chain DEX.
+      const token = { ...baseToken, network: NetworksEnum.citreaMainnet, type: ITokenType.unknown, symbol: null }
+      const tokenRate = { priceUsd: '0' }
+      expect(TokenUtils.shouldSkipFetch(token, tokenRate)).to.be.false
+    })
   })
 
   describe('getSpamScore', () => {

--- a/test/unit/modules/bottleneck.spec.ts
+++ b/test/unit/modules/bottleneck.spec.ts
@@ -244,4 +244,30 @@ describe('Module: bottleneck', () => {
       expect(limiter.schedule).to.be.a('function')
     })
   })
+
+  describe('getDexQuoterLimiter', () => {
+    it('returns the same instance for the same network', () => {
+      const limiter1 = BottleneckModule.getDexQuoterLimiter(NetworksEnum.citreaMainnet)
+      const limiter2 = BottleneckModule.getDexQuoterLimiter(NetworksEnum.citreaMainnet)
+
+      expect(limiter1).to.eq(limiter2)
+
+      const limiter3 = BottleneckModule.dexQuoterLimiters[NetworksEnum.citreaMainnet]
+      expect(limiter3).to.eq(limiter1)
+    })
+
+    it('returns different instances for different networks', () => {
+      const limiter1 = BottleneckModule.getDexQuoterLimiter(NetworksEnum.citreaMainnet)
+      const limiter2 = BottleneckModule.getDexQuoterLimiter(NetworksEnum.ethereumMainnet)
+
+      expect(limiter1).not.eq(limiter2)
+    })
+
+    it('does not share state with the node limiter', () => {
+      const dex = BottleneckModule.getDexQuoterLimiter(NetworksEnum.citreaMainnet)
+      const node = BottleneckModule.getNodeLimiter(NetworksEnum.citreaMainnet)
+
+      expect(dex).not.eq(node)
+    })
+  })
 })

--- a/test/unit/modules/dexQuoter.spec.ts
+++ b/test/unit/modules/dexQuoter.spec.ts
@@ -46,7 +46,7 @@ describe('Module: dexQuoter', () => {
 
     sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({} as any)
     scheduleStub = sandbox.stub().callsFake(async (fn: () => Promise<any>) => fn())
-    sandbox.stub(BottleneckModule, 'getNodeLimiter').returns({ schedule: scheduleStub } as any)
+    sandbox.stub(BottleneckModule, 'getDexQuoterLimiter').returns({ schedule: scheduleStub } as any)
 
     // Per-test factory stub: each `new Contract(address, abi, provider)` invocation
     // pulls the next pre-queued fake from `contractFactory`.

--- a/test/unit/modules/dexQuoter.spec.ts
+++ b/test/unit/modules/dexQuoter.spec.ts
@@ -1,0 +1,309 @@
+import config from '@config'
+import logger from '@logger'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+import { type HexAddress, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import proxyquire from 'proxyquire'
+import * as sinon from 'sinon'
+import { type SinonSandbox, type SinonStub } from 'sinon'
+
+describe('Module: dexQuoter', () => {
+  let sandbox: SinonSandbox
+  let DexQuoterModule: any
+  let contractFactory: SinonStub
+  let scheduleStub: SinonStub
+
+  const network = NetworksEnum.citreaMainnet
+  const tokenIn = '0x1111111111111111111111111111111111111111' as HexAddress
+  const tokenOut = '0x2222222222222222222222222222222222222222' as HexAddress
+  const wrappedNative = '0x3333333333333333333333333333333333333333' as HexAddress
+
+  const v3Dex = (overrides: Partial<any> = {}) => ({
+    name: 'satsumaV3',
+    kind: 'uniswapV3' as const,
+    router: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as HexAddress,
+    quoter: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as HexAddress,
+    wrappedNative,
+    feeTiers: [500, 3000, 10000],
+    ...overrides,
+  })
+
+  const v2Dex = (overrides: Partial<any> = {}) => ({
+    name: 'satsumaV2',
+    kind: 'uniswapV2' as const,
+    router: '0xcccccccccccccccccccccccccccccccccccccccc' as HexAddress,
+    wrappedNative,
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+
+    // Silence info / warn logs emitted by the module so test output stays clean.
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'warn')
+
+    sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({} as any)
+    scheduleStub = sandbox.stub().callsFake(async (fn: () => Promise<any>) => fn())
+    sandbox.stub(BottleneckModule, 'getNodeLimiter').returns({ schedule: scheduleStub } as any)
+
+    // Per-test factory stub: each `new Contract(address, abi, provider)` invocation
+    // pulls the next pre-queued fake from `contractFactory`.
+    contractFactory = sandbox.stub()
+
+    // Re-require the module through proxyquire so `ethers.Contract` is our fake.
+    DexQuoterModule = proxyquire.noCallThru()('@modules/dexQuoter', {
+      ethers: {
+        Contract: function (address: string, _abi: unknown, _provider: unknown) {
+          return contractFactory(address)
+        },
+      },
+    }).default
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  describe('getQuote', () => {
+    it('returns null when no DEX is configured for the network', async () => {
+      sandbox.stub(config, 'DEX_QUOTERS').value({})
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+      expect(contractFactory.called).to.be.false
+    })
+
+    it('uses uniswapV3 happy path returning the quote from the first fee tier', async () => {
+      const dex = v3Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v3Quoter = {
+        quoteExactInputSingle: {
+          staticCall: sandbox.stub(),
+        },
+      }
+      // First call resolves the input ERC20 (decimals); subsequent calls resolve the quoter.
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v3Quoter)
+
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(0).resolves({ amountOut: 5_000n })
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(1).rejects(new Error('no pool'))
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(2).rejects(new Error('no pool'))
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.deep.equal({ amountOut: 5_000n, amountIn: 10n ** 18n, dex: dex.name })
+      // ERC20 decimals + V3 quoter contract = 2 instances.
+      expect(contractFactory.callCount).to.equal(2)
+    })
+
+    it('iterates V3 fee tiers and picks the highest amountOut across multiple successful tiers', async () => {
+      const dex = v3Dex({ feeTiers: [100, 500, 3000] })
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(6n) }
+      const v3Quoter = {
+        quoteExactInputSingle: {
+          staticCall: sandbox.stub(),
+        },
+      }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v3Quoter)
+
+      // Tier 0 reverts, tier 1 returns 1_000 (positional encoding via array form),
+      // tier 2 returns 2_500 (the higher value -> should win).
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(0).rejects(new Error('no pool'))
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(1).resolves([1_000n])
+      v3Quoter.quoteExactInputSingle.staticCall.onCall(2).resolves({ amountOut: 2_500n })
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.deep.equal({ amountOut: 2_500n, amountIn: 10n ** 6n, dex: dex.name })
+    })
+
+    it('returns null and ignores zero quotes when every V3 tier reverts or returns 0', async () => {
+      const dex = v3Dex({ feeTiers: [500] })
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v3Quoter = {
+        quoteExactInputSingle: {
+          staticCall: sandbox.stub().resolves({ amountOut: 0n }),
+        },
+      }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v3Quoter)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
+
+    it('skips a V3 dex with no quoter, falling through to the next configured dex (V2 here)', async () => {
+      const v3 = v3Dex({ quoter: undefined })
+      const v2 = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [v3, v2] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v2Router = { getAmountsOut: sandbox.stub().resolves([10n ** 18n, 7_777n]) }
+      contractFactory.onCall(0).returns(erc20)
+      // No contract is built for the V3 dex (early return in quoteV3) — next call is the V2 router.
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.deep.equal({ amountOut: 7_777n, amountIn: 10n ** 18n, dex: v2.name })
+    })
+
+    it('returns null when V3 dex has no feeTiers and no other dex is configured', async () => {
+      const dex = v3Dex({ feeTiers: undefined })
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      contractFactory.onCall(0).returns(erc20)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
+
+    it('uses uniswapV2 happy path via getAmountsOut', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v2Router = { getAmountsOut: sandbox.stub().resolves([10n ** 18n, 42n]) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.deep.equal({ amountOut: 42n, amountIn: 10n ** 18n, dex: dex.name })
+      expect(v2Router.getAmountsOut.calledOnce).to.be.true
+      expect(v2Router.getAmountsOut.firstCall.args[1]).to.deep.equal([tokenIn, tokenOut])
+    })
+
+    it('returns null when V2 getAmountsOut throws', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v2Router = { getAmountsOut: sandbox.stub().rejects(new Error('no path')) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
+
+    it('returns null when V2 getAmountsOut returns a non-positive amount', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v2Router = { getAmountsOut: sandbox.stub().resolves([10n ** 18n, 0n]) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
+
+    it('returns null when every configured DEX fails', async () => {
+      const v3 = v3Dex({ feeTiers: [500] })
+      const v2 = v2Dex({ name: 'fallbackV2' })
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [v3, v2] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v3Quoter = {
+        quoteExactInputSingle: {
+          staticCall: sandbox.stub().rejects(new Error('no pool')),
+        },
+      }
+      const v2Router = { getAmountsOut: sandbox.stub().rejects(new Error('no path')) }
+
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.onCall(1).returns(v3Quoter)
+      contractFactory.onCall(2).returns(v2Router)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
+
+    it('passes through caller-provided amountIn without resolving ERC20 decimals', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const v2Router = { getAmountsOut: sandbox.stub().resolves([123n, 999n]) }
+      // First call is the V2 router — decimals path is never taken.
+      contractFactory.returns(v2Router)
+
+      const customAmountIn = 123n
+      const result = await DexQuoterModule.getQuote({
+        network,
+        tokenIn,
+        tokenOut,
+        amountIn: customAmountIn,
+      })
+
+      expect(result).to.deep.equal({ amountOut: 999n, amountIn: customAmountIn, dex: dex.name })
+      expect(v2Router.getAmountsOut.firstCall.args[0]).to.equal(customAmountIn)
+      // Only the router contract should have been instantiated (no ERC20 decimals lookup).
+      expect(contractFactory.callCount).to.equal(1)
+    })
+  })
+
+  describe('getRateInNative', () => {
+    it('returns null when no DEX is configured (decimals is never read)', async () => {
+      sandbox.stub(config, 'DEX_QUOTERS').value({})
+
+      const result = await DexQuoterModule.getRateInNative({ network, tokenAddress: tokenIn })
+
+      expect(result).to.be.null
+      expect(contractFactory.called).to.be.false
+    })
+
+    it('returns the wrapped-native quote with tokenDecimals on the happy path', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const v2Router = { getAmountsOut: sandbox.stub().resolves([10n ** 18n, 4_321n]) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getRateInNative({ network, tokenAddress: tokenIn })
+
+      expect(result).to.deep.equal({
+        amountOut: 4_321n,
+        amountIn: 10n ** 18n,
+        dex: dex.name,
+        tokenDecimals: 18,
+        wrappedNative,
+      })
+      // The inner getQuote should have been invoked with tokenOut === wrappedNative.
+      expect(v2Router.getAmountsOut.firstCall.args[1]).to.deep.equal([tokenIn, wrappedNative])
+    })
+
+    it('returns null when the inner getQuote produces no quote', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(8n) }
+      const v2Router = { getAmountsOut: sandbox.stub().rejects(new Error('no path')) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(v2Router)
+
+      const result = await DexQuoterModule.getRateInNative({ network, tokenAddress: tokenIn })
+
+      expect(result).to.be.null
+    })
+  })
+})

--- a/test/unit/modules/dexQuoter.spec.ts
+++ b/test/unit/modules/dexQuoter.spec.ts
@@ -305,5 +305,75 @@ describe('Module: dexQuoter', () => {
 
       expect(result).to.be.null
     })
+
+    it('returns null when readErc20Decimals fails (no provider)', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      // Make the provider missing — readErc20Decimals must return null and getRateInNative must bail.
+      ;(ProviderModule.getAnyRpcProvider as SinonStub).returns(undefined)
+
+      const result = await DexQuoterModule.getRateInNative({ network, tokenAddress: tokenIn })
+
+      expect(result).to.be.null
+      expect(contractFactory.called).to.be.false
+    })
+
+    it('warns and continues when a DEX entry declares a mismatched wrappedNative', async () => {
+      const primary = v2Dex({ name: 'primary' })
+      const mismatched = v2Dex({
+        name: 'mismatched',
+        wrappedNative: '0x9999999999999999999999999999999999999999' as HexAddress,
+      })
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [primary, mismatched] })
+
+      const erc20 = { decimals: sandbox.stub().resolves(18n) }
+      const primaryRouter = { getAmountsOut: sandbox.stub().resolves([10n ** 18n, 555n]) }
+      contractFactory.onCall(0).returns(erc20)
+      contractFactory.returns(primaryRouter)
+
+      const result = await DexQuoterModule.getRateInNative({ network, tokenAddress: tokenIn })
+
+      expect((logger.warn as SinonStub).calledWith('Ignoring DEX entries with mismatched wrappedNative')).to.be.true
+      expect(result).to.deep.equal({
+        amountOut: 555n,
+        amountIn: 10n ** 18n,
+        dex: 'primary',
+        tokenDecimals: 18,
+        wrappedNative,
+      })
+    })
+  })
+
+  describe('resilience', () => {
+    it('getQuote returns null when ProviderModule has no provider for the network', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      ;(ProviderModule.getAnyRpcProvider as SinonStub).returns(undefined)
+
+      const result = await DexQuoterModule.getQuote({
+        network,
+        tokenIn,
+        tokenOut,
+        amountIn: 1n,
+      })
+
+      expect(result).to.be.null
+      expect(contractFactory.called).to.be.false
+    })
+
+    it('getQuote returns null when default amountIn cannot be derived (decimals call throws)', async () => {
+      const dex = v2Dex()
+      sandbox.stub(config, 'DEX_QUOTERS').value({ [network]: [dex] })
+
+      // ERC20.decimals() throws → readErc20Decimals returns null → getQuote bails.
+      const erc20 = { decimals: sandbox.stub().rejects(new Error('not an ERC20')) }
+      contractFactory.returns(erc20)
+
+      const result = await DexQuoterModule.getQuote({ network, tokenIn, tokenOut })
+
+      expect(result).to.be.null
+    })
   })
 })

--- a/test/unit/services/aragon-rates/fetchRates.spec.ts
+++ b/test/unit/services/aragon-rates/fetchRates.spec.ts
@@ -7,6 +7,7 @@ import TokenUtils from '@helpers/tokenUtils'
 import Web3Helper from '@helpers/web3'
 import logger from '@logger'
 import DBCrawler from '@models/utils/crawler'
+import DexQuoterModule from '@modules/dexQuoter'
 import { FetchRates } from '@services/aragon-rates/fetchRates'
 import { FakeAsset } from '@test/mock/fakeAsset'
 import { EnumQueueName, ITokenType, NetworksEnum } from '@types'
@@ -255,6 +256,159 @@ describe('AragonRates: FetchRates', () => {
       expect(veSupplyStub.calledOnceWith(adapterToken.address, adapterToken.network)).to.be.true
       expect(erc20SupplyStub.called).to.be.false
       expect(updateStub.firstCall.args[0]).to.deep.include({ totalSupply: '1780000' })
+    })
+
+    it('should use DEX fallback for ERC20 on a non-CoinGecko network and skip CoinGecko call', async () => {
+      const citreaToken = await Models.Token.create({
+        network: NetworksEnum.citreaMainnet,
+        type: ITokenType.ERC20,
+        address: '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D',
+        logo: '',
+        name: 'Citrea USD',
+        symbol: 'CTUSD',
+        decimals: 6,
+        holders: 0,
+        totalSupply: '0',
+        priceUsd: '0',
+        hasTotalSupply: true,
+      })
+
+      sandbox.stub(Web3Helper, 'getTokenTotalSupply').resolves(1000n)
+      const coinGeckoStub = sandbox.stub(CoinGeckoHelper, 'getToken')
+      const dexStub = sandbox.stub(FetchRates, 'getDexPriceUsd').resolves('1.05')
+      sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
+
+      const mockDate = new Date('2023-01-01T00:00:00Z')
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => mockDate } as any)
+      const updateStub = sandbox.stub(citreaToken, 'update').resolves(citreaToken as any)
+      sandbox.stub(logger, 'verbose')
+
+      await FetchRates.onMainnetDocument(citreaToken as any)
+
+      expect(coinGeckoStub.called).to.be.false
+      expect(dexStub.calledOnceWith(citreaToken as any)).to.be.true
+      const args = updateStub.firstCall.args[0]
+      expect(args.priceUsd).to.equal('1.05')
+      expect(args.fetchRateFailCount).to.equal(0)
+      expect(args.nextFetchRateAt).to.be.null
+    })
+
+    it('should still query CoinGecko for native tokens on non-CoinGecko networks', async () => {
+      const citreaNative = await Models.Token.create({
+        network: NetworksEnum.citreaMainnet,
+        type: ITokenType.native,
+        address: '0x0000000000000000000000000000000000000000',
+        logo: '',
+        name: 'Bitcoin',
+        symbol: 'BTC',
+        decimals: 18,
+        holders: 0,
+        totalSupply: '0',
+        priceUsd: '0',
+      })
+
+      const coinGeckoStub = sandbox
+        .stub(CoinGeckoHelper, 'getToken')
+        .resolves({ priceUsd: '95000', logo: 'btc.svg' } as any)
+      const dexStub = sandbox.stub(FetchRates, 'getDexPriceUsd')
+      sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
+
+      const mockDate = new Date('2023-01-01T00:00:00Z')
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => mockDate } as any)
+      const updateStub = sandbox.stub(citreaNative, 'update').resolves(citreaNative as any)
+      sandbox.stub(logger, 'verbose')
+
+      await FetchRates.onMainnetDocument(citreaNative as any)
+
+      expect(coinGeckoStub.calledOnce).to.be.true
+      expect(dexStub.called).to.be.false
+      expect(updateStub.firstCall.args[0].priceUsd).to.equal('95000')
+    })
+
+    it('should increment backoff when CoinGecko skipped and DEX returns null', async () => {
+      const citreaToken = await Models.Token.create({
+        network: NetworksEnum.citreaMainnet,
+        type: ITokenType.ERC20,
+        address: '0xUnpriced',
+        logo: '',
+        name: 'Unpriced',
+        symbol: 'X',
+        decimals: 18,
+        holders: 0,
+        totalSupply: '0',
+        priceUsd: '0',
+        hasTotalSupply: true,
+      })
+
+      sandbox.stub(Web3Helper, 'getTokenTotalSupply').resolves(0n)
+      const coinGeckoStub = sandbox.stub(CoinGeckoHelper, 'getToken')
+      sandbox.stub(FetchRates, 'getDexPriceUsd').resolves(null)
+      sandbox.stub(TokenUtils, 'shouldSkipFetch').returns(false)
+      sandbox.stub(dayjs, 'utc').returns({ toDate: () => new Date() } as any)
+
+      const updateStub = sandbox.stub(citreaToken, 'update').resolves(citreaToken as any)
+      sandbox.stub(logger, 'verbose')
+
+      await FetchRates.onMainnetDocument(citreaToken as any)
+
+      expect(coinGeckoStub.called).to.be.false
+      const args = updateStub.firstCall.args[0]
+      expect(args.fetchRateFailCount).to.equal(1)
+      expect(args.nextFetchRateAt).to.be.instanceOf(Date)
+    })
+  })
+
+  describe('getDexPriceUsd', () => {
+    it('should return null when DEX returns no quote', async () => {
+      const token = { address: '0xAbc', network: NetworksEnum.citreaMainnet } as any
+      sandbox.stub(DexQuoterModule, 'getRateInNative').resolves(null)
+      sandbox.stub(logger, 'warn')
+
+      const result = await FetchRates.getDexPriceUsd(token)
+      expect(result).to.be.null
+    })
+
+    it('should return null when native Token has no priceUsd', async () => {
+      const token = { address: '0xAbc', network: NetworksEnum.citreaMainnet } as any
+      sandbox.stub(DexQuoterModule, 'getRateInNative').resolves({
+        amountOut: 10n ** 13n,
+        amountIn: 10n ** 6n,
+        dex: 'juiceswap',
+        tokenDecimals: 6,
+        wrappedNative: '0xWrappedNative' as any,
+      })
+      sandbox.stub(Models.Token, 'findOne').resolves({ priceUsd: '0', decimals: 18 } as any)
+      sandbox.stub(logger, 'warn')
+
+      const result = await FetchRates.getDexPriceUsd(token)
+      expect(result).to.be.null
+    })
+
+    it('should compute USD price from DEX quote and native Token price', async () => {
+      const token = { address: '0xAbc', network: NetworksEnum.citreaMainnet } as any
+      // 1 CTUSD -> 1e13 wei of WcBTC (~0.00001 cBTC at 18 decimals)
+      sandbox.stub(DexQuoterModule, 'getRateInNative').resolves({
+        amountOut: 10n ** 13n,
+        amountIn: 10n ** 6n,
+        dex: 'juiceswap',
+        tokenDecimals: 6,
+        wrappedNative: '0xWrappedNative' as any,
+      })
+      sandbox.stub(Models.Token, 'findOne').resolves({ priceUsd: '100000', decimals: 18 } as any)
+
+      const result = await FetchRates.getDexPriceUsd(token)
+      // 0.00001 * 100000 = 1
+      expect(Number(result)).to.be.closeTo(1, 1e-9)
+    })
+
+    it('should return null and log when an error occurs', async () => {
+      const token = { address: '0xAbc', network: NetworksEnum.citreaMainnet } as any
+      sandbox.stub(DexQuoterModule, 'getRateInNative').rejects(new Error('boom'))
+      const warnStub = sandbox.stub(logger, 'warn')
+
+      const result = await FetchRates.getDexPriceUsd(token)
+      expect(result).to.be.null
+      expect(warnStub.called).to.be.true
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `DexQuoterModule` (`src/modules/dexQuoter.ts`) — quotes token prices against configured on-chain DEX routers. Supports both Uniswap V2 (`getAmountsOut`) and Uniswap V3 (`QuoterV2.quoteExactInputSingle`, probes all configured fee tiers and returns the best amountOut).
- Wires Citrea → JuiceSwap V3 against wcBTC under `config.DEX_QUOTERS` (router \`0x565e…3cF8\`, quoter \`0x428f…8425\`, fee tiers 100/500/3000/10000).
- Adds `IDexQuoterConfig` type and new ABI artifacts (V2 router, V3 QuoterV2).

This is the building block for [BE-205 — Citrea has no rates](https://linear.app/aragon/issue/BE-205/citrea-has-no-rates). `getRateInNative` returns the price in wrapped-native units; callers multiply by the wrapper's USD price (BTC on Citrea, via CoinGecko's \`nativeTokenIdMap[citreaMainnet] = 'bitcoin'\`) to derive \`priceUsd\`.

Wiring into \`proxyToken.wrapTokenDetails\` / \`RateModule.fetchHistoricalRate\` for Citrea ERC20s is the follow-up — kept out of this PR to keep the diff reviewable.

## Test plan

- [x] \`yarn test:unit\` for \`test/unit/modules/dexQuoter.spec\` — 14 tests covering V2/V3 happy paths, fee-tier iteration, multi-DEX fallback, and all failure modes
- [x] \`yarn format:fix\` + biome lint clean on touched files
- [x] \`npx tsc --noEmit\` clean
- [ ] Integration spec at \`test/integration/specs/dexQuoter.spec.ts\` — run against a Citrea RPC to spot-check a real quote
- [ ] Follow-up PR: invoke \`DexQuoterModule.getRateInNative\` from \`proxyToken\` when CoinGecko has no data for the token, combine with native BTC price to populate \`priceUsd\` for Citrea ERC20s