### PR TITLE
chore(APP-818): harden Slack notify error log against log injection

### DIFF
--- a/.github/workflows/scripts/slackNotify.js
+++ b/.github/workflows/scripts/slackNotify.js
@@ -88,8 +88,9 @@ const req = https.request(
 )
 
 req.on('error', e => {
-  // Strip line breaks before logging to prevent log injection (CodeQL js/log-injection)
-  const message = (e.message || '').replace(/\n|\r/g, '')
+  // encodeURIComponent neutralizes CR/LF (and other control chars) so an error
+  // message cannot forge log entries — recognized log-injection sanitizer (CodeQL js/log-injection)
+  const message = encodeURIComponent(e.message || '')
   // biome-ignore lint/suspicious/noConsole: CLI script
   console.error(`Request error: ${message}`)
   process.exit(1)


### PR DESCRIPTION
Part of [APP-818](https://linear.app/aragon/issue/APP-818) (Supply Chain). Clean branch off current `development`.

The rest of the APP-818 backend work (yarn→pnpm migration, dependency refresh, Node 24.16, ws override, audit/code-scanning fixes, SHA-pinned actions) is **already in `development`**, so the only remaining delta is this one code-scanning fix:

- `slackNotify.js`: use `encodeURIComponent` on the request error message — a CodeQL-recognized `js/log-injection` sanitizer — resolving the last open code-scanning alert.

Supersedes the now-stale #1399 (its history dragged in already-merged commits + rebase conflicts). #1399 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)