### PR TITLE
ci(release): go-live toggles — enable DEV autodeploy + retire old release trigger

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -1,11 +1,8 @@
 name: Develop → DEV deploy
 run-name: DEV deploy ${{ github.ref_name }}
 
-# Auto-deploys development to the DEV environment on push (continuous integration
-# environment).
-#
-# Gated by the repo variable RELEASE_V2_ENABLED: the push trigger only deploys
-# when it is set to 'true' (workflow_dispatch always works for manual testing).
+# Auto-deploys development to the DEV environment on every push (continuous
+# integration environment). workflow_dispatch is also available for manual runs.
 # ──────────────────────────────────────────────────────────────────────────
 
 on:
@@ -22,7 +19,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || vars.RELEASE_V2_ENABLED == 'true'
     uses: ./.github/workflows/deploy-reusable.yml
     secrets: inherit
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,11 @@
 name: Release
 
 on:
+  # Retired: the PR-gated flow (release-start / release-pr / release-finalize +
+  # app-production) now owns versioning, tagging and the GitHub Release. This
+  # legacy semantic-release path is kept dispatch-only as a manual fallback and
+  # no longer auto-runs on push to main (which the branch ruleset blocks anyway).
   workflow_dispatch:
-  # TODO(flip): after sandbox QA of the new flow (release-start / release-pr /
-  # release-finalize + app-production), REMOVE this push:main trigger.
-  # release-finalize.yml then owns tagging + GitHub Release, and this
-  # semantic-release-on-push:main path is retired. Until then it stays live so
-  # the current release process is unaffected.
-  push:
-    branches:
-      - main
 
 jobs:
   release:


### PR DESCRIPTION
Two go-live switches on the **development** side:

1. **DEV autodeploy on** — `develop-deploy.yml`: drop the `RELEASE_V2_ENABLED` gate so every push to `development` auto-deploys to the DEV environment (no repo var needed; `workflow_dispatch` still works). ⚠️ merging this is itself a push to development → it will trigger the first DEV deploy.

2. **Retire the old release flow** — `release.yml`: remove the `push:[main]` trigger (kept dispatch-only). The legacy semantic-release path is structurally blocked by main's ruleset (`changes via PR`) and was firing red on every main push (e.g. on the #1383 merge). The PR-gated flow (release-start / release-pr / release-finalize + app-production) now owns versioning + tagging + release.

This change reaches **main** automatically with the first release merge — the `release/0.27.0` merge commit already carries `release.yml` without `push:main`, so the old flow won't fire on that merge (no double-tagging vs release-finalize). No separate PR into main needed.

Targets development; no conflicts with the first release (merge takes this side).