### PR TITLE
feat(rabbitMQ): enhance message handling to support duplicate replyTo messages

### DIFF
--- a/src/helpers/rabbitMQ.ts
+++ b/src/helpers/rabbitMQ.ts
@@ -62,6 +62,20 @@ const RabbitMQHelper = {
             // Unique key per queue and message ID
             const uniqueKey = `${queueName}-${data?.id}`
 
+            if (msg.properties.replyTo && msg.properties.correlationId) {
+              try {
+                const response = await handler(data)
+                await channelWrapper.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(response)), {
+                  correlationId: msg.properties.correlationId,
+                  contentType: 'application/json',
+                })
+                channel.ack(msg)
+              } catch (handlerErr) {
+                logger.error('Error in messageHandler', llo({ queueName, data, error: handlerErr }))
+              }
+              return
+            }
+
             const release = await RabbitMQHelper.mutex.acquire()
             try {
               if (RabbitMQHelper.activeJobs.has(uniqueKey)) {
@@ -74,13 +88,7 @@ const RabbitMQHelper = {
             }
 
             try {
-              const response = await handler(data)
-              if (msg.properties.replyTo && msg.properties.correlationId) {
-                await channelWrapper.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(response)), {
-                  correlationId: msg.properties.correlationId,
-                  contentType: 'application/json',
-                })
-              }
+              await handler(data)
               const releaseFinal = await RabbitMQHelper.mutex.acquire()
               try {
                 RabbitMQHelper.activeJobs.delete(uniqueKey) // Remove the job from active jobs map

--- a/test/unit/helpers/rabbitMQ.spec.ts
+++ b/test/unit/helpers/rabbitMQ.spec.ts
@@ -171,6 +171,47 @@ describe('Helpers:RabbitMQ', () => {
       expect(handler.calledOnce).to.be.true
     })
 
+    it('should reply to every replyTo message even when ids are duplicated', async () => {
+      const queueName = EnumQueueName.contractInfo
+      const makeMsg = (correlationId: string, replyTo: string): any => ({
+        content: Buffer.from(JSON.stringify({ id: 'same-id', data: 'test' })),
+        properties: { correlationId, replyTo },
+        fields: {} as any,
+      })
+
+      let onMessage: any
+      const fakeChannel: Partial<any> = {
+        consume: sandbox.stub().callsFake((_queue, callback) => {
+          onMessage = callback
+        }),
+        ack: sandbox.stub(),
+        prefetch: sandbox.stub().returns(Promise.resolve()),
+        assertQueue: sandbox.stub().resolves(),
+      }
+
+      const fakeChannelWrapper = {
+        addSetup: sandbox.stub().callsFake(async setupFn => {
+          await setupFn(fakeChannel as ConfirmChannel)
+        }),
+        sendToQueue: sandbox.stub().resolves(true),
+      }
+
+      sandbox.stub(RabbitMQ, 'getChannel').returns(fakeChannelWrapper as any)
+      const handler = sandbox.stub().callsFake(async () => {
+        await utils.wait(50)
+        return { ok: true }
+      })
+
+      await RabbitMQHelper.process(queueName, handler)
+      // second message arrives while the first is still being handled
+      await Promise.all([onMessage(makeMsg('corr-A', 'reply-A')), onMessage(makeMsg('corr-B', 'reply-B'))])
+
+      const replies = fakeChannelWrapper.sendToQueue.getCalls().map((call: any) => call.args[2].correlationId)
+      expect(replies).to.have.members(['corr-A', 'corr-B'])
+      expect(handler.calledTwice).to.be.true
+      expect(fakeChannel.ack.callCount).to.equal(2)
+    })
+
     it('should handle null messages gracefully', async () => {
       const queueName = EnumQueueName.contractInfo
 


### PR DESCRIPTION
## 📝 Summary

This pull request updates the RabbitMQ message processing logic to ensure that messages with `replyTo` and `correlationId` properties are always replied to, even if their IDs are duplicated. It also adds a new unit test to verify this behavior.

**RabbitMQ message reply improvements:**

* Updated `RabbitMQHelper.process` in `src/helpers/rabbitMQ.ts` to immediately reply to messages with `replyTo` and `correlationId`, ensuring each such message receives a response regardless of duplicate IDs. [[1]](diffhunk://#diff-8dbb9b028f52a8bef37a9057f7ba60691cf846b5d8376eae19dcf2e09996f56cR65-R78) [[2]](diffhunk://#diff-8dbb9b028f52a8bef37a9057f7ba60691cf846b5d8376eae19dcf2e09996f56cL77-R91)

**Testing enhancements:**

* Added a unit test in `test/unit/helpers/rabbitMQ.spec.ts` to verify that every message with a `replyTo` and duplicated IDs receives a reply and acknowledgment.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
