### PR TITLE
chore: cherry-pick hotfix into release/0.27.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+TEST HOTFIX 0.27.1
+
 ![UnitTest](https://github.com/aragon/app-backend/actions/workflows/app-backend-test.yml/badge.svg?branch=develop)
 ![Aragon](https://res.cloudinary.com/dbktgy3vg/image/upload/v1689668058/aragon-app_hpima1.png)
 


### PR DESCRIPTION
Auto cherry-pick of the hotfix fix commits onto `release/0.27.0` (clean). Review & merge to ship the hotfix in this release. The release keeps its own version.