### PR TITLE
ci(APP-785): add shadow-mode PR-gated release flow for app-backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aragon/app-team

--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -369,6 +369,9 @@ jobs:
 
       # Step 10: Deploy to server
       - name: Deploy to server
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
         run: |
           echo "🚀 Starting deployment to ${{ needs.validate.outputs.environment }}..."
           
@@ -382,13 +385,13 @@ jobs:
           
           # Show files that will be included in tar
           echo ""
-          echo "📁 Directory to be archived: ${{ github.event.repository.name }}"
+          echo "📁 Directory to be archived: $REPO_NAME"
           echo "📄 All .env files to be included in archive:"
-          ls -la ${{ github.event.repository.name }}/.env* | head -20
+          ls -la "$REPO_NAME"/.env* | head -20
           
           # Create tar archive of the entire repository
           echo "📦 Creating deployment archive..."
-          tar -czf deploy.tar.gz ${{ github.event.repository.name }}
+          tar -czf deploy.tar.gz "$REPO_NAME"
           
           # Verify tar contents
           echo "📋 Verifying .env files in archive:"
@@ -400,7 +403,9 @@ jobs:
           
           # Execute deployment on remote server
           echo "🚀 Executing deployment on remote server..."
-          ssh deployment-server bash -s << 'EOF'
+          ssh deployment-server bash -s "$REPO_NAME" "$DEPLOY_ENV" << 'EOF'
+          REPO_NAME=$1
+          DEPLOY_ENV=$2
           set -e
           
           # Extract the archive
@@ -413,7 +418,7 @@ jobs:
           rm -rf ~/app-backend-deploy
           
           # Rename extracted directory
-          mv ~/${{ github.event.repository.name }} ~/app-backend-deploy
+          mv ~/"$REPO_NAME" ~/app-backend-deploy
           
           # Navigate to deployment directory
           cd ~/app-backend-deploy
@@ -426,8 +431,8 @@ jobs:
           chmod +x scripts/*.sh
           
           # Export environment variables
-          export ENV_SUFFIX="${{ env.DEPLOY_ENV }}"
-          export DEPLOY_ENV="${{ env.DEPLOY_ENV }}"
+          export ENV_SUFFIX="$DEPLOY_ENV"
+          export DEPLOY_ENV="$DEPLOY_ENV"
           
           # CREATE DOCKER NETWORK BEFORE RUNNING THE DEPLOYMENT SCRIPT
           echo "🔧 Ensuring Docker network exists on remote server..."

--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -556,7 +556,7 @@ jobs:
           echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
 
       - name: Trigger E2E test suite
-        uses: aragon/app-qa/.github/actions/dispatch@main
+        uses: aragon/app-qa/.github/actions/dispatch@5954adf802c2577f6d63df5b118acbd74ff8bbf0 # main @ 2025-12-22 (no tagged releases upstream)
         with:
           opToken: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA }}
           environment: ${{ env.DEPLOY_ENV }}

--- a/.github/workflows/app-deploy.yaml
+++ b/.github/workflows/app-deploy.yaml
@@ -146,7 +146,7 @@ jobs:
 
 
       - name: Dispatch E2E tests
-        uses: aragon/app-qa/.github/actions/dispatch@main
+        uses: aragon/app-qa/.github/actions/dispatch@5954adf802c2577f6d63df5b118acbd74ff8bbf0 # main @ 2025-12-22 (no tagged releases upstream)
         with:
           opToken: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA }}
           environment: ${{ env.DEPLOY_ENV }}

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -1,0 +1,140 @@
+name: Production deploy
+run-name: Production deploy ${{ github.event.release.tag_name || inputs.tag }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Triggered by a published GitHub Release (from release-finalize) or manually
+# with a tag (hotfix / re-deploy / rollback target). Deploys behind the CI Gate
+# (production Environment protection), runs non-blocking E2E, then opens the
+# idempotent main → development back-merge PR.
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# Deploys to `sandbox` and SKIPS the back-merge. Also listens to `prereleased`
+# so the shadow prerelease from release-finalize exercises this end-to-end.
+#   # TODO(flip): deploy env sandbox → production; SHADOW=false;
+#   #             trigger types → [published]; back-merge arms automatically.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  release:
+    types: [published, prereleased] # TODO(flip): [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to (re)deploy to production
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+env:
+  SHADOW: 'true' # TODO(flip): 'false'
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.info.outputs.tag }}
+      version: ${{ steps.info.outputs.version }}
+      thread-ts: ${{ steps.info.outputs.ts }}
+    steps:
+      - name: Resolve tag / version / Slack thread
+        id: info
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          VERSION=$(echo "$TAG" | sed 's/^shadow-//; s/^v//')
+          BODY=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || echo "")
+          TS=$(echo "$BODY" | grep -oE '<!-- slack_ts: [0-9.]+ -->' | grep -oE '[0-9.]+' | head -1 || true)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+
+  deploy-prod:
+    needs: meta
+    # SHADOW: sandbox. # TODO(flip): sandbox → production (arms the CI Gate).
+    uses: ./.github/workflows/deploy-reusable.yml
+    secrets: inherit
+    with:
+      environment: sandbox
+      ref: ${{ needs.meta.outputs.tag }}
+      version: ${{ needs.meta.outputs.version }}
+      slack-thread-ts: ${{ needs.meta.outputs.thread-ts }}
+
+  e2e:
+    needs: [meta, deploy-prod]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Trigger E2E (non-blocking)
+        continue-on-error: true
+        uses: aragon/app-qa/.github/actions/dispatch@5954adf802c2577f6d63df5b118acbd74ff8bbf0 # main @ 2025-12-22 (no tagged releases upstream)
+        with:
+          opToken: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA }}
+          environment: sand # SHADOW. # TODO(flip): → prod
+      - name: Load Slack secrets
+        id: secrets
+        if: needs.meta.outputs.thread-ts != ''
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Notify Slack — E2E + release complete
+        if: needs.meta.outputs.thread-ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: |
+            :test_tube: E2E triggered for production (non-blocking)
+            :tada: *Backend Release v${{ needs.meta.outputs.version }} complete*
+
+  back-merge:
+    needs: [meta, deploy-prod]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+      # SHADOW: the dry run merges into test-release, not main — skip back-merge.
+      # TODO(flip): SHADOW=false arms the idempotent main → development PR.
+      - name: Open idempotent main → development back-merge PR
+        if: env.SHADOW != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          DIFF=$(gh api repos/${{ github.repository }}/compare/development...main --jq '.ahead_by')
+          if [ "$DIFF" = "0" ]; then echo "in sync, skipping"; exit 0; fi
+          EXISTING_PR=$(gh pr list --base development --head main --state open --json number -q '.[0].number // empty')
+          TITLE="chore: sync main (v${{ needs.meta.outputs.version }}) back to development"
+          BODY="Auto-generated after release v${{ needs.meta.outputs.version }}. Includes CHANGELOG.md update."
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+          else
+            gh pr create --base development --head main --title "$TITLE" --body "$BODY"
+          fi
+      - name: SHADOW note
+        if: env.SHADOW == 'true'
+        run: |
+          echo "SHADOW: skipping main → development back-merge (dry run targets test-release)."

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -47,9 +47,10 @@ jobs:
         id: info
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RAW_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG="$RAW_TAG"
           VERSION=$(echo "$TAG" | sed 's/^shadow-//; s/^v//')
           BODY=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || echo "")
           TS=$(echo "$BODY" | grep -oE '<!-- slack_ts: [0-9.]+ -->' | grep -oE '[0-9.]+' | head -1 || true)

--- a/.github/workflows/build-container-and-sca.yaml
+++ b/.github/workflows/build-container-and-sca.yaml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Vuln scan in Repo (html)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: success() || failure()
         with:
           scan-type: fs
@@ -114,7 +114,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vuln scan in Repo (junit)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln,secret,config
@@ -124,7 +124,7 @@ jobs:
           output: trivy-results-repo-${{ needs.build.outputs.GIT_HASH_SHORT }}.junit
 
       - name: Vuln scan in Repo (json)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln,secret,config
@@ -194,7 +194,7 @@ jobs:
       ## Generation of multiple repos is not supported as actions yet, only in cli:
       ## https://github.com/aquasecurity/trivy/issues/3243
       - name: Vuln scan in Docker (table)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: always()
         with:
           scan-type: image
@@ -206,7 +206,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vuln scan in Docker (html)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           scanners: vuln,secret
@@ -219,7 +219,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vulns scan in Docker (junit)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           scanners: vuln,secret
@@ -276,7 +276,7 @@ jobs:
           failOnError: false ## 'false' avoids stop execution and errors are logged
 
       - name: Vuln scan in Docker again (table)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: always()
         with:
           scan-type: image

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -1,0 +1,243 @@
+name: Deploy (reusable)
+run-name: Deploy ${{ inputs.ref }} to ${{ inputs.environment }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Reusable build-on-server Docker Compose deploy to a single environment.
+# Extracted from app-deploy-docker.yml so the new release flow can call it via
+# `workflow_call`. The `environment:` key is what enforces the approval gates:
+#   • staging     → Approve #1 (Environment protection)
+#   • production  → CI Gate    (Environment protection)
+#
+# Callers MUST pass `secrets: inherit` (this workflow reads org/repo secrets
+# dynamically: OP_SERVICE_ACCOUNT_TOKEN_{PROD,NONPROD}_TEMP / _BACKEND2_TEMP /
+# _BACKEND2_INFRA).
+#
+# ── SHADOW MODE (until sandbox QA passes) ──────────────────────────────────
+# During shadow, callers pass `environment: sandbox` so nothing prod/staging is
+# touched and the live release.yml process is unaffected.
+#   # TODO(flip): after the dry run, callers switch to staging/production.
+#   # TODO(flip): once this fully replaces app-deploy-docker.yml, retire that file.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Target environment (sandbox|development|staging|production)
+        required: true
+        type: string
+      ref:
+        description: Git ref (branch/tag/sha) to build & deploy
+        required: true
+        type: string
+      version:
+        description: Release version to show in notifications (optional, e.g. 1.5.0)
+        required: false
+        type: string
+        default: ''
+      slack-thread-ts:
+        description: Slack thread ts to post deploy updates under (optional)
+        required: false
+        type: string
+        default: ''
+    outputs:
+      thread-ts:
+        description: Slack ts of the deploy-start message (for threading further updates)
+        value: ${{ jobs.deploy.outputs.thread-ts }}
+
+env:
+  DEPLOYMENT_USER: 'deploy'
+  DEPLOYMENT_PATH: 'app-backend-deploy'
+  ARCHIVE_NAME: 'deploy.tar.gz'
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    # ⮕ APPROVAL GATE. If this Environment has a "Required reviewers" protection
+    #   rule (repo Settings → Environments → <env> → Required reviewers = code
+    #   owners), GitHub PAUSES this job until a reviewer approves it in the Actions
+    #   run. That pause IS Approve #1 (staging) / the CI Gate (production)
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: false
+    outputs:
+      thread-ts: ${{ steps.slack-deploy-start.outputs.ts }}
+
+    steps:
+      # Map environment → deploy code + 1Password vault / service-account secret names
+      - name: Configure deployment environment
+        id: configure
+        run: |
+          ENVIRONMENT="${{ inputs.environment }}"
+          case "$ENVIRONMENT" in
+            production)  DEPLOY_ENV="prod" ;;
+            staging)     DEPLOY_ENV="stg" ;;
+            development) DEPLOY_ENV="dev" ;;
+            sandbox)     DEPLOY_ENV="sand" ;;
+            *) echo "❌ Unknown environment: $ENVIRONMENT"; exit 1 ;;
+          esac
+          echo "DEPLOY_ENV=$DEPLOY_ENV" >> "$GITHUB_ENV"
+
+          if [[ "$ENVIRONMENT" == "production" ]]; then
+            echo "OP_VAULT=apikeys_production" >> "$GITHUB_ENV"
+          else
+            echo "OP_VAULT=apikeys_nonprod" >> "$GITHUB_ENV"
+          fi
+
+          OP_VAULT_NAME=$([[ "$ENVIRONMENT" == "production" ]] && echo "apikeys_production" || echo "apikeys_nonprod")
+          echo "OP_SERVER_USERNAME=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/username" >> "$GITHUB_ENV"
+          echo "OP_SERVER_URL=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/URL" >> "$GITHUB_ENV"
+          echo "OP_SERVER_CERT=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/deploy_backend2_${DEPLOY_ENV}" >> "$GITHUB_ENV"
+
+          echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=${{ inputs.ref }}"
+
+      - name: Load Slack secrets
+        id: slack-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: 'op://kv_backend2_infra/SLACK_BOT_TOKEN/credential'
+          SLACK_CHANNEL_ID: 'op://kv_backend2_infra/SLACK_CHANNEL_ID/credential'
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3.0.0
+
+      - name: Load server connection secrets
+        id: server-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.environment == 'production' && secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_TEMP || secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD_TEMP }}
+          SERVER_USERNAME: ${{ env.OP_SERVER_USERNAME }}
+          SERVER_URL: ${{ env.OP_SERVER_URL }}
+
+      - name: Checkout source at ref
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Notify Slack - Deploy Started
+        id: slack-deploy-start
+        if: steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ inputs.slack-thread-ts }}
+          message: |
+            :rocket: *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploying to ${{ inputs.environment }}...*
+            Ref: `${{ inputs.ref }}`
+            Triggered by: ${{ github.actor }}
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>
+
+      - name: Setup SSH authentication
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.environment == 'production' && secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_TEMP || secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD_TEMP }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          op read "${{ env.OP_SERVER_CERT }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          cat > ~/.ssh/config <<EOF
+          Host deployment-server
+            HostName ${{ steps.server-secrets.outputs.SERVER_URL }}
+            User ${{ steps.server-secrets.outputs.SERVER_USERNAME }}
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking accept-new
+            ServerAliveInterval 60
+            ServerAliveCountMax 3
+          EOF
+          ssh deployment-server "echo '✅ SSH connection established'"
+
+      - name: Download application configurations
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_TEMP }}
+        run: |
+          cat > download_configs.sh << 'SCRIPT'
+          #!/bin/bash
+          set -euo pipefail
+          VAULT="temporal_backend2"
+          ITEM="configs_app_backend2_$DEPLOY_ENV"
+          echo "📄 Downloading application configurations..."
+          op item get --vault "$VAULT" "$ITEM" --format json | \
+            jq -r '.fields.[].label' | sed 1d | \
+            while IFS= read -r config_name; do
+              op item get --vault "$VAULT" "$ITEM" --fields "$config_name" | \
+                sed '1s/^"//;$s/"$//' > temp_config
+              IFS=';' read -ra CONFIGS <<< "$config_name"
+              for conf in "${CONFIGS[@]}"; do
+                CONFIG_FILE=".env.$conf-$DEPLOY_ENV"
+                cp temp_config "$CONFIG_FILE"
+                case "$DEPLOY_ENV" in
+                  prod) LOGZIO_ENV="PRODUCTION" ;;
+                  stg)  LOGZIO_ENV="STAGING" ;;
+                  sand) LOGZIO_ENV="SANDBOX" ;;
+                  *)    LOGZIO_ENV="DEVELOPMENT" ;;
+                esac
+                sed -i "s/^LOGZIO_SERVER_NAME=.*/LOGZIO_SERVER_NAME=${conf^^}-${LOGZIO_ENV}/" "$CONFIG_FILE"
+              done
+              rm temp_config
+            done
+          op item get --vault "$VAULT" "configs_docker" --fields "docker-config" | \
+            sed '1s/^"//;$s/"$//' > .env.docker
+          if [[ ! -s .env.docker ]]; then echo "❌ Docker config not found"; exit 1; fi
+          echo "✅ Configuration download complete"
+          SCRIPT
+          chmod +x download_configs.sh
+          ./download_configs.sh
+
+      - name: Deploy to server
+        run: |
+          echo "🚀 Deploying ${{ inputs.ref }} to ${{ inputs.environment }}..."
+          cd ..
+          tar -czf deploy.tar.gz ${{ github.event.repository.name }}
+          scp deploy.tar.gz deployment-server:~/
+          ssh deployment-server bash -s << 'EOF'
+          set -e
+          tar -xzf ~/deploy.tar.gz
+          rm ~/deploy.tar.gz
+          rm -rf ~/app-backend-deploy
+          mv ~/${{ github.event.repository.name }} ~/app-backend-deploy
+          cd ~/app-backend-deploy
+          chmod +x scripts/*.sh
+          export ENV_SUFFIX="${{ env.DEPLOY_ENV }}"
+          export DEPLOY_ENV="${{ env.DEPLOY_ENV }}"
+          docker network create internal-net 2>/dev/null || true
+          docker network create public-net 2>/dev/null || true
+          bash scripts/app-deploy.sh "$ENV_SUFFIX"
+          echo "✅ Deployment completed"
+          EOF
+          rm deploy.tar.gz || true
+
+      - name: Verify deployment health
+        run: |
+          ssh deployment-server << 'HEALTH_CHECK'
+          set -euo pipefail
+          cd ~/app-backend-deploy
+          docker ps --filter "label=app=backend2" --filter "status=running" --format "table {{.Names}}\t{{.Status}}"
+          echo "✅ Health check passed"
+          HEALTH_CHECK
+
+      - name: Cleanup sensitive data
+        if: always()
+        run: |
+          rm -rf ~/.ssh/deploy_key ~/.ssh/config
+          rm -f .env* download_configs.sh
+          unset OP_SERVICE_ACCOUNT_TOKEN || true
+
+      - name: Notify Slack - Deploy Result
+        if: always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.slack-deploy-start.outputs.ts || inputs.slack-thread-ts }}
+          message: |
+            ${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploy to ${{ inputs.environment }} ${{ job.status }}*
+            Ref: `${{ inputs.ref }}`
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -69,8 +69,11 @@ jobs:
       # Map environment → deploy code + 1Password vault / service-account secret names
       - name: Configure deployment environment
         id: configure
+        env:
+          ENVIRONMENT_INPUT: ${{ inputs.environment }}
+          REF: ${{ inputs.ref }}
         run: |
-          ENVIRONMENT="${{ inputs.environment }}"
+          ENVIRONMENT="$ENVIRONMENT_INPUT"
           case "$ENVIRONMENT" in
             production)  DEPLOY_ENV="prod" ;;
             staging)     DEPLOY_ENV="stg" ;;
@@ -91,7 +94,7 @@ jobs:
           echo "OP_SERVER_URL=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/URL" >> "$GITHUB_ENV"
           echo "OP_SERVER_CERT=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/deploy_backend2_${DEPLOY_ENV}" >> "$GITHUB_ENV"
 
-          echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=${{ inputs.ref }}"
+          echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=$REF"
 
       - name: Load Slack secrets
         id: slack-secrets
@@ -192,21 +195,28 @@ jobs:
           ./download_configs.sh
 
       - name: Deploy to server
+        env:
+          REF: ${{ inputs.ref }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
         run: |
-          echo "🚀 Deploying ${{ inputs.ref }} to ${{ inputs.environment }}..."
+          echo "🚀 Deploying $REF to $ENVIRONMENT..."
           cd ..
-          tar -czf deploy.tar.gz ${{ github.event.repository.name }}
+          tar -czf deploy.tar.gz "$REPO_NAME"
           scp deploy.tar.gz deployment-server:~/
-          ssh deployment-server bash -s << 'EOF'
+          ssh deployment-server bash -s "$REPO_NAME" "$DEPLOY_ENV" << 'EOF'
+          REPO_NAME=$1
+          DEPLOY_ENV=$2
           set -e
           tar -xzf ~/deploy.tar.gz
           rm ~/deploy.tar.gz
           rm -rf ~/app-backend-deploy
-          mv ~/${{ github.event.repository.name }} ~/app-backend-deploy
+          mv ~/"$REPO_NAME" ~/app-backend-deploy
           cd ~/app-backend-deploy
           chmod +x scripts/*.sh
-          export ENV_SUFFIX="${{ env.DEPLOY_ENV }}"
-          export DEPLOY_ENV="${{ env.DEPLOY_ENV }}"
+          export ENV_SUFFIX="$DEPLOY_ENV"
+          export DEPLOY_ENV="$DEPLOY_ENV"
           docker network create internal-net 2>/dev/null || true
           docker network create public-net 2>/dev/null || true
           bash scripts/app-deploy.sh "$ENV_SUFFIX"

--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -1,0 +1,35 @@
+name: Develop → DEV deploy
+run-name: DEV deploy ${{ github.ref_name }}
+
+# Auto-deploys development to the DEV environment on push (continuous integration
+# environment)
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# OFF by default (guarded) so landing this file changes nothing. Test via
+# workflow_dispatch; it deploys to `sandbox` during shadow.
+#   # TODO(flip): set repo var RELEASE_V2_ENABLED=true (arms push trigger) and
+#   #             change deploy environment sandbox → development.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: develop-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || vars.RELEASE_V2_ENABLED == 'true'
+    # SHADOW: sandbox; gated off in shadow (RELEASE_V2_ENABLED).
+    # TODO(flip): sandbox → development, and set RELEASE_V2_ENABLED=true.
+    uses: ./.github/workflows/deploy-reusable.yml
+    secrets: inherit
+    with:
+      environment: sandbox
+      ref: ${{ github.ref_name }}

--- a/.github/workflows/hotfix-start.yml
+++ b/.github/workflows/hotfix-start.yml
@@ -7,6 +7,22 @@ run-name: Start hotfix from main
 # instructions to push the fix. release-pr.yml then runs tests + staging on PR
 # sync; merging triggers release-finalize.yml (same gates as a release).
 #
+# Only ONE hotfix may be in flight at a time (guard below) — two hotfixes would
+# both branch off main and compute the same patch version, colliding on the tag.
+#
+# ── COLLISIONS WITH AN OPEN RELEASE ────────────────────────────────────────
+# A hotfix may run in parallel with an open release/* PR (intended: ship the fix
+# now, the release absorbs it later). The back-merge does NOT auto-update the
+# release branch, so:
+#   • Merge the hotfix FIRST; release-finalize → app-production opens the
+#     idempotent main → development back-merge PR — merge it so dev gets the fix.
+#   • Then rebase/merge development into the open release/* branch and resolve
+#     the CHANGELOG.md + package.json version conflicts by hand.
+#   • If the pending release is itself patch-level it computes the SAME version
+#     as the hotfix → release-finalize fails on a duplicate tag. Re-cut the
+#     release version (or land the hotfix as part of that release instead).
+# ──────────────────────────────────────────────────────────────────────────
+#
 # ── SHADOW MODE ────────────────────────────────────────────────────────────
 # Branches from main (read-only) but opens the PR against TARGET_BRANCH =
 # test-release, so nothing reaches main during the dry run.
@@ -57,6 +73,21 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Guard — only one active hotfix
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh pr list --base "$TARGET_BRANCH" --state open --json headRefName \
+            -q '[.[] | select(.headRefName | startswith("hotfix/"))] | length')
+          if [ "${OPEN:-0}" -ne 0 ]; then
+            echo "❌ An active hotfix PR already exists — only one active hotfix at a time." >&2
+            echo "   Merge or close it first, then re-run this workflow." >&2
+            gh pr list --base "$TARGET_BRANCH" --state open --json number,headRefName \
+              -q '.[] | select(.headRefName|startswith("hotfix/")) | "  #\(.number) \(.headRefName)"' >&2 || true
+            exit 1
+          fi
+
       - name: Install Node.js
         uses: actions/setup-node@v5
         with:
@@ -80,9 +111,11 @@ jobs:
 
       - name: Create hotfix branch
         id: branch
+        env:
+          DESCRIPTION: ${{ inputs.description }}
         run: |
           set -euo pipefail
-          SLUG=$(echo "${{ inputs.description }}" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-30)
+          SLUG=$(printf '%s' "$DESCRIPTION" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-30)
           BR="hotfix/${{ steps.v.outputs.version }}${SLUG:+-$SLUG}"
           git checkout -b "$BR"
           echo "name=$BR" >> "$GITHUB_OUTPUT"
@@ -100,7 +133,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
         run: |
           set -euo pipefail
-          BODY="Hotfix v${{ steps.v.outputs.version }} (manual mode). Push the fix to \`${{ steps.branch.outputs.name }}\`; CI re-runs on PR sync. Remember to update CHANGELOG.md with the fix."
+          BODY="Hotfix v${{ steps.v.outputs.version }} (manual mode). Push the fix to \`${{ steps.branch.outputs.name }}\`; CI re-runs on PR sync. Remember to update CHANGELOG.md with the fix.
+
+          If a release/* PR is open: merge this hotfix first, merge the auto back-merge PR (main → development), then rebase the release branch onto development and resolve the CHANGELOG.md / package.json conflicts."
           URL=$(gh pr create --base "$TARGET_BRANCH" --head "${{ steps.branch.outputs.name }}" \
             --title "Hotfix v${{ steps.v.outputs.version }}" --body "$BODY")
           echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/hotfix-start.yml
+++ b/.github/workflows/hotfix-start.yml
@@ -1,0 +1,131 @@
+name: Hotfix — Start
+run-name: Start hotfix from main
+
+# ──────────────────────────────────────────────────────────────────────────
+# Manual hotfix. Branches hotfix/<version> from main,
+# bumps a patch version (version-only commit), opens the PR, and posts Slack
+# instructions to push the fix. release-pr.yml then runs tests + staging on PR
+# sync; merging triggers release-finalize.yml (same gates as a release).
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# Branches from main (read-only) but opens the PR against TARGET_BRANCH =
+# test-release, so nothing reaches main during the dry run.
+#   # TODO(flip): TARGET_BRANCH test-release → main
+#   # TODO(phase 2): add auto cherry-pick mode (SHAs from development).
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      description:
+        description: Short hotfix description (used in the branch name)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: hotfix-start
+  cancel-in-progress: false
+
+env:
+  TARGET_BRANCH: test-release # TODO(flip): main
+
+jobs:
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          GPG_PASSPHRASE: op://kv_backend2_infra/arabot-1_SIGN_CERTS/credential
+          GPG_PRIVATE_KEY: op://kv_backend2_infra/arabot-1_SIGN_CERTS/private_key
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          ref: main
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ steps.secrets.outputs.GPG_PRIVATE_KEY }}
+          passphrase: ${{ steps.secrets.outputs.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Compute hotfix (patch) version
+        id: v
+        run: |
+          set -euo pipefail
+          CUR=$(node -p "require('./package.json').version")
+          NEXT=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number);console.log(a+'.'+b+'.'+(c+1))" "$CUR")
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Create hotfix branch
+        id: branch
+        run: |
+          set -euo pipefail
+          SLUG=$(echo "${{ inputs.description }}" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-30)
+          BR="hotfix/${{ steps.v.outputs.version }}${SLUG:+-$SLUG}"
+          git checkout -b "$BR"
+          echo "name=$BR" >> "$GITHUB_OUTPUT"
+
+      - name: Bump patch version (version-only commit)
+        run: |
+          npm version "${{ steps.v.outputs.version }}" --no-git-tag-version --allow-same-version
+          git add -A
+          git commit -m "chore(release): ${{ steps.v.outputs.version }} (hotfix)"
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      - name: Create PR → target
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          BODY="Hotfix v${{ steps.v.outputs.version }} (manual mode). Push the fix to \`${{ steps.branch.outputs.name }}\`; CI re-runs on PR sync. Remember to update CHANGELOG.md with the fix."
+          URL=$(gh pr create --base "$TARGET_BRANCH" --head "${{ steps.branch.outputs.name }}" \
+            --title "Hotfix v${{ steps.v.outputs.version }}" --body "$BODY")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "number=$(gh pr view "$URL" --json number -q .number)" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack — Hotfix Started (root)
+        id: slack
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          message: |
+            :adhesive_bandage: *Backend Hotfix v${{ steps.v.outputs.version }} Started*
+            *PR:* ${{ steps.pr.outputs.url }}
+            Branch: `${{ steps.branch.outputs.name }}` · by ${{ github.actor }}
+
+            :point_right: Manual mode — push your fix to `${{ steps.branch.outputs.name }}`; CI re-runs on PR sync.
+
+      - name: Embed slack_ts in PR body
+        if: steps.slack.outputs.ts != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr view ${{ steps.pr.outputs.number }} --json body -q .body > body.md
+          printf '\n\n<!-- slack_ts: %s -->\n' "${{ steps.slack.outputs.ts }}" >> body.md
+          gh pr edit ${{ steps.pr.outputs.number }} --body-file body.md

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     branches:
       - 'development'
-      - 'staging'
+      - 'staging' # TODO(flip): remove once the staging branch is retired
       - 'main'
+      - 'test-release' # SHADOW: gate dry-run release PRs. # TODO(flip): remove
 
 permissions:
   contents: read

--- a/.github/workflows/release-cancel.yml
+++ b/.github/workflows/release-cancel.yml
@@ -1,0 +1,57 @@
+name: Release — Cancel
+run-name: Release cancel ${{ github.event.pull_request.head.ref }}
+
+# Fires when a release/* or hotfix/* PR is closed WITHOUT merging. Notifies the
+# Slack thread that the release was abandoned.
+#
+# ── SHADOW MODE ──  # TODO(flip): branches test-release → main
+on:
+  pull_request:
+    types: [closed]
+    branches: [test-release]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  cancel:
+    if: >
+      github.event.pull_request.merged == false &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Extract Slack thread ts from PR body
+        id: ts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          TS=$(grep -oE '<!-- slack_ts: [0-9.]+ -->' pr_body.txt | grep -oE '[0-9.]+' | head -1 || true)
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack — cancelled
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: |
+            :no_entry_sign: *Release cancelled* — PR closed without merging. Production unchanged.
+      # NOTE: if a hotfix landed on main while this release was open, the hotfix's
+      # own app-production run already opened the main → development back-merge PR,
+      # so development stays consistent even when the release is cancelled.

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -68,7 +68,7 @@ jobs:
           set -euo pipefail
           VER="${{ steps.v.outputs.version }}"
           awk -v ver="$VER" '
-            /^## / { if (inblock) exit; if (index($0, ver)) { inblock=1; print; next } }
+            /^#{1,2} \[/ { if (inblock) exit; if (index($0, "[" ver "]")) { inblock=1; print; next } }
             inblock { print }
           ' CHANGELOG.md > notes.md || true
           if [ ! -s notes.md ]; then echo "Release v$VER" > notes.md; fi

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -64,9 +64,11 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Extract CHANGELOG section for this version
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
         run: |
           set -euo pipefail
-          VER="${{ steps.v.outputs.version }}"
+          VER="$VERSION"
           awk -v ver="$VER" '
             /^#{1,2} \[/ { if (inblock) exit; if (index($0, "[" ver "]")) { inblock=1; print; next } }
             inblock { print }
@@ -101,14 +103,16 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          VERSION: ${{ steps.v.outputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
-          TAG="${TAG_PREFIX}v${{ steps.v.outputs.version }}"
+          TAG="${TAG_PREFIX}v${VERSION}"
           PRE=""
           [ "${PRERELEASE}" = "true" ] && PRE="--prerelease"
           gh release create "$TAG" \
-            --target "${{ github.event.pull_request.merge_commit_sha }}" \
-            --title "Release v${{ steps.v.outputs.version }}${TAG_PREFIX:+ (shadow)}" \
+            --target "$MERGE_SHA" \
+            --title "Release v${VERSION}${TAG_PREFIX:+ (shadow)}" \
             --notes-file notes.md $PRE
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,124 @@
+name: Release — Finalize
+run-name: Finalize ${{ github.event.pull_request.head.ref }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fires when a release/* (or hotfix/*) PR merges into the target branch.
+# Creates the tag + GitHub Release from the prepared CHANGELOG section and
+# carries the Slack thread into the release body. The published release
+# triggers app-production.yml.
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# Trigger branch = `test-release` (not main) → never collides with the live
+# release.yml. Tags are namespaced `shadow-vX.Y.Z` and the release is a
+# prerelease, so semantic-release's tag-based version detection on main is NOT
+# polluted (it ignores prefixed/prerelease tags).
+#   # TODO(flip): branches test-release → main; TAG_PREFIX "" ; PRERELEASE false.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [closed]
+    # TODO(flip): test-release → main
+    branches: [test-release]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-finalize-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  TAG_PREFIX: 'shadow-' # TODO(flip): ''
+  PRERELEASE: 'true' # TODO(flip): 'false'
+
+jobs:
+  finalize:
+    if: >
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+
+      - name: Checkout merged SHA
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+
+      - name: Read version
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Extract CHANGELOG section for this version
+        run: |
+          set -euo pipefail
+          VER="${{ steps.v.outputs.version }}"
+          awk -v ver="$VER" '
+            /^## / { if (inblock) exit; if (index($0, ver)) { inblock=1; print; next } }
+            inblock { print }
+          ' CHANGELOG.md > notes.md || true
+          if [ ! -s notes.md ]; then echo "Release v$VER" > notes.md; fi
+
+      - name: Extract Slack thread ts from PR body
+        id: ts
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          TS=$(grep -oE '<!-- slack_ts: [0-9.]+ -->' pr_body.txt | grep -oE '[0-9.]+' | head -1 || true)
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+
+      - name: Carry slack_ts into release notes
+        if: steps.ts.outputs.ts != ''
+        run: |
+          printf '\n\n<!-- slack_ts: %s -->\n' "${{ steps.ts.outputs.ts }}" >> notes.md
+
+      - name: Notify Slack — tagging & releasing
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: ':label: *PR merged — creating tag & GitHub Release...*'
+
+      - name: Create tag + GitHub Release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${TAG_PREFIX}v${{ steps.v.outputs.version }}"
+          PRE=""
+          [ "${PRERELEASE}" = "true" ] && PRE="--prerelease"
+          gh release create "$TAG" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --title "Release v${{ steps.v.outputs.version }}${TAG_PREFIX:+ (shadow)}" \
+            --notes-file notes.md $PRE
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack — release created
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: |
+            :package: *GitHub Release created:* <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag }}|${{ steps.release.outputs.tag }}>
+            _Production deploy (SHADOW: sandbox) will start automatically..._

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,161 @@
+name: Release — PR (test + staging)
+run-name: Release PR #${{ github.event.pull_request.number }} — test + staging
+
+# ──────────────────────────────────────────────────────────────────────────
+# Runs on release/* and hotfix/* PRs into the target branch (SHADOW: test-release):
+#   1. fast checks (lint, format, unit + coverage) — pre-staging gate
+#   2. deploy to staging (Approve #1 = staging Environment protection)
+#   3. post "what to test" + non-blocking E2E into the Slack thread
+#
+# unit-dep + integration run via the existing unit-dep.yml / integration-test.yml
+# on the same PR and are required checks for MERGE (Approve #2). We keep only the
+# fast checks here to avoid duplicating the docker-compose-test infra before
+# staging.
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# Deploys to `sandbox` so staging/prod and the live process are untouched.
+#   # TODO(flip): change deploy environment sandbox → staging to arm Approve #1.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # SHADOW: only test-release PRs, so main/live release.yml is untouched.
+    # TODO(flip): test-release → main
+    branches: [test-release]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  meta:
+    if: >
+      startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      thread-ts: ${{ steps.ts.outputs.ts }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Read version from package.json
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Get PR body
+        id: body
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          DELIM="EOF_$(date +%s%N)_$RANDOM"
+          { echo "body<<$DELIM"; cat pr_body.txt; echo "$DELIM"; } >> "$GITHUB_OUTPUT"
+      - name: Extract Slack thread ts
+        id: ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          text: ${{ steps.body.outputs.body }}
+
+  test:
+    needs: meta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn format:check
+      - run: yarn test:unit:coverage
+      - run: yarn test:coverage:check
+
+  notify-gate1:
+    needs: [meta, test]
+    if: needs.meta.outputs.thread-ts != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+          # Slack user-group to ping on gates. # TODO(infra): create this user-group.
+          CODEOWNERS_GROUP_ID: op://kv_backend2_infra/SLACK_CODEOWNERS_GROUP_ID/credential
+      - name: Notify Slack — waiting Approve #1
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: |
+            :pause_button: *Waiting Approve #1 — deploy to staging* ${{ steps.secrets.outputs.CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.CODEOWNERS_GROUP_ID) || '' }}
+            Approve the staging deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
+            <!-- SHADOW: targets sandbox; no real pause until flipped to staging -->
+
+  deploy-staging:
+    needs: [meta, test]
+    # SHADOW: deploys to sandbox; gate is armed by the sandbox Environment's
+    # Required-reviewers rule (add it to test Approve #1 during the dry run).
+    # TODO(flip): sandbox → staging.
+    uses: ./.github/workflows/deploy-reusable.yml
+    secrets: inherit
+    with:
+      environment: sandbox
+      ref: ${{ github.event.pull_request.head.sha }}
+      version: ${{ needs.meta.outputs.version }}
+      slack-thread-ts: ${{ needs.meta.outputs.thread-ts }}
+
+
+  e2e:
+    needs: [meta, deploy-staging]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Trigger E2E (non-blocking)
+        continue-on-error: true
+        uses: aragon/app-qa/.github/actions/dispatch@5954adf802c2577f6d63df5b118acbd74ff8bbf0 # main @ 2025-12-22 (no tagged releases upstream)
+        with:
+          opToken: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA }}
+          environment: sand # SHADOW. # TODO(flip): → stg
+      - name: Load Slack secrets
+        id: secrets
+        if: needs.meta.outputs.thread-ts != ''
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Notify Slack — E2E triggered
+        if: needs.meta.outputs.thread-ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: ':test_tube: E2E tests triggered for staging (non-blocking)'

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,0 +1,200 @@
+name: Release — Start
+run-name: Start release (base ${{ inputs.base_commit || 'development' }})
+
+# ──────────────────────────────────────────────────────────────────────────
+# Manually-triggered. Computes the next version from conventional commits,
+# creates release/x.y.z from development, commits the version bump + CHANGELOG
+# (reviewable in the PR), opens the PR → main, and starts the Slack thread.
+#
+# This workflow does NOT deploy and does NOT tag.
+#
+# ── SHADOW MODE ────────────────────────────────────────────────────────────
+# Opens the release PR against TARGET_BRANCH = `test-release` (a throwaway branch
+# off main), NOT main — so the whole flow (PR → merge → finalize → sandbox deploy
+# → notifications) can be dry-run end-to-end without touching main or prod, and
+# the live release.yml (push:main) is never triggered.
+#   # TODO(flip): set TARGET_BRANCH=main, then remove push:main from release.yml.
+# Prereq: create the `test-release` branch from main before the dry run.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_commit:
+        description: 'Commit/branch to start the release from (default: development HEAD)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-start
+  cancel-in-progress: false
+
+env:
+  # SHADOW: open the release PR against a throwaway branch so nothing reaches
+  # main and the live release.yml is untouched.
+  # TODO(flip): TARGET_BRANCH: test-release → main
+  TARGET_BRANCH: test-release
+
+jobs:
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          GPG_PASSPHRASE: op://kv_backend2_infra/arabot-1_SIGN_CERTS/credential
+          GPG_PRIVATE_KEY: op://kv_backend2_infra/arabot-1_SIGN_CERTS/private_key
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+
+      - name: Checkout base
+        uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          ref: ${{ inputs.base_commit || 'development' }}
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Guard — only one active release
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh pr list --base "$TARGET_BRANCH" --state open --json headRefName \
+            -q '[.[] | select(.headRefName | startswith("release/"))] | length')
+          if [ "${OPEN:-0}" -ne 0 ]; then
+            echo "❌ An active release PR already exists — only one active release at a time." >&2
+            gh pr list --base "$TARGET_BRANCH" --state open --json number,headRefName \
+              -q '.[] | select(.headRefName|startswith("release/")) | "  #\(.number) \(.headRefName)"' >&2 || true
+            exit 1
+          fi
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ steps.secrets.outputs.GPG_PRIVATE_KEY }}
+          passphrase: ${{ steps.secrets.outputs.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Compute next version (semantic-release dry-run)
+        id: version
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE="${{ inputs.base_commit || 'development' }}"
+          # semantic-release only runs on configured branches; override --branches
+          # so the dry-run computes the next version from this base.
+          # NOTE(shadow): validate this log parse against the installed
+          # semantic-release version during sandbox QA.
+          npx semantic-release --dry-run --branches "$BASE" > sr.log 2>&1 || true
+          VERSION=$(grep -oiE 'next release version is [0-9]+\.[0-9]+\.[0-9]+' sr.log \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+          if [ -z "$VERSION" ]; then
+            echo "❌ Could not determine next version from semantic-release dry-run." >&2
+            echo "   (No releasable commits, or output format changed.)" >&2
+            tail -n 50 sr.log >&2 || true
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "✅ Next version: v$VERSION"
+
+      - name: Create release branch
+        id: branch
+        run: |
+          set -euo pipefail
+          BR="release/${{ steps.version.outputs.version }}"
+          git checkout -b "$BR"
+          echo "name=$BR" >> "$GITHUB_OUTPUT"
+
+      - name: Bump package.json
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Update CHANGELOG.md
+        # conventionalcommits preset matches our commit convention; prepends the
+        # new section (header version comes from the just-bumped package.json).
+        run: npx -y conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s -r 1
+
+      - name: Generate release summary (Slack / PR body)
+        id: summary
+        run: |
+          set -euo pipefail
+          node .github/workflows/scripts/generateReleaseSummary.js > summary.md
+          DELIM="EOF_$(date +%s%N)_$RANDOM"
+          {
+            echo "summary<<$DELIM"
+            cat summary.md
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect DB migrations in this release (flag only)
+        id: migrations
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ] && git diff --name-only "$LAST_TAG"..HEAD | grep -qiE 'migration'; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit & push
+        run: |
+          set -euo pipefail
+          git add -A
+          git commit -m "chore(release): ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      - name: Create PR → main
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          URL=$(gh pr create --base "$TARGET_BRANCH" --head "${{ steps.branch.outputs.name }}" \
+            --title "Release v${{ steps.version.outputs.version }}" \
+            --body-file summary.md)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "number=$(gh pr view "$URL" --json number -q .number)" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack — Release Started (root message)
+        id: slack
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          message: |
+            :rocket: *Backend Release v${{ steps.version.outputs.version }} Started*
+            *PR:* ${{ steps.pr.outputs.url }}
+            Branch: `${{ steps.branch.outputs.name }}` · by ${{ github.actor }}
+            ${{ steps.migrations.outputs.has == 'true' && ':warning: *Contains DB migrations* — roll-forward only' || '' }}
+
+            ${{ steps.summary.outputs.summary }}
+
+      - name: Embed slack_ts in PR body
+        if: steps.slack.outputs.ts != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr view ${{ steps.pr.outputs.number }} --json body -q .body > body.md
+          printf '\n\n<!-- slack_ts: %s -->\n' "${{ steps.slack.outputs.ts }}" >> body.md
+          gh pr edit ${{ steps.pr.outputs.number }} --body-file body.md

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -97,9 +97,10 @@ jobs:
         id: version
         env:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          BASE_INPUT: ${{ inputs.base_commit || 'development' }}
         run: |
           set -euo pipefail
-          BASE="${{ inputs.base_commit || 'development' }}"
+          BASE="$BASE_INPUT"
           # semantic-release only runs on configured branches; override --branches
           # so the dry-run computes the next version from this base.
           # NOTE(shadow): validate this log parse against the installed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+  # TODO(flip): after sandbox QA of the new flow (release-start / release-pr /
+  # release-finalize + app-production), REMOVE this push:main trigger.
+  # release-finalize.yml then owns tagging + GitHub Release, and this
+  # semantic-release-on-push:main path is retired. Until then it stays live so
+  # the current release process is unaffected.
   push:
     branches:
       - main

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -29,18 +29,29 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    outputs:
+      # Display version with the tag prefix stripped (deploy-reusable adds the
+      # leading `v` itself, so passing the raw tag would render as `vv1.4.0`).
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Verify tag exists
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if ! git rev-parse -q --verify "refs/tags/${{ inputs.tag }}^{commit}" >/dev/null; then
-            echo "❌ Tag '${{ inputs.tag }}' not found." >&2
+          if ! git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null; then
+            echo "❌ Tag '$TAG' not found." >&2
             exit 1
           fi
-          echo "✅ Tag '${{ inputs.tag }}' found."
+          echo "✅ Tag '$TAG' found."
+      - name: Derive display version
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "version=$(printf '%s' "$TAG" | sed 's/^shadow-//; s/^v//')" >> "$GITHUB_OUTPUT"
 
   rollback:
     needs: validate
@@ -50,7 +61,7 @@ jobs:
     with:
       environment: sandbox
       ref: ${{ inputs.tag }}
-      version: ${{ inputs.tag }}
+      version: ${{ needs.validate.outputs.version }}
 
   notify:
     needs: [validate, rollback]

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,83 @@
+name: Rollback (production)
+run-name: Rollback to ${{ inputs.tag }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Redeploys a previous tag to production (build-on-server rebuild). There is no
+# image registry, so "rollback" = check out a prior tag and redeploy it.
+#
+# ⚠️  CODE ONLY — this does NOT revert DB migrations (they are forward-only).
+#     For migration-bearing releases, fix forward (hotfix) instead of rolling back.
+#
+# ── SHADOW MODE ──  # TODO(flip): deploy environment sandbox → production
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to redeploy (e.g. v1.4.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Verify tag exists
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify "refs/tags/${{ inputs.tag }}^{commit}" >/dev/null; then
+            echo "❌ Tag '${{ inputs.tag }}' not found." >&2
+            exit 1
+          fi
+          echo "✅ Tag '${{ inputs.tag }}' found."
+
+  rollback:
+    needs: validate
+    # SHADOW: sandbox. # TODO(flip): sandbox → production (arms the CI Gate).
+    uses: ./.github/workflows/deploy-reusable.yml
+    secrets: inherit
+    with:
+      environment: sandbox
+      ref: ${{ inputs.tag }}
+      version: ${{ inputs.tag }}
+
+  notify:
+    needs: [validate, rollback]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Notify Slack — rollback
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          message: |
+            :leftwards_arrow_with_hook: *Backend rollback to `${{ inputs.tag }}` — ${{ needs.rollback.result }}*
+            :warning: Code only — DB migrations are NOT reverted (roll-forward policy).
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>

--- a/.github/workflows/unit-dep.yml
+++ b/.github/workflows/unit-dep.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - 'development'
-      - 'staging'
+      - 'staging' # TODO(flip): remove once the staging branch is retired
       - 'main'
+      - 'test-release' # SHADOW: gate dry-run release PRs. # TODO(flip): remove
 
 jobs:
   unit-dep:


### PR DESCRIPTION
# Release flow — SHADOW MODE

New PR-gated release flow. It is landed in **shadow mode**: everything runs against a throwaway **`test-release`** branch and the **`sandbox`** environment, so the current `release.yml` (semantic-release on push:main) keeps working untouched. Nothing reaches `main`, `staging`, or `production` until the flip.

## New / changed files

| File | Role |
| --- | --- |
| `deploy-reusable.yml` | `workflow_call` build-on-server deploy to one env (the `environment:` key is the approval gate) |
| `release-start.yml` | manual: dry-run version → `release/x.y.z` → bump + CHANGELOG → PR → Slack root |
| `release-pr.yml` | PR checks (fast) + deploy (Approve 1) + non-blocking E2E |
| `release-finalize.yml` | on merge: tag + GitHub Release from CHANGELOG (carries Slack thread) |
| `app-production.yml` | on release published / dispatch: prod deploy (CI Gate) + E2E + back-merge |
| `release-cancel.yml` | PR closed unmerged → Slack "cancelled" |
| `hotfix-start.yml` | manual hotfix from `main` (patch bump) → PR |
| `rollback.yml` | redeploy a previous tag (code only; DB not reverted) |
| `develop-deploy.yml` | `development` → DEV auto-deploy (guarded off in shadow) |
| `CODEOWNERS` | Approve 2 (PR review) ownership |
| `release.yml`, `unit-dep.yml`, `integration-test.yml` | flip-notes / additive `test-release` trigger |

## The part that pauses on CI approval

The gate is two things together:

1. The **`environment:` key on the deploy job** in `deploy-reusable.yml` (`environment: ${{ inputs.environment }}`). This binds the job to a GitHub Environment.
2. A **"Required reviewers" protection rule** on that Environment (repo Settings → Environments → `<env>` → Required reviewers = code-owner team).

When both are present, GitHub **pauses the deploy job before it runs** and waits for a reviewer to click **Approve** in the Actions run. That pause *is* **Approve 1** (on `staging`) and the **CI Gate** (on `production`).

- In shadow we deploy to **`sandbox`**, which has no protection rule → no pause.
- **To test the approval UX during the dry run:** add Required reviewers to the **`sandbox`** Environment. The sandbox deploy will then pause for approval.
- `notify-gate1` (in `release-pr.yml`) posts the "⏳ Waiting Approve 1" Slack ping in parallel; the actual pause is the Environment rule above.

**Approve 2 (merge)** is separate: branch protection on `main` ("Require review from Code Owners") + `.github/CODEOWNERS`.

## Prerequisites

1. **Create the `test-release` branch** from `main`.
2. **Slack user-group** for gate @mentions → store its ID at `op://kv_backend2_infra/SLACK_CODEOWNERS_GROUP_ID/credential`.
3. **Confirm the CODEOWNERS team slug** (`.github/CODEOWNERS`).
4. *(optional, to test the gate)* add Required reviewers to the `sandbox` Environment.
5. Confirm CI secrets exist (already used elsewhere): `OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA`, `OP_SERVICE_ACCOUNT_TOKEN_NONPROD_TEMP`, `OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_TEMP`, `OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA`, `ARABOT_APP_BACKEND_RELEASES`.

## Dry run (sandbox)

1. Run **Release — Start** (`workflow_dispatch`). Verify: `release/x.y.z` created, PR → `test-release` with bump + CHANGELOG diff, Slack root message (version, PR, grouped changelog, migration flag).
2. On the PR: fast checks run; **deploy to sandbox**; Slack thread shows start → deploy → E2E. (With a sandbox Required-reviewers rule, the deploy pauses for Approve 1.)
3. **Merge the PR into `test-release`** → `release-finalize` creates a `shadow-vX.Y.Z` prerelease → `app-production` deploys to **sandbox** + threads "release complete".
4. Exercise **Hotfix — Start** and **Rollback** the same way.

> Shadow tags are prefixed `shadow-` and marked prerelease so semantic-release's real version detection on `main` is never polluted.

## Flip checklist (after the dry run passes)

Single coordinated change, when no release is in flight:

- [ ] `release.yml`: remove the `push: branches: [main]` trigger.
- [ ] `release-start.yml`: `TARGET_BRANCH: test-release` → `main`.
- [ ] `release-pr.yml`: trigger `branches: [test-release]` → `[main]`; deploy env `sandbox` → `staging`; E2E env `sand` → `stg`.
- [ ] `release-finalize.yml`: trigger `branches: [test-release]` → `[main]`; `TAG_PREFIX: ''`; `PRERELEASE: 'false'`.
- [ ] `app-production.yml`: deploy env `sandbox` → `production`; `SHADOW: 'false'`; trigger types → `[published]`; E2E env `sand` → `prod`.
- [ ] `hotfix-start.yml`: `TARGET_BRANCH: test-release` → `main`.
- [ ] `rollback.yml`: deploy env `sandbox` → `production`.
- [ ] `develop-deploy.yml`: deploy env `sandbox` → `development`; set repo var `RELEASE_V2_ENABLED=true`.
- [ ] `unit-dep.yml` / `integration-test.yml`: drop `staging` and `test-release` from triggers.
- [ ] GitHub: branch protection on `main` (1 review + code owners = Approve 2); Environment protection (Required reviewers = code owners) on `staging` (Approve 1) and `production` (CI Gate).
- [ ] Retire the `staging` branch and delete `test-release`.

## Known assumptions to validate in the dry run

- Version via `semantic-release --dry-run --branches <base>` log parse — confirm against the installed semantic-release version.
- CHANGELOG via `conventional-changelog-cli` (conventionalcommits preset).
- Pre-staging gate = fast checks; `unit-dep` + `integration` gate the merge (existing workflows on the PR).
- Committer identity comes from the `arabot-1` GPG key.
