### PR TITLE
ci(release): seed main with PR-gated release flow (PR-base side)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aragon/app-team

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -1,0 +1,265 @@
+name: Deploy (reusable)
+run-name: Deploy ${{ inputs.ref }} to ${{ inputs.environment }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Reusable build-on-server Docker Compose deploy to a single environment.
+# Extracted from app-deploy-docker.yml so the new release flow can call it via
+# `workflow_call`. The `environment:` key is what enforces the approval gates:
+#   • staging     → Approve #1 (Environment protection)
+#   • production  → CI Gate    (Environment protection)
+#
+# Callers MUST pass `secrets: inherit` (this workflow reads org/repo secrets
+# dynamically: OP_SERVICE_ACCOUNT_TOKEN_{PROD,NONPROD}_TEMP / _BACKEND2_TEMP /
+# _BACKEND2_INFRA).
+#
+# Callers pass environment = development | staging | production (sandbox is still
+# valid for ad-hoc tests). NOTE: this is intended to fully replace
+# app-deploy-docker.yml — retire that file once nothing else references it.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Target environment (sandbox|development|staging|production)
+        required: true
+        type: string
+      ref:
+        description: Git ref (branch/tag/sha) to build & deploy
+        required: true
+        type: string
+      version:
+        description: Release version to show in notifications (optional, e.g. 1.5.0)
+        required: false
+        type: string
+        default: ''
+      slack-thread-ts:
+        description: Slack thread ts to post deploy updates under (optional)
+        required: false
+        type: string
+        default: ''
+    outputs:
+      thread-ts:
+        description: Slack ts of the deploy-start message (for threading further updates)
+        value: ${{ jobs.deploy.outputs.thread-ts }}
+
+env:
+  DEPLOYMENT_USER: 'deploy'
+  DEPLOYMENT_PATH: 'app-backend-deploy'
+  ARCHIVE_NAME: 'deploy.tar.gz'
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    # ⮕ APPROVAL GATE. If this Environment has a "Required reviewers" protection
+    #   rule (repo Settings → Environments → <env> → Required reviewers = code
+    #   owners), GitHub PAUSES this job until a reviewer approves it in the Actions
+    #   run. That pause IS Approve #1 (staging) / the CI Gate (production)
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: false
+    outputs:
+      thread-ts: ${{ steps.slack-deploy-start.outputs.ts }}
+
+    steps:
+      # Map environment → deploy code + 1Password vault / service-account secret names
+      - name: Configure deployment environment
+        id: configure
+        env:
+          ENVIRONMENT_INPUT: ${{ inputs.environment }}
+          REF: ${{ inputs.ref }}
+        run: |
+          ENVIRONMENT="$ENVIRONMENT_INPUT"
+          case "$ENVIRONMENT" in
+            production)  DEPLOY_ENV="prod" ;;
+            staging)     DEPLOY_ENV="stg" ;;
+            development) DEPLOY_ENV="dev" ;;
+            sandbox)     DEPLOY_ENV="sand" ;;
+            *) echo "❌ Unknown environment: $ENVIRONMENT"; exit 1 ;;
+          esac
+          echo "DEPLOY_ENV=$DEPLOY_ENV" >> "$GITHUB_ENV"
+
+          if [[ "$ENVIRONMENT" == "production" ]]; then
+            echo "OP_VAULT=apikeys_production" >> "$GITHUB_ENV"
+          else
+            echo "OP_VAULT=apikeys_nonprod" >> "$GITHUB_ENV"
+          fi
+
+          OP_VAULT_NAME=$([[ "$ENVIRONMENT" == "production" ]] && echo "apikeys_production" || echo "apikeys_nonprod")
+          # Emit the server op:// references as STEP OUTPUTS, not $GITHUB_ENV.
+          # load-secrets-action scans the entire environment and resolves every
+          # op:// var with the current step's token. A global OP_SERVER_*
+          # (apikeys_nonprod/apikeys_production) gets picked up by the later
+          # "Load Slack secrets" step — whose kv_backend2_infra token can't see
+          # those vaults — and fails with "isn't a vault in this account".
+          # Step outputs stay scoped to the steps that opt in. (Env-agnostic bug:
+          # it would break staging/production too, not just sandbox.)
+          echo "server_username=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/username" >> "$GITHUB_OUTPUT"
+          echo "server_url=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/URL" >> "$GITHUB_OUTPUT"
+          echo "server_cert=op://${OP_VAULT_NAME}/backend2_server_${DEPLOY_ENV}/deploy_backend2_${DEPLOY_ENV}" >> "$GITHUB_OUTPUT"
+
+          # Checkout creates a sibling dir named after the repo (not owner/repo).
+          # GITHUB_REPOSITORY is always set on the runner; github.event.repository.name
+          # can be empty when this reusable workflow is invoked via workflow_call.
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_ENV"
+
+          echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=$REF repo=$REPO_NAME"
+
+      - name: Load Slack secrets
+        id: slack-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: 'op://kv_backend2_infra/SLACK_BOT_TOKEN/credential'
+          SLACK_CHANNEL_ID: 'op://kv_backend2_infra/SLACK_CHANNEL_ID/credential'
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3.0.0
+
+      - name: Load server connection secrets
+        id: server-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.environment == 'production' && secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_TEMP || secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD_TEMP }}
+          SERVER_USERNAME: ${{ steps.configure.outputs.server_username }}
+          SERVER_URL: ${{ steps.configure.outputs.server_url }}
+
+      - name: Checkout source at ref
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Notify Slack - Deploy Started
+        id: slack-deploy-start
+        if: steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ inputs.slack-thread-ts }}
+          message: |
+            :rocket: *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploying to ${{ inputs.environment }}...*
+            Ref: `${{ inputs.ref }}`
+            Triggered by: ${{ github.actor }}
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>
+
+      - name: Setup SSH authentication
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.environment == 'production' && secrets.OP_SERVICE_ACCOUNT_TOKEN_PROD_TEMP || secrets.OP_SERVICE_ACCOUNT_TOKEN_NONPROD_TEMP }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          op read "${{ steps.configure.outputs.server_cert }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          cat > ~/.ssh/config <<EOF
+          Host deployment-server
+            HostName ${{ steps.server-secrets.outputs.SERVER_URL }}
+            User ${{ steps.server-secrets.outputs.SERVER_USERNAME }}
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking accept-new
+            ServerAliveInterval 60
+            ServerAliveCountMax 3
+          EOF
+          ssh deployment-server "echo '✅ SSH connection established'"
+
+      - name: Download application configurations
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_TEMP }}
+        run: |
+          cat > download_configs.sh << 'SCRIPT'
+          #!/bin/bash
+          set -euo pipefail
+          VAULT="temporal_backend2"
+          ITEM="configs_app_backend2_$DEPLOY_ENV"
+          echo "📄 Downloading application configurations..."
+          op item get --vault "$VAULT" "$ITEM" --format json | \
+            jq -r '.fields.[].label' | sed 1d | \
+            while IFS= read -r config_name; do
+              op item get --vault "$VAULT" "$ITEM" --fields "$config_name" | \
+                sed '1s/^"//;$s/"$//' > temp_config
+              IFS=';' read -ra CONFIGS <<< "$config_name"
+              for conf in "${CONFIGS[@]}"; do
+                CONFIG_FILE=".env.$conf-$DEPLOY_ENV"
+                cp temp_config "$CONFIG_FILE"
+                case "$DEPLOY_ENV" in
+                  prod) LOGZIO_ENV="PRODUCTION" ;;
+                  stg)  LOGZIO_ENV="STAGING" ;;
+                  sand) LOGZIO_ENV="SANDBOX" ;;
+                  *)    LOGZIO_ENV="DEVELOPMENT" ;;
+                esac
+                sed -i "s/^LOGZIO_SERVER_NAME=.*/LOGZIO_SERVER_NAME=${conf^^}-${LOGZIO_ENV}/" "$CONFIG_FILE"
+              done
+              rm temp_config
+            done
+          op item get --vault "$VAULT" "configs_docker" --fields "docker-config" | \
+            sed '1s/^"//;$s/"$//' > .env.docker
+          if [[ ! -s .env.docker ]]; then echo "❌ Docker config not found"; exit 1; fi
+          echo "✅ Configuration download complete"
+          SCRIPT
+          chmod +x download_configs.sh
+          ./download_configs.sh
+
+      - name: Deploy to server
+        env:
+          REF: ${{ inputs.ref }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          REPO_NAME: ${{ env.REPO_NAME }}
+          DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
+        run: |
+          echo "🚀 Deploying $REF to $ENVIRONMENT..."
+          cd ..
+          tar -czf deploy.tar.gz "$REPO_NAME"
+          scp deploy.tar.gz deployment-server:~/
+          ssh deployment-server bash -s "$REPO_NAME" "$DEPLOY_ENV" << 'EOF'
+          REPO_NAME=$1
+          DEPLOY_ENV=$2
+          set -e
+          tar -xzf ~/deploy.tar.gz
+          rm ~/deploy.tar.gz
+          rm -rf ~/app-backend-deploy
+          mv ~/"$REPO_NAME" ~/app-backend-deploy
+          cd ~/app-backend-deploy
+          chmod +x scripts/*.sh
+          export ENV_SUFFIX="$DEPLOY_ENV"
+          export DEPLOY_ENV="$DEPLOY_ENV"
+          docker network create internal-net 2>/dev/null || true
+          docker network create public-net 2>/dev/null || true
+          bash scripts/app-deploy.sh "$ENV_SUFFIX"
+          echo "✅ Deployment completed"
+          EOF
+          rm deploy.tar.gz || true
+
+      - name: Verify deployment health
+        run: |
+          ssh deployment-server << 'HEALTH_CHECK'
+          set -euo pipefail
+          cd ~/app-backend-deploy
+          docker ps --filter "label=app=backend2" --filter "status=running" --format "table {{.Names}}\t{{.Status}}"
+          echo "✅ Health check passed"
+          HEALTH_CHECK
+
+      - name: Cleanup sensitive data
+        if: always()
+        run: |
+          rm -rf ~/.ssh/deploy_key ~/.ssh/config
+          rm -f .env* download_configs.sh
+          unset OP_SERVICE_ACCOUNT_TOKEN || true
+
+      - name: Notify Slack - Deploy Result
+        if: always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.slack-deploy-start.outputs.ts || inputs.slack-thread-ts }}
+          message: |
+            ${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploy to ${{ inputs.environment }} ${{ job.status }}*
+            Ref: `${{ inputs.ref }}`
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -1,0 +1,68 @@
+name: Release — Back-merge into development
+run-name: Back-merge ${{ github.event.pull_request.head.ref }} → development
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fires the MOMENT a release/* or hotfix/* PR merges into the release target.
+# Whatever lands on main must flow back to development immediately — so this is
+# deliberately decoupled from tagging/release (release-finalize) and from
+# app-production: a finalize failure (e.g. a duplicate tag in shadow) must NOT
+# block the back-merge. Opens an idempotent back-merge PR; never auto-merged.
+#
+# The companion "hotfix → open release/*" port is handled separately by
+# release-hotfix-cherrypick.yml (also on the merge), so both directions
+# (main → development AND → the open release) are covered off the merge alone.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  back-merge:
+    if: >
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          # Release PAT — the back-merge PR hits CODEOWNERS (@aragon/app-team
+          # auto-requested); the token needs org `read:org`.
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+
+      - name: Open idempotent back-merge PR (main → development)
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          MERGED_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          BASE="development"; HEAD="main"
+          VERSION="${MERGED_HEAD##*/}" # release/0.27.0 | hotfix/0.27.1 -> 0.27.x
+          echo "Back-merge: $HEAD → $BASE (from $MERGED_HEAD)"
+          TITLE="chore: sync $HEAD (v$VERSION) back to $BASE"
+          BODY="Auto-opened when \`$MERGED_HEAD\` merged into \`$HEAD\`. Carries the merged changes (incl. CHANGELOG.md / version) back into \`$BASE\`."
+          EXISTING_PR=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number -q '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+            echo "Updated existing back-merge PR #$EXISTING_PR"
+          elif OUT=$(gh pr create --base "$BASE" --head "$HEAD" --title "$TITLE" --body "$BODY" 2>&1); then
+            echo "$OUT"
+          else
+            echo "$OUT"
+            # No diff or a PR already exists → nothing to do, not a failure.
+            echo "$OUT" | grep -qiE 'No commits between|already exists' \
+              && { echo "$BASE already in sync with $HEAD — nothing to back-merge"; exit 0; }
+            exit 1
+          fi

--- a/.github/workflows/release-cancel.yml
+++ b/.github/workflows/release-cancel.yml
@@ -1,0 +1,90 @@
+name: Release — Cancel
+run-name: Release cancel ${{ github.event.pull_request.head.ref }}
+
+# Fires when a release/* or hotfix/* PR is closed.
+#   • If closed WITHOUT merging: notify the Slack thread it was abandoned.
+#   • On ANY close (merged or not): cancel the PR's release-pr run if it's still
+#     sitting on the Approve #1 (staging) environment gate — that gate is moot
+#     once the PR is gone, so it shouldn't linger as "Waiting" forever.
+#
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  cancel-runs:
+    # Any close (merged or not): drop runs still waiting on approval / running.
+    if: >
+      startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel the PR's release-pr run if it's still waiting on the gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # Scope to release-pr.yml so we never cancel THIS workflow, finalize,
+          # or app-production. Match the PR's head branch and any not-yet-finished
+          # status (waiting = pending environment approval).
+          IDS=$(gh run list --workflow=release-pr.yml --branch "$HEAD" --limit 50 \
+            --json databaseId,status \
+            -q '.[] | select(.status=="waiting" or .status=="queued" or .status=="in_progress" or .status=="requested" or .status=="pending" or .status=="action_required") | .databaseId')
+          if [ -z "$IDS" ]; then
+            echo "No active release-pr run for $HEAD."
+            exit 0
+          fi
+          for id in $IDS; do
+            echo "Cancelling run $id"
+            gh run cancel "$id" || echo "  (run $id already finished?)"
+          done
+
+  cancel:
+    if: >
+      github.event.pull_request.merged == false &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Extract Slack thread ts from PR body
+        id: ts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          TS=$(grep -oE '<!-- slack_ts: [0-9.]+ -->' pr_body.txt | grep -oE '[0-9.]+' | head -1 || true)
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack — cancelled
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: |
+            :no_entry_sign: *Release cancelled* — PR closed without merging. Production unchanged.
+      # NOTE: if a hotfix landed on main while this release was open, the hotfix's
+      # own app-production run already opened the main → development back-merge PR,
+      # so development stays consistent even when the release is cancelled.

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,124 @@
+name: Release — Finalize
+run-name: Finalize ${{ github.event.pull_request.head.ref }}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Fires when a release/* (or hotfix/*) PR merges into the target branch.
+# Creates the tag + GitHub Release from the prepared CHANGELOG section and
+# carries the Slack thread into the release body. The published release
+# triggers app-production.yml.
+#
+# Trigger branch = `main`. Tags the release `vX.Y.Z` and publishes a (non-pre)
+# GitHub Release, which triggers app-production.yml. This is the only place a
+# release tag is created (the legacy push:main semantic-release is retired).
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-finalize-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  TAG_PREFIX: ''
+  PRERELEASE: 'false'
+
+jobs:
+  finalize:
+    if: >
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+
+      - name: Checkout merged SHA
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+
+      - name: Read version
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Extract CHANGELOG section for this version
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          VER="$VERSION"
+          awk -v ver="$VER" '
+            /^#{1,2} \[/ { if (inblock) exit; if (index($0, "[" ver "]")) { inblock=1; print; next } }
+            inblock { print }
+          ' CHANGELOG.md > notes.md || true
+          if [ ! -s notes.md ]; then echo "Release v$VER" > notes.md; fi
+
+      - name: Extract Slack thread ts from PR body
+        id: ts
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          TS=$(grep -oE '<!-- slack_ts: [0-9.]+ -->' pr_body.txt | grep -oE '[0-9.]+' | head -1 || true)
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+
+      - name: Carry slack_ts into release notes
+        if: steps.ts.outputs.ts != ''
+        run: |
+          printf '\n\n<!-- slack_ts: %s -->\n' "${{ steps.ts.outputs.ts }}" >> notes.md
+
+      - name: Notify Slack — tagging & releasing
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: ':label: *PR merged — creating tag & GitHub Release...*'
+
+      - name: Create tag + GitHub Release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          VERSION: ${{ steps.v.outputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          TAG="${TAG_PREFIX}v${VERSION}"
+          PRE=""
+          [ "${PRERELEASE}" = "true" ] && PRE="--prerelease"
+          gh release create "$TAG" \
+            --target "$MERGE_SHA" \
+            --title "Release v${VERSION}${TAG_PREFIX:+ (shadow)}" \
+            --notes-file notes.md $PRE
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack — release created
+        if: steps.ts.outputs.ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ steps.ts.outputs.ts }}
+          message: |
+            :package: *GitHub Release created:* <${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag }}|${{ steps.release.outputs.tag }}>
+            _Production deploy will start automatically (behind the CI Gate)..._

--- a/.github/workflows/release-hotfix-cherrypick.yml
+++ b/.github/workflows/release-hotfix-cherrypick.yml
@@ -1,0 +1,121 @@
+name: Release — Cherry-pick hotfix into open release
+run-name: Cherry-pick hotfix into the open release/* branch
+
+# ──────────────────────────────────────────────────────────────────────────
+# When a hotfix/* PR merges into the release target (`main`) and
+# a release/* PR is still open, that release branch was cut BEFORE the hotfix and
+# is missing the fix. Cherry-pick ONLY the hotfix's fix commits — NOT the version
+# bump, NOT all of development (the release branch is intentionally frozen, so we
+# must not drag unreleased commits into it) — onto a branch off release/* and
+# open a PR into it. NEVER auto-merged.
+#
+# Best-effort: on a cherry-pick conflict the conflicted state is committed and
+# pushed, and the PR opens as a DRAFT flagged for manual resolution.
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherry-pick:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_BASE: main
+      HOTFIX_PR: ${{ github.event.pull_request.number }}
+      HOTFIX_HEAD: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          # Release PAT — MUST have org `read:org` (CODEOWNERS reviewer read).
+          GITHUB_RELEASE_TOKEN: op://kv_backend2_infra/ARABOT_APP_BACKEND_RELEASES/credential
+          GPG_PASSPHRASE: op://kv_backend2_infra/arabot-1_SIGN_CERTS/credential
+          GPG_PRIVATE_KEY: op://kv_backend2_infra/arabot-1_SIGN_CERTS/private_key
+
+      - name: Find open release/* branch
+        id: rel
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          REL=$(gh pr list --base "$RELEASE_BASE" --state open \
+            --json headRefName -q '[.[] | select(.headRefName|startswith("release/"))][0].headRefName // empty')
+          echo "branch=$REL" >> "$GITHUB_OUTPUT"
+          if [ -n "$REL" ]; then echo "Open release branch: $REL"; else echo "No open release/* PR — nothing to port."; fi
+
+      - name: Checkout release branch
+        if: steps.rel.outputs.branch != ''
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ steps.rel.outputs.branch }}
+          fetch-depth: 0
+          token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+
+      - name: Import GPG key
+        if: steps.rel.outputs.branch != ''
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ steps.secrets.outputs.GPG_PRIVATE_KEY }}
+          passphrase: ${{ steps.secrets.outputs.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Cherry-pick fix commits onto a branch off the release & open PR
+        if: steps.rel.outputs.branch != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REL: ${{ steps.rel.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # Fix commits = the hotfix PR's commits MINUS the chore(release) bump.
+          mapfile -t SHAS < <(gh pr view "$HOTFIX_PR" --json commits \
+            -q '.commits[] | select((.messageHeadline // "") | startswith("chore(release)") | not) | .oid')
+          if [ ${#SHAS[@]} -eq 0 ]; then
+            echo "Only the version bump on the hotfix — no fix commits to port."
+            exit 0
+          fi
+          echo "Porting ${#SHAS[@]} commit(s) onto $REL: ${SHAS[*]}"
+
+          SYNC="sync/hotfix-${HOTFIX_HEAD#hotfix/}-into-${REL#release/}"
+          git checkout -B "$SYNC"
+
+          CONFLICT=0
+          git cherry-pick -x "${SHAS[@]}" || CONFLICT=1
+          if [ "$CONFLICT" = 1 ]; then
+            echo "⚠️ Cherry-pick conflicted — committing the conflicted state for manual resolution."
+            git add -A
+            GIT_EDITOR=true git cherry-pick --continue 2>/dev/null || \
+              git commit --no-verify -m "cherry-pick hotfix $HOTFIX_HEAD into $REL (CONFLICTS — resolve before merge)"
+          fi
+          git push --force origin "$SYNC"
+
+          TITLE="chore: cherry-pick hotfix into $REL"
+          if [ "$CONFLICT" = 1 ]; then
+            BODY="Auto cherry-pick of the hotfix fix commits onto \`$REL\`. ⚠️ **Conflicts** — the conflicted state was committed. Resolve the markers, then merge. Do NOT merge with markers. The release keeps its own version."
+            DRAFT=--draft
+          else
+            BODY="Auto cherry-pick of the hotfix fix commits onto \`$REL\` (clean). Review & merge to ship the hotfix in this release. The release keeps its own version."
+            DRAFT=
+          fi
+          EXISTING=$(gh pr list --base "$REL" --head "$SYNC" --state open --json number -q '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body "$BODY"
+            echo "Updated existing cherry-pick PR #$EXISTING"
+          else
+            gh pr create --base "$REL" --head "$SYNC" --title "$TITLE" --body "$BODY" $DRAFT
+          fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,156 @@
+name: Release — PR (test + staging)
+run-name: Release PR #${{ github.event.pull_request.number }} — test + staging
+
+# ──────────────────────────────────────────────────────────────────────────
+# Runs on release/* and hotfix/* PRs into `main`:
+#   1. fast checks (lint, format, unit + coverage) — pre-staging gate
+#   2. deploy to staging (Approve #1 = staging Environment protection)
+#   3. post "what to test" + non-blocking E2E into the Slack thread
+#
+# unit-dep + integration run via the existing unit-dep.yml / integration-test.yml
+# on the same PR and are required checks for MERGE (Approve #2). We keep only the
+# fast checks here to avoid duplicating the docker-compose-test infra before
+# staging.
+#
+# Deploys to `staging` — the staging Environment's Required-reviewers rule is
+# Approve #1 (pauses the deploy until a reviewer approves).
+# ──────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  meta:
+    if: >
+      startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      thread-ts: ${{ steps.ts.outputs.ts }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Read version from package.json
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Get PR body
+        id: body
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} --json body -q .body > pr_body.txt
+          DELIM="EOF_$(date +%s%N)_$RANDOM"
+          { echo "body<<$DELIM"; cat pr_body.txt; echo "$DELIM"; } >> "$GITHUB_OUTPUT"
+      - name: Extract Slack thread ts
+        id: ts
+        uses: ./.github/actions/extract-slack-ts
+        with:
+          text: ${{ steps.body.outputs.body }}
+
+  test:
+    needs: meta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn format:check
+      - run: yarn test:unit:coverage
+      - run: yarn test:coverage:check
+
+  notify-gate1:
+    needs: [meta, test]
+    if: needs.meta.outputs.thread-ts != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+          # Slack user-group to ping on gates. # TODO(infra): create this user-group.
+          CODEOWNERS_GROUP_ID: op://kv_backend2_infra/SLACK_CODEOWNERS_GROUP_ID/credential
+      - name: Notify Slack — waiting Approve #1
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: |
+            :double_vertical_bar: *Waiting Approve #1 — deploy to staging* ${{ steps.secrets.outputs.CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.CODEOWNERS_GROUP_ID) || '' }}
+            Approve the staging deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
+
+  deploy-staging:
+    needs: [meta, test]
+    # Deploys to staging; Approve #1 = the staging Environment's Required-reviewers
+    # rule, which pauses this job until a reviewer approves.
+    uses: ./.github/workflows/deploy-reusable.yml
+    secrets: inherit
+    with:
+      environment: staging
+      ref: ${{ github.event.pull_request.head.sha }}
+      version: ${{ needs.meta.outputs.version }}
+      slack-thread-ts: ${{ needs.meta.outputs.thread-ts }}
+
+
+  e2e:
+    needs: [meta, deploy-staging]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      - name: Trigger E2E (non-blocking)
+        continue-on-error: true
+        uses: aragon/app-qa/.github/actions/dispatch@5954adf802c2577f6d63df5b118acbd74ff8bbf0 # main @ 2025-12-22 (no tagged releases upstream)
+        with:
+          opToken: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APP_NEXT_QA }}
+          environment: stg
+      - name: Load Slack secrets
+        id: secrets
+        if: needs.meta.outputs.thread-ts != ''
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Notify Slack — E2E triggered
+        if: needs.meta.outputs.thread-ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: ':test_tube: E2E tests triggered for staging (non-blocking)'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,152 @@
+# app-backend — Release runbook
+
+PR-gated release / hotfix / rollback flow for **app-backend**. Modeled on the
+frontend (`app`) flow, adapted for this repo: version via **semantic-release**
+(dry-run, log-parsed), changelog via **conventional-changelog**, **build-on-server
+Docker** deploy (no image registry), **forward-only** DB migrations.
+
+> The legacy `release.yml` (semantic-release on `push:main`) is retired —
+> `release-finalize.yml` is now the only place a release tag is created.
+
+---
+
+## Branch model
+
+| Branch | Role | Merge method |
+|---|---|---|
+| `development` | default branch; integration of feature work | **squash** feature PRs |
+| `main` | release line; every merge is a release/hotfix | **merge commit** (preserves dev↔main lineage & tag reachability) |
+| `release/x.y.z` | cut from `development` by Release — Start | merge-commit into `main` |
+| `hotfix/x.y.z` | cut from `main` by Hotfix — Start | merge-commit into `main` |
+| back-merge PR `main → development` | keeps `development` in sync after every release/hotfix | **merge** (never squash) |
+
+⚠️ Do **not** squash-merge into `main` — squashing breaks tag reachability and the
+next `release-start` would mis-compute the version. The back-merge PR into
+`development` must also stay a merge (so `development` keeps descending from the
+release tags). Per-branch `allowed_merge_methods` rulesets can enforce this.
+
+## The three gates
+
+| Gate | Where | Mechanism |
+|---|---|---|
+| **Approve #1** | `release-pr.yml` deploy → **staging** | `staging` Environment "Required reviewers" pauses the deploy |
+| **Approve #2** | merge the release PR into `main` | PR review + **CODEOWNERS** (`* @aragon/app-team`) |
+| **CI Gate** | `app-production.yml` deploy → **production** | `production` Environment "Required reviewers" pauses the deploy |
+
+A gate is the `environment:` key on `deploy-reusable.yml`'s deploy job **plus** the
+Required-reviewers rule on that GitHub Environment (repo Settings → Environments —
+not a file). Both `staging` and `production` MUST have Required reviewers, or the
+deploys won't pause.
+
+### Prerequisites (infra)
+
+- `@aragon/app-team` has access to the repo (so CODEOWNERS resolves the reviewer).
+- The 1Password release PAT `ARABOT_APP_BACKEND_RELEASES` has org **`read:org`** —
+  CODEOWNERS auto-requests the team on every PR and `gh pr create` reads the
+  reviewer back; without it gh fails on `reviewRequests`.
+- `staging` + `production` Environments have Required reviewers.
+- Vault has `SLACK_CODEOWNERS_GROUP_ID` (team ping on the gates).
+- Repo variable `RELEASE_V2_ENABLED=true` (arms `develop-deploy` push trigger).
+
+---
+
+## Workflows & operator steps
+
+All release PRs target `main`. Slack threads are correlated via a
+`<!-- slack_ts: … -->` marker embedded in the PR/release body.
+
+### 1. Release — Start (`release-start.yml`) — manual
+Dispatch **on `development`** (Actions → "Release — Start" → Run workflow → branch
+`development`; leave `base_commit` empty). It:
+- computes the next version (`semantic-release --dry-run --branches development`,
+  log-parsed) with a **stale-lineage guard** (fails if the computed version ≤ the
+  latest tag — that means `development` needs a back-merge first);
+- cuts `release/x.y.z` from `development`, commits the version bump + CHANGELOG
+  section (reviewable in the PR), force-pushes the branch;
+- opens the PR → `main` and starts the Slack thread (version, PR link, changelog,
+  DB-migration flag).
+- **Guard:** only one open `release/*` PR at a time.
+
+### 2. Release — PR (`release-pr.yml`) — on PR sync into `main`
+On `release/*` / `hotfix/*` PRs into `main`:
+- fast checks (lint, format, unit + coverage);
+- deploy to **staging** → **Approve #1** (the staging Environment pauses it;
+  Slack thread + team ping);
+- after approval: non-blocking E2E (staging) + Slack note.
+- `unit-dep.yml` / `integration-test.yml` run on the same PR and are the required
+  checks for **merge (Approve #2)**.
+
+### 3. Merge the PR into `main` = Approve #2
+Review + CODEOWNERS approval, then **merge commit** (not squash). This fires
+finalize, back-merge, and (if a hotfix) cherry-pick.
+
+### 4. Release — Finalize (`release-finalize.yml`) — on PR close (merged) into `main`
+Reads the version from `package.json`, extracts the CHANGELOG section, creates the
+tag **`vX.Y.Z`** + a published GitHub Release (carrying the Slack ts). The publish
+triggers production deploy.
+
+### 5. Production deploy (`app-production.yml`) — on Release `published`
+Deploys the tag to **production** → **CI Gate** (production Environment pauses it;
+a parallel `notify-gate` posts to Slack). After approval: deploy + non-blocking
+E2E (prod) + "release complete" Slack note. Also dispatchable manually with a tag
+(re-deploy / rollback target).
+
+### 6. Back-merge (`release-backmerge.yml`) — on PR close (merged) into `main`
+Opens an **idempotent** PR `main → development` so whatever shipped flows back to
+`development` immediately. Decoupled from tagging — a finalize failure can't block
+it. Merge it (merge method) to keep `development` in sync. "No commits / already
+exists" is a no-op.
+
+### 7. Hotfix — Start (`hotfix-start.yml`) — manual
+Branches `hotfix/x.y.z` from **`main`** (TARGET_BRANCH), bumps the patch version,
+opens the PR → `main`, posts Slack instructions. Push the fix to the branch; CI
+re-runs on sync (same gates as a release). Merging → finalize → production.
+- **Guard:** only one open `hotfix/*` at a time.
+
+### 8. Cherry-pick hotfix into an open release (`release-hotfix-cherrypick.yml`)
+When a `hotfix/*` PR merges into `main` **and** a `release/*` PR is still open, the
+release branch (cut earlier) is missing the fix. This ports **only the fix commits**
+(NOT the `chore(release)` bump, NOT all of `development`) onto a `sync/…` branch off
+the release and opens a PR into it. Never auto-merged; the release keeps its own
+version. On conflict it commits the conflicted state and opens a **DRAFT** PR
+flagged "resolve manually".
+
+### 9. Rollback (`rollback.yml`) — manual
+Redeploys a previous tag to **production** (build-on-server rebuild; there is no
+image registry). Behind the CI Gate. ⚠️ **Code only** — DB migrations are
+forward-only and are **not** reverted; for migration-bearing releases, fix forward
+(hotfix) instead.
+
+### 10. Release — Cancel (`release-cancel.yml`) — on PR close
+If a `release/*` / `hotfix/*` PR closes:
+- cancels its `release-pr` run if it's still waiting on the Approve #1 gate (the
+  gate is moot once the PR is gone);
+- if closed **without** merging, notifies the Slack thread it was abandoned.
+
+### 11. Develop → DEV deploy (`develop-deploy.yml`) — on push to `development`
+Auto-deploys `development` to the DEV environment. Gated by `RELEASE_V2_ENABLED`
+(push only deploys when it's `true`; `workflow_dispatch` always works).
+
+---
+
+## Concurrency / one-active guards
+
+- One open `release/*` and one open `hotfix/*` at a time (start workflows guard).
+- `deploy-reusable` serializes per-environment (`concurrency: deploy-<env>`,
+  `cancel-in-progress: false`) — a hotfix + release deploying to the same env queue
+  ("two deploys, one waiting" is expected).
+- A hotfix may run alongside an open release: merge the hotfix first, then merge
+  the auto back-merge (main → development) and the cherry-pick PR into the release.
+  If the pending release is also patch-level it computes the **same** version →
+  finalize fails on a duplicate tag; re-cut the release version.
+
+## Versioning
+
+`release-start` runs `semantic-release --dry-run --branches <base>` and parses
+"next release version is X.Y.Z" from the log. `--branches` tracks the dispatch
+branch. The CHANGELOG is generated by `conventional-changelog-cli`
+(conventionalcommits preset). The tag is created **only** by `release-finalize`.
+
+> **Lineage note:** `development` must descend from the latest release tag, or
+> semantic-release baselines on a stale tag. The post-release back-merge keeps it
+> in sync; a one-time bootstrap merge `main → development` repairs it initially.


### PR DESCRIPTION
**Phase 2 (main side) of the release-flow flip.** `main` is the release-PR base, so GitHub resolves `pull_request` workflows + the called reusable from here. Seeds exactly what the first real release PR needs — all **additions**, nothing on main is overwritten.

**Adds:**
- `release-pr.yml` (Approve #1 = deploy to staging) + `deploy-reusable.yml` (the gated deploy)
- `release-finalize.yml` (tags `vX.Y.Z` + GitHub Release) + `release-backmerge.yml` (main → development)
- `release-cancel.yml`, `release-hotfix-cherrypick.yml`
- `.github/CODEOWNERS` (`* @aragon/app-team`) = **Approve #2**
- `RELEASE.md`

The development-side workflows (release-start, app-production, hotfix-start, rollback, develop-deploy) and the unit-dep/integration-test trigger trims arrive on main automatically with the **first release merge** (development → main) — kept out here to avoid overwriting main's own copies.

⚠️ Merge method on main is **merge-commit** (ruleset-enforced). Pairs with #1381 + #1382. No deploys triggered by merging this.