### PR TITLE
chore: sync main (v0.27.1-rabbitmq) back to development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aragon-backend",
   "description": "OpenSource backend services",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "author": "Aragon Development Team",

--- a/src/helpers/rabbitMQ.ts
+++ b/src/helpers/rabbitMQ.ts
@@ -62,6 +62,20 @@ const RabbitMQHelper = {
             // Unique key per queue and message ID
             const uniqueKey = `${queueName}-${data?.id}`
 
+            if (msg.properties.replyTo && msg.properties.correlationId) {
+              try {
+                const response = await handler(data)
+                await channelWrapper.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(response)), {
+                  correlationId: msg.properties.correlationId,
+                  contentType: 'application/json',
+                })
+                channel.ack(msg)
+              } catch (handlerErr) {
+                logger.error('Error in messageHandler', llo({ queueName, data, error: handlerErr }))
+              }
+              return
+            }
+
             const release = await RabbitMQHelper.mutex.acquire()
             try {
               if (RabbitMQHelper.activeJobs.has(uniqueKey)) {
@@ -74,13 +88,7 @@ const RabbitMQHelper = {
             }
 
             try {
-              const response = await handler(data)
-              if (msg.properties.replyTo && msg.properties.correlationId) {
-                await channelWrapper.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(response)), {
-                  correlationId: msg.properties.correlationId,
-                  contentType: 'application/json',
-                })
-              }
+              await handler(data)
               const releaseFinal = await RabbitMQHelper.mutex.acquire()
               try {
                 RabbitMQHelper.activeJobs.delete(uniqueKey) // Remove the job from active jobs map

--- a/test/unit/helpers/rabbitMQ.spec.ts
+++ b/test/unit/helpers/rabbitMQ.spec.ts
@@ -171,6 +171,47 @@ describe('Helpers:RabbitMQ', () => {
       expect(handler.calledOnce).to.be.true
     })
 
+    it('should reply to every replyTo message even when ids are duplicated', async () => {
+      const queueName = EnumQueueName.contractInfo
+      const makeMsg = (correlationId: string, replyTo: string): any => ({
+        content: Buffer.from(JSON.stringify({ id: 'same-id', data: 'test' })),
+        properties: { correlationId, replyTo },
+        fields: {} as any,
+      })
+
+      let onMessage: any
+      const fakeChannel: Partial<any> = {
+        consume: sandbox.stub().callsFake((_queue, callback) => {
+          onMessage = callback
+        }),
+        ack: sandbox.stub(),
+        prefetch: sandbox.stub().returns(Promise.resolve()),
+        assertQueue: sandbox.stub().resolves(),
+      }
+
+      const fakeChannelWrapper = {
+        addSetup: sandbox.stub().callsFake(async setupFn => {
+          await setupFn(fakeChannel as ConfirmChannel)
+        }),
+        sendToQueue: sandbox.stub().resolves(true),
+      }
+
+      sandbox.stub(RabbitMQ, 'getChannel').returns(fakeChannelWrapper as any)
+      const handler = sandbox.stub().callsFake(async () => {
+        await utils.wait(50)
+        return { ok: true }
+      })
+
+      await RabbitMQHelper.process(queueName, handler)
+      // second message arrives while the first is still being handled
+      await Promise.all([onMessage(makeMsg('corr-A', 'reply-A')), onMessage(makeMsg('corr-B', 'reply-B'))])
+
+      const replies = fakeChannelWrapper.sendToQueue.getCalls().map((call: any) => call.args[2].correlationId)
+      expect(replies).to.have.members(['corr-A', 'corr-B'])
+      expect(handler.calledTwice).to.be.true
+      expect(fakeChannel.ack.callCount).to.equal(2)
+    })
+
     it('should handle null messages gracefully', async () => {
       const queueName = EnumQueueName.contractInfo
 


### PR DESCRIPTION
Auto-opened when `hotfix/0.27.1-rabbitmq` merged into `main`. Carries the merged changes (incl. CHANGELOG.md / version) back into `development`.