### PR TITLE
feat(campaign): remove isDraft filter from findDraftByMerkleRoot method

### DIFF
--- a/src/models/schema/campaignMerkleRoot.ts
+++ b/src/models/schema/campaignMerkleRoot.ts
@@ -69,7 +69,7 @@ export default class CampaignMerkleRoot extends Model {
   }
 
   static async findDraftByMerkleRoot(pluginAddress: HexAddress, network: NetworksEnum, merkleRoot: string) {
-    return await this.findOne({ pluginAddress, network, merkleRoot, isDraft: true })
+    return await this.findOne({ pluginAddress, network, merkleRoot })
   }
 
   async update(params: Partial<CampaignMerkleRoot>, tOpts?: SaveOptions) {

--- a/test/unit/models/schema/campaignMerkleRoot.spec.ts
+++ b/test/unit/models/schema/campaignMerkleRoot.spec.ts
@@ -145,7 +145,7 @@ describe('Model: CampaignMerkleRoot', () => {
       expect(found?.isDraft).to.be.true
     })
 
-    it('Should not find non-draft CampaignMerkleRoot', async () => {
+    it('Should find non-draft CampaignMerkleRoot', async () => {
       await Models.CampaignMerkleRoot.create({
         ...rawCampaignMerkleRoot,
         isDraft: false,
@@ -157,7 +157,9 @@ describe('Model: CampaignMerkleRoot', () => {
         rawCampaignMerkleRoot.merkleRoot!,
       )
 
-      expect(found).to.be.null
+      expect(found).to.not.be.null
+      expect(found?.campaignId).to.eq(rawCampaignMerkleRoot.campaignId)
+      expect(found?.isDraft).to.be.false
     })
 
     it('Should return null when no matching merkle root exists', async () => {


### PR DESCRIPTION
Cherry-picks #1363 onto staging in isolation.

`development` currently carries #1352, #1362, #1363, #1364 — a plain development→staging would pull all of them. This brings **only** #1363 (commits f20736983 + 1823dbabb), which changes only `campaignMerkleRoot.ts` and its test.

Cherry-picked from development.