### PR TITLE
feat(decoder): enhance metadata handling for nested cross-DAO updates

### DIFF
--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -351,7 +351,8 @@ class DecodeActions {
       return null
     }
 
-    const metadataOriginKey = daoRecord || document.daoAddress === action.to ? 'daoAddress' : 'pluginAddress'
+    const isDaoMetadata = Boolean(daoRecord) || document.daoAddress === action.to
+    const metadataOriginKey = isDaoMetadata ? 'daoAddress' : 'pluginAddress'
 
     const existingMetadata = await Models.LogMetadata.getMetadataAtBlockNumber(
       action.to,

--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -342,16 +342,16 @@ class DecodeActions {
       return null
     }
 
-    const [pluginMetadata, daoMetadata] = await Promise.all([
+    const [daoRecord, pluginRecord] = await Promise.all([
       Models.Dao.findByAddress(action.to, document.network!),
       Models.Plugin.findByAddress(action.to, document.network!),
     ])
 
-    if (pluginMetadata && daoMetadata) {
+    if (daoRecord && pluginRecord) {
       return null
     }
 
-    const metadataOriginKey = document.daoAddress === action.to ? 'daoAddress' : 'pluginAddress'
+    const metadataOriginKey = daoRecord || document.daoAddress === action.to ? 'daoAddress' : 'pluginAddress'
 
     const existingMetadata = await Models.LogMetadata.getMetadataAtBlockNumber(
       action.to,

--- a/test/unit/helpers/decodeAction.spec.ts
+++ b/test/unit/helpers/decodeAction.spec.ts
@@ -2302,6 +2302,62 @@ describe('Helpers: DecodeActions', () => {
       expect(result?.type).to.be.eq('MetadataPluginUpdate')
       expect(parseContractNetspecStub.calledOnce).to.be.true
     })
+
+    it('should resolve a nested cross-DAO setMetadata as a DAO update and pick up the existing metadata', async () => {
+      // The nested `setMetadata` targets a DAO different from the outer proposal's `document.daoAddress`
+      // (e.g. reached via an `execute` on another DAO). It must be keyed off `daoAddress`, not `pluginAddress`.
+      const baseAction = {
+        textSignature: 'setMetadata(bytes)',
+        function: 'setMetadata',
+        contract: 'DaoFactory',
+        parameters: [
+          {
+            name: 'metadata',
+            type: 'bytes',
+            value:
+              '0x697066733a2f2f516d4e753239435378354276596a506a786d716e6a6a6d5a68326e6a4e4b6e68346a7a566b5a6d476d4778667458',
+          },
+        ],
+      }
+
+      const action = {
+        to: '0x9642F9b4480F6e134742922d8e0C7D3503F95b0e',
+        value: 0n,
+        data: '0x00',
+      }
+
+      // Outer proposal belongs to a different DAO than the nested setMetadata target.
+      const document = {
+        daoAddress: '0x4648e36587B6c3DbF04Addf77e0121A33ce67c80',
+        blockNumber: 123,
+        network: NetworksEnum.ethereumSepolia,
+      }
+
+      const actionDecode = new DecodeActions()
+
+      // `action.to` resolves to a DAO, not a plugin.
+      sandbox.stub(Models.Dao, 'findByAddress').resolves(true)
+      sandbox.stub(Models.Plugin, 'findByAddress').resolves(false)
+      const getMetadataAtBlockNumberStub = sandbox.stub(Models.LogMetadata, 'getMetadataAtBlockNumber').resolves({
+        name: 'Release_test_0',
+        description: 'existing',
+        links: [],
+      })
+      const ipfsStub = Ipfs.fetchMetadata as sinon.SinonStub
+      ipfsStub.resolves({ name: 'Release_test_0 EDIT FROM DAO' })
+      sandbox.stub(Web3Utils, 'extractMetadataUri').returns('https://link')
+      sandbox.stub(Web3Utils, 'parseDaoMetadata').returns({ name: 'Release_test_0 EDIT FROM DAO' } as any)
+
+      const result: any = await actionDecode._parseUpdateDaoMetadata(baseAction, action, document as any)
+
+      expect(result?.type).to.be.eq(ProposalActionType.MetadataUpdate)
+      expect(result?.existingMetadata?.name).to.be.eq('Release_test_0')
+      // Existing metadata must be looked up by the DAO origin key, using the nested target address.
+      expect(getMetadataAtBlockNumberStub.calledOnce).to.be.true
+      const [lookupAddress, , , originKey] = getMetadataAtBlockNumberStub.firstCall.args
+      expect(lookupAddress).to.be.eq('0x9642F9b4480F6e134742922d8e0C7D3503F95b0e')
+      expect(originKey).to.be.eq('daoAddress')
+    })
   })
 
   describe('_parseStageUpdatedOnSppAction', () => {


### PR DESCRIPTION
## 📝 Summary

This pull request improves the handling of nested cross-DAO `setMetadata` actions to ensure metadata updates are correctly attributed to DAOs rather than plugins. It also adds a comprehensive unit test to verify this behavior.

**Decode logic improvements:**

* Updated the logic in `DecodeActions._parseUpdateDaoMetadata` to determine the correct metadata origin key (`daoAddress` or `pluginAddress`) based on whether the target address is a DAO, ensuring accurate metadata lookup for nested cross-DAO actions.

**Testing enhancements:**

* Added a unit test in `decodeAction.spec.ts` to verify that nested cross-DAO `setMetadata` actions are resolved as DAO updates and that existing metadata is correctly retrieved using the DAO address as the origin key.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
