### PR TITLE
refactor(logMetadata): update block number comparison and restrict test suite execution

### DIFF
--- a/src/models/schema/logMetadata.ts
+++ b/src/models/schema/logMetadata.ts
@@ -205,7 +205,7 @@ export default class LogMetadata extends Model {
       {
         $match: {
           blockNumber: {
-            $lte: blockNumber,
+            $lt: blockNumber,
           },
         },
       },

--- a/test/unit/models/schema/logMetadata.spec.ts
+++ b/test/unit/models/schema/logMetadata.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 
-describe('Model: LogMetadata', () => {
+describe.only('Model: LogMetadata', () => {
   let sandbox: SinonSandbox
   let rawLogDaoMetadata: Partial<LogMetadata>
 
@@ -143,7 +143,7 @@ describe('Model: LogMetadata', () => {
     const createdLogDao = await Models.LogMetadata.create(rawLogDaoMetadata)
     const metadataAtBlockNumber = await Models.LogMetadata.getMetadataAtBlockNumber(
       rawLogDaoMetadata.daoAddress!,
-      rawLogDaoMetadata.blockNumber!,
+      rawLogDaoMetadata.blockNumber! + 1,
       NetworksEnum.ethereumMainnet,
     )
 

--- a/test/unit/models/schema/logMetadata.spec.ts
+++ b/test/unit/models/schema/logMetadata.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 
-describe.only('Model: LogMetadata', () => {
+describe('Model: LogMetadata', () => {
   let sandbox: SinonSandbox
   let rawLogDaoMetadata: Partial<LogMetadata>
 


### PR DESCRIPTION
## 📝 Summary

This pull request makes a small adjustment to the logic for retrieving log metadata and updates the related test to match the new behavior. It also temporarily marks the test suite to run exclusively.

- **Logic update:**
  - Changed the query in `LogMetadata` so that it now fetches metadata strictly before the specified `blockNumber` (using `$lt` instead of `$lte`).

- **Testing updates:**
  - Updated the test in `logMetadata.spec.ts` to query at `blockNumber + 1` to align with the new logic.
  - Added `.only` to the test suite, making only this suite run during testing (likely for debugging purposes).

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
