### PR TITLE
Feat/add create campaign action decoding details app 720

### DIFF
--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -842,25 +842,22 @@ class DecodeActions {
       const merkleRoot = decodedData.parameters[1]?.value?.[2] as string | undefined
       const payoutTokenAddress = decodedData.parameters[2]?.value?.[0] as string | undefined
 
-      if (!merkleRoot) {
-        return null
+      let totals = { totalAmount: '0', claimersCount: 0 }
+      if (merkleRoot) {
+        const draft = await Models.CampaignMerkleRoot.findDraftByMerkleRoot(
+          action.to as HexAddress,
+          document.network!,
+          merkleRoot,
+        )
+
+        if (draft) {
+          totals = await Models.CampaignReward.aggregateCampaignAllocations(
+            action.to as HexAddress,
+            document.network!,
+            draft.campaignId,
+          )
+        }
       }
-
-      const draft = await Models.CampaignMerkleRoot.findDraftByMerkleRoot(
-        action.to as HexAddress,
-        document.network!,
-        merkleRoot,
-      )
-
-      if (!draft) {
-        return null
-      }
-
-      const totals = await Models.CampaignReward.aggregateCampaignAllocations(
-        action.to as HexAddress,
-        document.network!,
-        draft.campaignId,
-      )
 
       let tokenInfo: any = null
       if (payoutTokenAddress) {

--- a/src/types/proposalAction.ts
+++ b/src/types/proposalAction.ts
@@ -50,7 +50,7 @@ export enum KnownActionSignature {
   RegisterGauge = 'registerGauge(address,uint8,address,string)',
   CreateGauge = 'createGauge(address,string)',
   UpdateGaugeMetadata = 'updateGaugeMetadata(address,string)',
-  CreateCampaign = 'createCampaign(bytes,(bytes32,bytes,bytes),(address,bytes32,bytes),(uint64,uint64))',
+  CreateCampaign = 'createCampaign(bytes,tuple,tuple,tuple)',
   // Functions that carry a nested `IDAO.Action[]` (decoded by ethers as `tuple[]`).
   Execute = 'execute(bytes32,tuple[],uint256)',
   CreateProposalMultisig = 'createProposal(bytes,tuple[],uint256,bool,bool,uint64,uint64)',

--- a/test/unit/helpers/decodeAction.spec.ts
+++ b/test/unit/helpers/decodeAction.spec.ts
@@ -2817,19 +2817,46 @@ describe('Helpers: DecodeActions', () => {
       expect(result).to.be.null
     })
 
-    it('should return null when no draft merkle root matches', async () => {
+    it('should zero the totals but still attach token and metadata when no draft merkle root matches', async () => {
       const decodeActions = new DecodeActions()
+
+      const saveAndGetTokenStub = sandbox.stub(ProxyToken, 'saveAndGetToken').resolves({
+        pickFields: () => tokenFields,
+      } as any)
+
+      sandbox.stub(Web3Utils, 'extractMetadataUri').returns('ipfs://QmCampaignMeta')
+      const parsedMetadata = { title: 'Spring Rewards', description: 'Campaign description', resources: [] }
+      const ipfsFetchStub = Ipfs.fetchMetadata as sinon.SinonStub
+      ipfsFetchStub.resolves({ raw: true })
+      sandbox.stub(Web3Utils, 'parseCampaignMetadata').returns(parsedMetadata)
+
       const decoded = buildDecoded(merkleRoot, payoutToken)
       const result = await decodeActions._parseCreateCampaignAction(decoded as any, rawAction as any, document)
-      expect(result).to.be.null
+
+      expect(result?.type).to.eq(ProposalActionType.CreateCampaign)
+      expect(result?.inputData.totalAmount).to.eq('0')
+      expect(result?.inputData.claimersCount).to.eq(0)
+      expect(result?.inputData.token).to.deep.eq(tokenFields)
+      expect(result?.inputData.metadata).to.deep.eq(parsedMetadata)
+      expect(saveAndGetTokenStub.calledOnceWith(payoutToken, network)).to.be.true
     })
 
-    it('should return null when merkleRoot path is missing', async () => {
+    it('should zero the totals when the merkleRoot path is missing but still attach metadata', async () => {
       const decodeActions = new DecodeActions()
-      const decoded = buildDecoded(undefined, payoutToken)
 
+      sandbox.stub(ProxyToken, 'saveAndGetToken').resolves({ pickFields: () => tokenFields } as any)
+      sandbox.stub(Web3Utils, 'extractMetadataUri').returns('ipfs://QmCampaignMeta')
+      const parsedMetadata = { title: 'Spring Rewards', description: 'Campaign description', resources: [] }
+      ;(Ipfs.fetchMetadata as sinon.SinonStub).resolves({ raw: true })
+      sandbox.stub(Web3Utils, 'parseCampaignMetadata').returns(parsedMetadata)
+
+      const decoded = buildDecoded(undefined, payoutToken)
       const result = await decodeActions._parseCreateCampaignAction(decoded as any, rawAction as any, document)
-      expect(result).to.be.null
+
+      expect(result?.type).to.eq(ProposalActionType.CreateCampaign)
+      expect(result?.inputData.totalAmount).to.eq('0')
+      expect(result?.inputData.claimersCount).to.eq(0)
+      expect(result?.inputData.metadata).to.deep.eq(parsedMetadata)
     })
   })
 


### PR DESCRIPTION
## 📝 Summary

This pull request refines the handling of "CreateCampaign" actions, particularly improving robustness when a draft merkle root is missing or does not match. Instead of returning `null`, the logic now ensures that the totals are set to zero while still attaching token and metadata information. The changes also update the action signature for clarity and expand test coverage to reflect the new behavior.

**Improvements to CreateCampaign action handling:**

* The `_parseCreateCampaignAction` method in `DecodeActions` now returns an object with zeroed totals and includes token and metadata information when no draft merkle root is found, instead of returning `null`. This ensures more consistent and informative results for downstream consumers.

* The enum value for `CreateCampaign` in `KnownActionSignature` was updated to use a more generic tuple signature, improving type compatibility and clarity.

**Testing enhancements:**

* Unit tests in `decodeAction.spec.ts` were updated and expanded to verify the new behavior: they now check that totals are zeroed and that token and metadata are still attached when the draft merkle root is missing or does not match, instead of expecting a `null` result.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
