### PR TITLE
feat(proposal): improve error handling for unresolved daoId in pagination queries

### DIFF
--- a/src/services/aragon-api/controllers/proposal.ts
+++ b/src/services/aragon-api/controllers/proposal.ts
@@ -51,6 +51,10 @@ const ProposalController = {
     paginationParams = await PairDataModule.pairFromPaginationParams(paginationParams)
     extraParams = await PairDataModule.pairFromExtraParams(extraParams, pairParams)
 
+    if (pairParams?.daoId) {
+      assertExposable(!!extraParams?.daoAddress, ErrorKeyEnum.daoNotFound)
+    }
+
     const hasOnlyDaoAndNetwork =
       extraParams.daoAddress &&
       extraParams.network &&

--- a/test/unit/services/aragon-api/controllers/proposal.spec.ts
+++ b/test/unit/services/aragon-api/controllers/proposal.spec.ts
@@ -242,7 +242,7 @@ describe('Controller: Proposal', () => {
       expect(response.metadata.totalRecords).to.eq(1)
     })
 
-    it('should get proposals with pagination - daoId not found', async () => {
+    it('should reject with daoNotFound when daoId cannot be resolved instead of running an unscoped query', async () => {
       const paginationParams = {
         search: '',
         pageSize: 10,
@@ -258,10 +258,11 @@ describe('Controller: Proposal', () => {
       sandbox.stub(PairDataModule, 'pairFromExtraParams').resolves({})
       const spyReq = sandbox.spy(Models.Proposal, 'findWithPagination')
 
-      const response = await ProposalController.getProposalsWithPagination(paginationParams, filterParams, pairParams)
+      await expect(
+        ProposalController.getProposalsWithPagination(paginationParams, filterParams, pairParams),
+      ).to.be.rejectedWith(ErrorKeyEnum.daoNotFound)
 
-      expect(spyReq.calledOnce).to.be.true
-      expect(response).to.have.property('data').with.lengthOf(1)
+      expect(spyReq.called).to.be.false
     })
 
     it('should include linked accounts when dao has linked accounts and includeLinkedAccounts is true', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request improves the handling of invalid `daoId` parameters when fetching proposals, ensuring that queries are properly scoped and errors are surfaced to the client. The main focus is on preventing unscoped database queries when a `daoId` cannot be resolved, and adding corresponding tests to verify this behavior.

Error handling improvements:

* Added a check in `ProposalController.getProposalsWithPagination` to assert that a valid `daoAddress` exists when a `daoId` is provided, throwing a `daoNotFound` error if not.

Test enhancements:

* Updated the unit test to verify that when a `daoId` cannot be resolved, the controller rejects with the `daoNotFound` error and does not perform an unscoped database query. [[1]](diffhunk://#diff-a401eec0d1164ff7ddaca8372ffeb2a0698cb75107333001a761dd27ca2a6756L245-R245) [[2]](diffhunk://#diff-a401eec0d1164ff7ddaca8372ffeb2a0698cb75107333001a761dd27ca2a6756L261-R265)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
