### PR TITLE
feat(simulation): implement simulateDirectExecute for direct action simulations

### DIFF
--- a/src/services/aragon-api/controllers/simulation.ts
+++ b/src/services/aragon-api/controllers/simulation.ts
@@ -60,7 +60,13 @@ class SimulationController {
       status: ISimulationStatus
     }
 
-    Errors.assertExposable(!!result, ErrorKeyEnum.badSimulationRequest, 400, 'Simulation Not Implemented', llo({}))
+    Errors.assertExposable(
+      !!result,
+      ErrorKeyEnum.badSimulationRequest,
+      400,
+      'Simulation Not Implemented',
+      llo({ pluginAddress, network }),
+    )
 
     return {
       status: result.status,
@@ -109,7 +115,13 @@ class SimulationController {
       status: ISimulationStatus
     }
 
-    Errors.assertExposable(!!result, ErrorKeyEnum.badSimulationRequest, 400, 'Simulation Not Implemented', llo({}))
+    Errors.assertExposable(
+      !!result,
+      ErrorKeyEnum.badSimulationRequest,
+      400,
+      'Simulation Not Implemented',
+      llo({ daoAddress, from, network }),
+    )
 
     return {
       status: result.status,

--- a/src/services/aragon-api/controllers/simulation.ts
+++ b/src/services/aragon-api/controllers/simulation.ts
@@ -5,7 +5,7 @@ import * as Errors from '@errors'
 import logger from '@logger'
 import DbOperations from '@models/utils/dbOperations'
 import TenderlyModule from '@modules/tenderly'
-import { ErrorKeyEnum, IPluginStatus, type ISimulationStatus, type NetworksEnum } from '@types'
+import { ErrorKeyEnum, type HexAddress, IPluginStatus, type ISimulationStatus, type NetworksEnum } from '@types'
 import { ethers, Interface } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'simulation-controller' })
@@ -52,6 +52,55 @@ class SimulationController {
       data: encodedData,
       value: '0',
       from: pluginAddress,
+    }
+
+    const result = (await TenderlyModule.simulate(simulationAction, network)) as {
+      url?: string
+      runAt?: number
+      status: ISimulationStatus
+    }
+
+    Errors.assertExposable(!!result, ErrorKeyEnum.badSimulationRequest, 400, 'Simulation Not Implemented', llo({}))
+
+    return {
+      status: result.status,
+      url: result.url,
+      runAt: result.runAt,
+      network,
+    }
+  }
+
+  /**
+   * Run a simulation for a direct-execute action where the caller is the
+   * connected wallet (EOA) rather than a plugin. Validates the target DAO is
+   * indexed, but allows any `from` address.
+   * @param daoAddress
+   * @param from
+   * @param actions
+   * @param network
+   */
+  static async simulateDirectExecute(
+    daoAddress: string,
+    from: string,
+    actions: Array<{ data: string; value: string; to: string }>,
+    network: NetworksEnum,
+  ): Promise<any> {
+    const dao = await Models.Dao.findByAddress(daoAddress as HexAddress, network)
+    Errors.assertExposable(
+      dao,
+      ErrorKeyEnum.badSimulationRequest,
+      400,
+      'Invalid DAO: must be an indexed DAO',
+      llo({ daoAddress, network }),
+    )
+
+    const encodedData = SimulationController.parseSimulationRequest(actions)
+
+    const simulationAction = {
+      to: dao.address,
+      data: encodedData,
+      value: '0',
+      from,
     }
 
     const result = (await TenderlyModule.simulate(simulationAction, network)) as {

--- a/src/services/aragon-api/routers/schema/simulation.ts
+++ b/src/services/aragon-api/routers/schema/simulation.ts
@@ -17,6 +17,22 @@ const SimulationSchema = {
       .required(),
   }),
 
+  simulateDirectExecute: Joi.object({
+    daoAddress: ValidationSchema.joiAddress.required(),
+    network: ValidationSchema.joiNetworks.required(),
+    from: ValidationSchema.joiAddress.required(),
+    actions: Joi.array()
+      .items(
+        Joi.object({
+          to: ValidationSchema.joiAddress.required(),
+          data: Joi.string().required(),
+          value: Joi.string().default('0'),
+        }),
+      )
+      .min(1)
+      .required(),
+  }),
+
   simulationProposal: Joi.object({
     proposalId: Joi.string().required(),
   }),

--- a/src/services/aragon-api/routers/schema/simulation.ts
+++ b/src/services/aragon-api/routers/schema/simulation.ts
@@ -5,7 +5,9 @@ import Joi from 'joi'
 const SimulationSchema = {
   simulate: Joi.object({
     pluginAddress: ValidationSchema.joiAddress.required(),
-    network: ValidationSchema.joiNetworks.required(),
+    network: Joi.string()
+      .valid(...Object.values(NetworksEnum))
+      .required(),
     actions: Joi.array()
       .items(
         Joi.object({

--- a/src/services/aragon-api/routers/schema/simulation.ts
+++ b/src/services/aragon-api/routers/schema/simulation.ts
@@ -1,4 +1,5 @@
 import ValidationSchema from '@helpers/validationSchema'
+import { NetworksEnum } from '@types'
 import Joi from 'joi'
 
 const SimulationSchema = {
@@ -19,7 +20,9 @@ const SimulationSchema = {
 
   simulateDirectExecute: Joi.object({
     daoAddress: ValidationSchema.joiAddress.required(),
-    network: ValidationSchema.joiNetworks.required(),
+    network: Joi.string()
+      .valid(...Object.values(NetworksEnum))
+      .required(),
     from: ValidationSchema.joiAddress.required(),
     actions: Joi.array()
       .items(

--- a/src/services/aragon-api/routers/v2/simulation.ts
+++ b/src/services/aragon-api/routers/v2/simulation.ts
@@ -25,6 +25,27 @@ const SimulationRouter = {
     )
   },
 
+  async simulateDirectExecute(ctx: RouterContext) {
+    const result = await ValidationSchema.validateRoute(ctx, {
+      params: {
+        daoAddress: ctx.params.daoAddress,
+        network: ctx.params.network,
+        from: (ctx.request as any).body.from,
+        actions: (ctx.request as any).body.actions,
+      },
+      schemas: {
+        params: SimulationSchema.simulateDirectExecute,
+      },
+    })
+
+    ctx.body = await SimulationController.simulateDirectExecute(
+      result.params.daoAddress,
+      result.params.from,
+      result.params.actions,
+      result.params.network,
+    )
+  },
+
   async simulateProposal(ctx: RouterContext) {
     const result = await ValidationSchema.validateRoute(ctx, {
       params: {
@@ -92,6 +113,7 @@ const SimulationRouter = {
     const router = new Router()
 
     router.post('/:network/plugin/:pluginAddress/simulate', SimulationRouter.simulate)
+    router.post('/:network/dao/:daoAddress/simulate', SimulationRouter.simulateDirectExecute)
     router.post('/proposal/:proposalId', SimulationRouter.simulateProposal)
     router.get('/proposal/:proposalId', SimulationRouter.getSimulationResultOfProposal)
     router.post('/:network/dispatch/:policyAddress', SimulationRouter.simulateDispatch)

--- a/test/unit/services/aragon-api/controllers/simulation.spec.ts
+++ b/test/unit/services/aragon-api/controllers/simulation.spec.ts
@@ -145,6 +145,79 @@ describe('Controller: Simulation', () => {
     })
   })
 
+  describe('simulateDirectExecute', () => {
+    const mockActions = [
+      { data: '0xabcdef1234567890', value: '100', to: '0x1111111111111111111111111111111111111111' },
+      { data: '0x9876543210fedcba', value: '0', to: '0x2222222222222222222222222222222222222222' },
+    ]
+
+    const daoAddress = '0x4444444444444444444444444444444444444444'
+    const fromAddress = '0x5555555555555555555555555555555555555555'
+    const mockDao = { address: daoAddress, network: NetworksEnum.ethereumMainnet }
+
+    it('should successfully run simulation for an indexed DAO', async () => {
+      sandbox.stub(Models.Dao, 'findByAddress').resolves(mockDao)
+      sandbox.stub(TenderlyModule, 'simulate').resolves({
+        url: 'https://tenderly.co/simulation/direct',
+        runAt: 1234567890,
+        status: ISimulationStatus.SUCCESS,
+      })
+
+      const result = await SimulationController.simulateDirectExecute(
+        daoAddress,
+        fromAddress,
+        mockActions,
+        NetworksEnum.ethereumMainnet,
+      )
+
+      expect(result).to.deep.equal({
+        status: ISimulationStatus.SUCCESS,
+        url: 'https://tenderly.co/simulation/direct',
+        runAt: 1234567890,
+        network: NetworksEnum.ethereumMainnet,
+      })
+    })
+
+    it('should throw error when DAO is not indexed', async () => {
+      sandbox.stub(Models.Dao, 'findByAddress').resolves(null)
+
+      await expect(
+        SimulationController.simulateDirectExecute(daoAddress, fromAddress, mockActions, NetworksEnum.ethereumMainnet),
+      ).to.be.rejectedWith('badSimulationRequest')
+    })
+
+    it('should target the DAO and use the provided from address', async () => {
+      sandbox.stub(Models.Dao, 'findByAddress').resolves(mockDao)
+      const simulateStub = sandbox.stub(TenderlyModule, 'simulate').resolves({
+        url: 'https://tenderly.co/simulation/direct',
+        runAt: 1234567890,
+        status: ISimulationStatus.SUCCESS,
+      })
+
+      await SimulationController.simulateDirectExecute(
+        daoAddress,
+        fromAddress,
+        mockActions,
+        NetworksEnum.ethereumMainnet,
+      )
+
+      const simulationCall = simulateStub.firstCall.args[0]
+      expect(simulationCall.to).to.equal(daoAddress)
+      expect(simulationCall.from).to.equal(fromAddress)
+      expect(simulationCall.value).to.equal('0')
+      expect(simulationCall.data).to.be.a('string')
+    })
+
+    it('should throw error when simulation not implemented', async () => {
+      sandbox.stub(Models.Dao, 'findByAddress').resolves(mockDao)
+      sandbox.stub(TenderlyModule, 'simulate').resolves(false)
+
+      await expect(
+        SimulationController.simulateDirectExecute(daoAddress, fromAddress, mockActions, NetworksEnum.ethereumMainnet),
+      ).to.be.rejectedWith('badSimulationRequest')
+    })
+  })
+
   describe('simulateProposal', () => {
     const mockProposal = {
       entityId: 'proposal-123',

--- a/test/unit/services/aragon-api/routers/v2/simulation.spec.ts
+++ b/test/unit/services/aragon-api/routers/v2/simulation.spec.ts
@@ -77,6 +77,8 @@ describe('RouterV2: Simulation', () => {
       expect(stubCtrl.calledOnce).to.be.true
       expect(stubCtrl.firstCall.args[0]).to.equal(daoAddress)
       expect(stubCtrl.firstCall.args[1]).to.equal(fromAddress)
+      expect(stubCtrl.firstCall.args[2]).to.deep.equal(mockActions)
+      expect(stubCtrl.firstCall.args[3]).to.equal('ethereum-mainnet')
     })
   })
 

--- a/test/unit/services/aragon-api/routers/v2/simulation.spec.ts
+++ b/test/unit/services/aragon-api/routers/v2/simulation.spec.ts
@@ -46,6 +46,40 @@ describe('RouterV2: Simulation', () => {
     })
   })
 
+  describe('simulateDirectExecute', () => {
+    it('should call SimulationController.simulateDirectExecute with correct parameters', async () => {
+      const mockActions = [
+        { data: '0xabcdef1234567890', value: '100', to: '0x1111111111111111111111111111111111111111' },
+      ]
+      const mockResult = {
+        status: ISimulationStatus.SUCCESS,
+        url: 'https://tenderly.co/simulation/direct',
+        runAt: 1234567890,
+        network: NetworksEnum.ethereumMainnet,
+      }
+
+      const stubCtrl = sandbox.stub(SimulationController, 'simulateDirectExecute').resolves(mockResult)
+
+      const daoAddress = '0x4444444444444444444444444444444444444444'
+      const fromAddress = '0x5555555555555555555555555555555555555555'
+      const ctx: any = {
+        request: { body: { from: fromAddress, actions: mockActions } },
+        params: {
+          daoAddress,
+          network: 'ethereum-mainnet',
+        },
+        query: {},
+      }
+
+      await SimulationRouter.simulateDirectExecute(ctx)
+
+      expect(ctx.body).to.deep.equal(mockResult)
+      expect(stubCtrl.calledOnce).to.be.true
+      expect(stubCtrl.firstCall.args[0]).to.equal(daoAddress)
+      expect(stubCtrl.firstCall.args[1]).to.equal(fromAddress)
+    })
+  })
+
   describe('simulateProposal', () => {
     it('should call SimulationController.simulateProposal with correct parameters', async () => {
       const mockResult = {
@@ -98,7 +132,7 @@ describe('RouterV2: Simulation', () => {
       const router = SimulationRouter.router()
 
       expect(router).to.exist
-      expect(router.stack).to.have.lengthOf(4)
+      expect(router.stack).to.have.lengthOf(5)
 
       const routes = router.stack.map((layer: any) => ({
         path: layer.path,
@@ -107,6 +141,7 @@ describe('RouterV2: Simulation', () => {
 
       expect(routes).to.deep.include.members([
         { path: '/:network/plugin/:pluginAddress/simulate', methods: ['POST'] },
+        { path: '/:network/dao/:daoAddress/simulate', methods: ['POST'] },
         { path: '/proposal/:proposalId', methods: ['POST'] },
         { path: '/proposal/:proposalId', methods: ['HEAD', 'GET'] },
         { path: '/:network/dispatch/:policyAddress', methods: ['POST'] },
@@ -121,6 +156,11 @@ describe('RouterV2: Simulation', () => {
         (layer: any) => layer.path === '/:network/plugin/:pluginAddress/simulate' && layer.methods.includes('POST'),
       )
       expect(simulateLayer?.stack[0]).to.equal(SimulationRouter.simulate)
+
+      const simulateDirectExecuteLayer = layers.find(
+        (layer: any) => layer.path === '/:network/dao/:daoAddress/simulate' && layer.methods.includes('POST'),
+      )
+      expect(simulateDirectExecuteLayer?.stack[0]).to.equal(SimulationRouter.simulateDirectExecute)
 
       const simulateProposalLayer = layers.find(
         (layer: any) => layer.path === '/proposal/:proposalId' && layer.methods.includes('POST'),


### PR DESCRIPTION
## 📝 Summary

This pull request introduces a new feature to support direct execution simulations for DAOs, allowing users to simulate actions as an externally owned account (EOA) rather than through a plugin. The implementation includes controller logic, API schema validation, router integration, and comprehensive unit tests for both the controller and router layers.

**Direct Execution Simulation Feature:**

* Added a new `simulateDirectExecute` method to `SimulationController`, enabling simulation of DAO actions directly from a specified EOA address. This includes validation to ensure the DAO is indexed and proper error handling for invalid requests or unimplemented simulations.
* Extended the API schema in `SimulationSchema` to validate the new direct execution simulation parameters, including `daoAddress`, `from`, `actions`, and `network`.
* Integrated a new POST endpoint (`/:network/dao/:daoAddress/simulate`) in the simulation router to expose the direct execution simulation functionality. [[1]](diffhunk://#diff-75bccf8b1eaf3c284581c886b095f5721dfa1be3558498bc4c477236e6e3ab35R28-R48) [[2]](diffhunk://#diff-75bccf8b1eaf3c284581c886b095f5721dfa1be3558498bc4c477236e6e3ab35R116)

**Testing Enhancements:**

* Added comprehensive unit tests for the `simulateDirectExecute` controller method, covering successful execution, error scenarios, and correct parameter usage.
* Added router-level unit tests to verify correct routing, parameter passing, and endpoint registration for the new direct execution simulation route. [[1]](diffhunk://#diff-4a66cfbe623c41979fe457e722eef002c40e5393842e4b855f615f884d0024ddR49-R82) [[2]](diffhunk://#diff-4a66cfbe623c41979fe457e722eef002c40e5393842e4b855f615f884d0024ddL101-R135) [[3]](diffhunk://#diff-4a66cfbe623c41979fe457e722eef002c40e5393842e4b855f615f884d0024ddR144) [[4]](diffhunk://#diff-4a66cfbe623c41979fe457e722eef002c40e5393842e4b855f615f884d0024ddR160-R164)

**Type Improvements:**

* Updated type imports in `simulation.ts` to include `HexAddress`, ensuring type safety for addresses used in the new simulation logic.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
