### PR TITLE
feat(networks): add support for monadMainnet in various configurations

### DIFF
--- a/config/common.ts
+++ b/config/common.ts
@@ -432,6 +432,17 @@ const getConfigObject = (sourceConfig: Record<string, any>): IConfig => {
         INTERVAL_BLOCK_TIME: utils.configParser(sourceConfig, 'number', 'NODES_HEMI_MAINNET_INTERVAL_BLOCK_TIME', 12),
         MAX_BLOCK_RANGE: utils.configParser(sourceConfig, 'number', 'NODES_HEMI_MAINNET_MAX_BLOCK_RANGE', 999),
       },
+      MONAD_MAINNET: {
+        ALCHEMY_API_KEY: utils.configParser(sourceConfig, 'string', 'NODES_MONAD_MAINNET_ALCHEMY_API_KEY', null),
+        DRPC_API_KEY: utils.configParser(sourceConfig, 'string', 'NODES_MONAD_MAINNET_DRPC_API_KEY', null),
+        ARAGON_RPC: utils.configParser(sourceConfig, 'string', 'NODES_MONAD_MAINNET_ARAGON_RPC', null),
+        FROM_BLOCK: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_FROM_BLOCK', 78667015),
+        OFFSET_TO_BLOCK: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_OFFSET_TO_BLOCK', 0),
+        POOLING_INTERVAL: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_POOLING_INTERVAL', 2 * 1000),
+        CONFIRMATION_BLOCKS: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_CONFIRMATION_BLOCKS', 1),
+        INTERVAL_BLOCK_TIME: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_INTERVAL_BLOCK_TIME', 1),
+        MAX_BLOCK_RANGE: utils.configParser(sourceConfig, 'number', 'NODES_MONAD_MAINNET_MAX_BLOCK_RANGE', 10000),
+      },
     },
 
     BOTTLENECK: {

--- a/src/helpers/coinGecko.ts
+++ b/src/helpers/coinGecko.ts
@@ -54,6 +54,7 @@ const CoinGeckoHelper = {
     [NetworksEnum.katanaMainnet]: 'katana',
     [NetworksEnum.hemiMainnet]: 'hemi',
     [NetworksEnum.citreaMainnet]: 'citrea',
+    [NetworksEnum.monadMainnet]: 'monad',
   },
 
   nativeTokenIdMap: {
@@ -70,6 +71,7 @@ const CoinGeckoHelper = {
     [NetworksEnum.katanaMainnet]: 'ethereum',
     [NetworksEnum.citreaMainnet]: 'bitcoin',
     [NetworksEnum.hemiMainnet]: 'ethereum',
+    [NetworksEnum.monadMainnet]: 'monad',
   },
 
   testnetNativeTokenMap: {

--- a/src/helpers/etherscan.ts
+++ b/src/helpers/etherscan.ts
@@ -22,6 +22,7 @@ const EtherscanHelper = {
     [NetworksEnum.katanaMainnet]: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     [NetworksEnum.citreaMainnet]: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     [NetworksEnum.hemiMainnet]: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    [NetworksEnum.monadMainnet]: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
   },
 
   axiosInstance: () =>

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -28,6 +28,7 @@ const Utils = {
     [NetworksEnum.katanaMainnet]: 'KATANA_MAINNET',
     [NetworksEnum.citreaMainnet]: 'CITREA_MAINNET',
     [NetworksEnum.hemiMainnet]: 'HEMI_MAINNET',
+    [NetworksEnum.monadMainnet]: 'MONAD_MAINNET',
   },
 
   networkToAragon: (network: NetworksEnum) => Utils.aragonNetworkMap[network],

--- a/src/modules/provider.ts
+++ b/src/modules/provider.ts
@@ -97,6 +97,7 @@ const ProviderModule = {
     [NetworksEnum.avaxMainnet]: DrpcNetwork.AVAX_MAINNET,
     [NetworksEnum.katanaMainnet]: DrpcNetwork.KATANA_MAINNET,
     [NetworksEnum.hemiMainnet]: DrpcNetwork.HEMI_MAINNET,
+    [NetworksEnum.monadMainnet]: DrpcNetwork.MONAD_MAINNET,
   },
 
   // Maps raw config keys to your NetworksEnum.
@@ -116,6 +117,7 @@ const ProviderModule = {
     KATANA_MAINNET: NetworksEnum.katanaMainnet,
     CITREA_MAINNET: NetworksEnum.citreaMainnet,
     HEMI_MAINNET: NetworksEnum.hemiMainnet,
+    MONAD_MAINNET: NetworksEnum.monadMainnet,
   },
 
   networkChainMap: {
@@ -134,6 +136,7 @@ const ProviderModule = {
     [NetworksEnum.katanaMainnet]: 747474,
     [NetworksEnum.citreaMainnet]: 4114,
     [NetworksEnum.hemiMainnet]: 43111,
+    [NetworksEnum.monadMainnet]: 143,
   },
 
   // Converts a config key to a NetworksEnum.

--- a/src/modules/proxyProvider/index.ts
+++ b/src/modules/proxyProvider/index.ts
@@ -13,6 +13,7 @@ const ProxyWeb3Provider: IWeb3Provider & { forward: any; getProvider: any; getDe
       case NetworksEnum.cornMainnet:
         return RoutescanProvider
       case NetworksEnum.katanaMainnet:
+      case NetworksEnum.monadMainnet:
         return KatanaProvider
       default:
         return Web3Provider

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -86,6 +86,7 @@ export interface IConfig {
     KATANA_MAINNET?: IRawNodeConfig
     CITREA_MAINNET?: IRawNodeConfig
     HEMI_MAINNET?: IRawNodeConfig
+    MONAD_MAINNET?: IRawNodeConfig
   }
   SUPPORTED_ENS_NETWORKS: SupportedEnsNetworksEnum[]
   SUPPORTED_NETWORKS: NetworksEnum[]

--- a/src/types/drpcNetwork.ts
+++ b/src/types/drpcNetwork.ts
@@ -12,6 +12,7 @@ export enum DrpcNetwork {
   AVAX_MAINNET = 'avalanche', // https://avalanche.drpc.org
   KATANA_MAINNET = 'katana', // https://katana.drpc.org
   HEMI_MAINNET = 'hemi', // https://hemi.drpc.org
+  MONAD_MAINNET = 'monad', // https://monad-mainnet.drpc.org
 }
 
 // DRPC load balanced URL format

--- a/src/types/networks.ts
+++ b/src/types/networks.ts
@@ -35,6 +35,7 @@ export enum NetworksEnum {
   katanaMainnet = 'katana-mainnet',
   citreaMainnet = 'citrea-mainnet',
   hemiMainnet = 'hemi-mainnet',
+  monadMainnet = 'monad-mainnet',
 }
 
 export enum StatusNetworkEnum {

--- a/test/unit/helpers/utils.spec.ts
+++ b/test/unit/helpers/utils.spec.ts
@@ -146,6 +146,7 @@ describe('Helpers:Utils', () => {
       'katana-mainnet': 'KATANA_MAINNET',
       'citrea-mainnet': 'CITREA_MAINNET',
       'hemi-mainnet': 'HEMI_MAINNET',
+      'monad-mainnet': 'MONAD_MAINNET',
     }
 
     Object.keys(NetworksEnum).forEach(key => {

--- a/test/unit/modules/provider.spec.ts
+++ b/test/unit/modules/provider.spec.ts
@@ -31,6 +31,7 @@ describe('Module: provider', () => {
     expect(ProviderModule.networksMap.PEAQ_MAINNET).to.equal(NetworksEnum.peaqMainnet)
     expect(ProviderModule.networksMap.CHILIZ_MAINNET).to.equal(NetworksEnum.chilizMainnet)
     expect(ProviderModule.networksMap.HEMI_MAINNET).to.equal(NetworksEnum.hemiMainnet)
+    expect(ProviderModule.networksMap.MONAD_MAINNET).to.equal(NetworksEnum.monadMainnet)
   })
 
   it('alchemyNetworksMap', () => {
@@ -57,6 +58,7 @@ describe('Module: provider', () => {
     expect(ProviderModule.drpcNetworksMap[NetworksEnum.avaxMainnet]).to.equal(DrpcNetwork.AVAX_MAINNET)
     expect(ProviderModule.drpcNetworksMap[NetworksEnum.katanaMainnet]).to.equal(DrpcNetwork.KATANA_MAINNET)
     expect(ProviderModule.drpcNetworksMap[NetworksEnum.hemiMainnet]).to.equal(DrpcNetwork.HEMI_MAINNET)
+    expect(ProviderModule.drpcNetworksMap[NetworksEnum.monadMainnet]).to.equal(DrpcNetwork.MONAD_MAINNET)
   })
 
   it('should correctly parseNetworkChain', () => {
@@ -82,6 +84,8 @@ describe('Module: provider', () => {
     expect(result9).to.equal(88888)
     const result10 = ProviderModule.getChainId(NetworksEnum.hemiMainnet)
     expect(result10).to.equal(43111)
+    const result11 = ProviderModule.getChainId(NetworksEnum.monadMainnet)
+    expect(result11).to.equal(143)
   })
 
   it('should correctly parseNetwork', () => {

--- a/test/unit/modules/proxyProvider/index.spec.ts
+++ b/test/unit/modules/proxyProvider/index.spec.ts
@@ -43,6 +43,11 @@ describe('ProxyWeb3Provider', () => {
       const provider = ProxyWeb3Provider.getProvider(NetworksEnum.katanaMainnet)
       expect(provider).to.equal(KatanaProvider)
     })
+
+    it('should return KatanaProvider for monadMainnet network', () => {
+      const provider = ProxyWeb3Provider.getProvider(NetworksEnum.monadMainnet)
+      expect(provider).to.equal(KatanaProvider)
+    })
   })
 
   describe('getDefaultProvider', () => {


### PR DESCRIPTION
## 📝 Summary

This pull request adds support for the Monad Mainnet network across the codebase. The changes ensure that Monad Mainnet is recognized and handled in configuration, provider selection, network mapping, and helper utilities. Unit tests are updated to verify the new functionality.

**Monad Mainnet Integration**

* Added `monadMainnet` to the `NetworksEnum` and included corresponding entries in configuration interfaces and network mappings to support Monad Mainnet throughout the application. [[1]](diffhunk://#diff-301866faf17e5aebd1b45b13aee5e679701b7060a089260d410ead5c76ba913bR38) [[2]](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aR89) [[3]](diffhunk://#diff-94e01b9bcaf37dddbea5defec6f62b685b2f2362d74b42d01d29fab89a70432bR31) [[4]](diffhunk://#diff-eab3a534ec46dc4d6fe7bd6ca1d2408171831f0a71cef83b5145d15743569b4eR120) [[5]](diffhunk://#diff-eab3a534ec46dc4d6fe7bd6ca1d2408171831f0a71cef83b5145d15743569b4eR139) [[6]](diffhunk://#diff-e2ecc8e5133f2fbd80e6d9d5ae7dd923894f56b17f362af076a49b5aae96f492R435-R445)

* Integrated Monad Mainnet into provider modules:
  - Mapped `NetworksEnum.monadMainnet` to `DrpcNetwork.MONAD_MAINNET` and assigned the correct chain ID. [[1]](diffhunk://#diff-75e9e2672cb1f1011838bd8f32d880bd3408349a495bb83701455318c6b287ffR15) [[2]](diffhunk://#diff-eab3a534ec46dc4d6fe7bd6ca1d2408171831f0a71cef83b5145d15743569b4eR100) [[3]](diffhunk://#diff-eab3a534ec46dc4d6fe7bd6ca1d2408171831f0a71cef83b5145d15743569b4eR139)
  - Ensured the provider selection logic returns `KatanaProvider` for Monad Mainnet, matching Katana's behavior.

**Helper Utilities Updates**

* Updated helper modules to recognize Monad Mainnet:
  - Added network and token mappings in `CoinGeckoHelper` and `EtherscanHelper` for Monad Mainnet. [[1]](diffhunk://#diff-c162fcfbe4117f15ceca6f810a868febbfe2aef0431a5ddf32911b19818ae924R57) [[2]](diffhunk://#diff-c162fcfbe4117f15ceca6f810a868febbfe2aef0431a5ddf32911b19818ae924R74) [[3]](diffhunk://#diff-330486014216f5881e0a5dd19651e3ca9a0d44836e0e1778b809e9ad49b0330eR25)

**Testing Enhancements**

* Expanded unit tests to cover Monad Mainnet in provider mapping, chain ID resolution, and provider selection logic. [[1]](diffhunk://#diff-4317fc0ab7da457d400df72b305a228a99e10c34b2278085d5c5d3e6f570dfa4R34) [[2]](diffhunk://#diff-4317fc0ab7da457d400df72b305a228a99e10c34b2278085d5c5d3e6f570dfa4R61) [[3]](diffhunk://#diff-4317fc0ab7da457d400df72b305a228a99e10c34b2278085d5c5d3e6f570dfa4R87-R88) [[4]](diffhunk://#diff-7afcfcd48a30bca26eb23ef0dbe124cf35256a997315252a40ceef2ce99c0da1R46-R50) [[5]](diffhunk://#diff-43ebf3049201e7e2807ab4fb35d89b8dd1154f13c14cf343a04cb350f6bcab5eR149)

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
