### PR TITLE
Hotfix v0.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aragon-backend",
   "description": "OpenSource backend services",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "author": "Aragon Development Team",


### PR DESCRIPTION
Hotfix v0.26.1 (manual mode). Push the fix to `hotfix/0.26.1`; CI re-runs on PR sync. Remember to update CHANGELOG.md with the fix.

If a release/* PR is open: merge this hotfix first, merge the auto back-merge PR (main → development), then rebase the release branch onto development and resolve the CHANGELOG.md / package.json conflicts.