### PR TITLE
feat(retryRequest): update warning message for server error retries

### DIFF
--- a/src/helpers/retryRequest.ts
+++ b/src/helpers/retryRequest.ts
@@ -46,7 +46,7 @@ export async function retryRequest<T>(requestFunction: () => Promise<T>, options
         throw error
       } else if (isErrorRelatedToServerIssue(error)) {
         logger.warn(
-          'Warn, retrying on alchemy server error...',
+          'Warn, retrying on upstream server error...',
           llo({ retryCount, wait: retryDelay(retryCount), error }),
         )
         await Utils.wait(retryDelay(retryCount))

--- a/test/unit/helpers/retryRequest.spec.ts
+++ b/test/unit/helpers/retryRequest.spec.ts
@@ -135,7 +135,7 @@ describe('Helpers:RetryRequest', () => {
       expect(requestFunction.calledTwice).to.be.true
       expect(waitStub.calledOnce).to.be.true
       expect(warnStub.calledOnce).to.be.true
-      expect(warnStub.calledWithMatch('Warn, retrying on alchemy server error...' as any)).to.be.true
+      expect(warnStub.calledWithMatch('Warn, retrying on upstream server error...' as any)).to.be.true
     })
 
     it('should retry when the error is TIMEOUT and isErrorRelatedToServerIssue returns true', async () => {
@@ -163,7 +163,7 @@ describe('Helpers:RetryRequest', () => {
       expect(requestFunction.calledTwice).to.be.true
       expect(waitStub.calledOnce).to.be.true
       expect(warnStub.calledOnce).to.be.true
-      expect(warnStub.calledWithMatch('Warn, retrying on alchemy server error...' as any)).to.be.true
+      expect(warnStub.calledWithMatch('Warn, retrying on upstream server error...' as any)).to.be.true
     })
 
     it('should throw the last error after exceeding max retries', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request updates the retry logic in the `retryRequest` helper to use more generic logging language, and updates the corresponding tests to match. The change improves clarity by referring to "upstream server error" instead of the more specific "alchemy server error".

Logging message update:

* Changed the warning log message in `retryRequest.ts` from "Warn, retrying on alchemy server error..." to "Warn, retrying on upstream server error..." for more general applicability.

Test updates:

* Updated the tests in `retryRequest.spec.ts` to expect the new log message, ensuring consistency with the code change. [[1]](diffhunk://#diff-745107e83cdb538ac7bd8ee5d2e55ae359901425bdf2679b736ac80ddcb80126L138-R138) [[2]](diffhunk://#diff-745107e83cdb538ac7bd8ee5d2e55ae359901425bdf2679b736ac80ddcb80126L166-R166)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
