### PR TITLE
ci(deploy): unify deploy Slack notifications (gate + result) in deploy-reusable

### DIFF
--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -56,34 +56,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "ts=$TS" >> "$GITHUB_OUTPUT"
 
-  # Announce the gate BEFORE deploy-prod pauses on the production Environment
-  # protection (the CI Gate). Runs in parallel with deploy-prod — NOT via
-  # needs: — so that skipping it (no Slack thread) never cancels the deploy.
-  notify-gate:
-    needs: meta
-    if: needs.meta.outputs.thread-ts != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Load Slack secrets
-        id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
-          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
-          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
-      - name: Notify Slack — waiting CI Gate (production deploy)
-        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
-        uses: ./.github/actions/slack-notify
-        with:
-          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
-          thread-ts: ${{ needs.meta.outputs.thread-ts }}
-          message: |
-            :double_vertical_bar: *Waiting CI Gate — deploy to production*
-            Approve the production deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
-
+  # The "waiting CI Gate" ping is posted by deploy-reusable (notify-gate), so it
+  # fires for both release and manual/rollback prod deploys and isn't duplicated.
   deploy-prod:
     needs: meta
     # Deploys to production; the CI Gate = the production Environment's

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -39,9 +39,9 @@ on:
         type: string
         default: ''
     outputs:
-      thread-ts:
-        description: Slack ts of the deploy-start message (for threading further updates)
-        value: ${{ jobs.deploy.outputs.thread-ts }}
+      gate-ts:
+        description: ts of the approval-gate Slack message (for threading further notices, e.g. rollback)
+        value: ${{ jobs.notify-gate.outputs.ts }}
 
 env:
   DEPLOYMENT_USER: 'deploy'
@@ -49,6 +49,44 @@ env:
   ARCHIVE_NAME: 'deploy.tar.gz'
 
 jobs:
+  # Announce the approval gate BEFORE the deploy job pauses on the Environment
+  # protection. Runs in PARALLEL with deploy (NOT via needs) so it can never
+  # block/cancel the deploy. staging/production only — dev/sandbox have no gate
+  # and stay silent. Posts into the release thread when one is passed, otherwise
+  # as a new channel message whose ts threads the result (manual deploy).
+  notify-gate:
+    if: inputs.environment == 'staging' || inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    outputs:
+      ts: ${{ steps.gate.outputs.ts }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+      - name: Load Slack secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+          CODEOWNERS_GROUP_ID: op://kv_backend2_infra/SLACK_CODEOWNERS_GROUP_ID/credential
+      - name: Notify Slack — waiting for approval gate
+        id: gate
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ inputs.slack-thread-ts }}
+          message: |
+            :double_vertical_bar: *Waiting ${{ inputs.environment == 'production' && 'CI Gate' || 'Approve #1' }} — deploy to ${{ inputs.environment }}* ${{ steps.secrets.outputs.CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.CODEOWNERS_GROUP_ID) || '' }}
+            ${{ inputs.version && format('v{0} · ', inputs.version) || '' }}Ref: `${{ inputs.ref }}`
+            Approve the deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
+
   deploy:
     name: Deploy to ${{ inputs.environment }}
     runs-on: ubuntu-latest
@@ -60,8 +98,6 @@ jobs:
     concurrency:
       group: deploy-${{ inputs.environment }}
       cancel-in-progress: false
-    outputs:
-      thread-ts: ${{ steps.slack-deploy-start.outputs.ts }}
 
     steps:
       # Map environment → deploy code + 1Password vault / service-account secret names
@@ -108,16 +144,6 @@ jobs:
 
           echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=$REF repo=$REPO_NAME"
 
-      - name: Load Slack secrets
-        id: slack-secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
-          SLACK_BOT_TOKEN: 'op://kv_backend2_infra/SLACK_BOT_TOKEN/credential'
-          SLACK_CHANNEL_ID: 'op://kv_backend2_infra/SLACK_CHANNEL_ID/credential'
-
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3.0.0
 
@@ -136,20 +162,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
-
-      - name: Notify Slack - Deploy Started
-        id: slack-deploy-start
-        if: steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
-        uses: ./.github/actions/slack-notify
-        with:
-          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
-          thread-ts: ${{ inputs.slack-thread-ts }}
-          message: |
-            :rocket: *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploying to ${{ inputs.environment }}...*
-            Ref: `${{ inputs.ref }}`
-            Triggered by: ${{ github.actor }}
-            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>
 
       - name: Setup SSH authentication
         env:
@@ -252,14 +264,35 @@ jobs:
           rm -f .env* download_configs.sh
           unset OP_SERVICE_ACCOUNT_TOKEN || true
 
-      - name: Notify Slack - Deploy Result
-        if: always() && steps.slack-secrets.outputs.SLACK_BOT_TOKEN != ''
+  # Deploy result (success/failure) — staging/production only; dev/sandbox stay
+  # silent. Threads under the release thread if one was passed, otherwise under
+  # the gate message (so a manual deploy self-threads: gate = root, result = reply).
+  notify-result:
+    needs: [deploy, notify-gate]
+    if: always() && (inputs.environment == 'staging' || inputs.environment == 'production')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions
+      - name: Load Slack secrets
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      - name: Notify Slack — deploy result
+        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
         uses: ./.github/actions/slack-notify
         with:
-          slack-bot-token: ${{ steps.slack-secrets.outputs.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ steps.slack-secrets.outputs.SLACK_CHANNEL_ID }}
-          thread-ts: ${{ steps.slack-deploy-start.outputs.ts || inputs.slack-thread-ts }}
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ inputs.slack-thread-ts != '' && inputs.slack-thread-ts || needs.notify-gate.outputs.ts }}
           message: |
-            ${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploy to ${{ inputs.environment }} ${{ job.status }}*
+            ${{ needs.deploy.result == 'success' && ':white_check_mark:' || ':x:' }} *Backend ${{ inputs.version && format('v{0} ', inputs.version) || '' }}deploy to ${{ inputs.environment }} ${{ needs.deploy.result }}*
             Ref: `${{ inputs.ref }}`
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -76,38 +76,8 @@ jobs:
       - run: yarn test:unit:coverage
       - run: yarn test:coverage:check
 
-  notify-gate1:
-    needs: [meta, test]
-    if: needs.meta.outputs.thread-ts != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-        with:
-          sparse-checkout: |
-            .github/actions
-            .github/workflows/scripts
-      - name: Load secrets
-        id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
-          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
-          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
-          # Slack user-group to ping on gates. # TODO(infra): create this user-group.
-          CODEOWNERS_GROUP_ID: op://kv_backend2_infra/SLACK_CODEOWNERS_GROUP_ID/credential
-      - name: Notify Slack — waiting Approve #1
-        if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
-        uses: ./.github/actions/slack-notify
-        with:
-          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
-          thread-ts: ${{ needs.meta.outputs.thread-ts }}
-          message: |
-            :double_vertical_bar: *Waiting Approve #1 — deploy to staging* ${{ steps.secrets.outputs.CODEOWNERS_GROUP_ID && format('<!subteam^{0}>', steps.secrets.outputs.CODEOWNERS_GROUP_ID) || '' }}
-            Approve the staging deploy: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>
-
+  # The "waiting Approve #1" gate ping is posted by deploy-reusable (notify-gate),
+  # so it fires for both release and manual deploys and isn't duplicated here.
   deploy-staging:
     needs: [meta, test]
     # Deploys to staging; Approve #1 = the staging Environment's Required-reviewers

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -60,7 +60,10 @@ jobs:
       environment: production
       ref: ${{ inputs.tag }}
       version: ${{ needs.validate.outputs.version }}
+      # Gate + deploy result Slack notifications are posted by deploy-reusable.
 
+  # Rollback-specific safety notice — NOT a duplicate of the deploy result.
+  # Threads under the deploy's gate message so it lands in the same thread.
   notify:
     needs: [validate, rollback]
     if: always()
@@ -70,8 +73,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions
-            .github/workflows/scripts
-      - name: Load secrets
+      - name: Load Slack secrets
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
@@ -80,13 +82,12 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
           SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
           SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
-      - name: Notify Slack — rollback
+      - name: Notify Slack — rollback is code-only
         if: steps.secrets.outputs.SLACK_BOT_TOKEN != ''
         uses: ./.github/actions/slack-notify
         with:
           slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          thread-ts: ${{ needs.rollback.outputs.gate-ts }}
           message: |
-            :leftwards_arrow_with_hook: *Backend rollback to `${{ inputs.tag }}` — ${{ needs.rollback.result }}*
-            :warning: Code only — DB migrations are NOT reverted (roll-forward policy).
-            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>
+            :warning: *Rollback to `${{ inputs.tag }}` is code-only* — DB migrations are NOT reverted (roll-forward policy).


### PR DESCRIPTION
Single, deduplicated deploy-notification strategy as discussed.

**Where:** staging + production only. **dev + sandbox → silent** (no more noise on every merge to development).

**deploy-reusable** becomes the one source of deploy notifications:
- `notify-gate` (parallel to the gated deploy job): posts the **approval-gate** ping — *Waiting Approve #1* (staging) / *Waiting CI Gate* (production) + `@app-team` mention. Into the **release thread** if `slack-thread-ts` is passed; otherwise a **new channel message** (manual deploy) whose ts threads the result.
- `notify-result`: **success/failure**, threaded under the release thread, or under the gate message — so a **manual deploy self-threads** (gate = root, result = reply).
- Removed the per-deploy *'deploying…'* start spam.
- Exposes a `gate-ts` output for threading further notices.

**Dedup (removed duplicates):**
- `release-pr` → dropped `notify-gate1` (gate ping now from deploy-reusable).
- `app-production` → dropped `notify-gate` (same). Kept *'🎉 Release complete'* + E2E.
- `rollback` → dropped the duplicated success/fail line; **kept the 'code-only, DB migrations NOT reverted' warning**, now posted into the deploy thread.

Untouched (not deploy-level): release/hotfix *Started*, *Release created*, *cancelled*, E2E pings.

Targets development; reaches main with the first release (deploy-reusable may need a one-time manual conflict resolve there, as agreed).