### PR TITLE
feat(decoder): ensure value is always a string in toRawAction function

### DIFF
--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -754,7 +754,7 @@ class DecodeActions {
     const toRawAction = (tuple: any): IRawAction => ({
       from: action.to,
       to: tuple?.to ?? tuple?.[0],
-      value: tuple?.value ?? tuple?.[1] ?? '0',
+      value: String(tuple?.value ?? tuple?.[1] ?? '0'),
       data: tuple?.data ?? tuple?.[2] ?? '0x',
     })
 


### PR DESCRIPTION
## 📝 Summary

This pull request makes a minor update to the `DecodeActions` class in `src/helpers/decodeAction.ts`. The main change ensures that the `value` property in the `toRawAction` function is always a string, improving type consistency.

- Ensured the `value` property in the `toRawAction` function is always converted to a string for consistency.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
