### PR TITLE
perf(db): add compound indexes covering proposal and vote list sort paths

### DIFF
--- a/src/models/schema/proposal.ts
+++ b/src/models/schema/proposal.ts
@@ -241,6 +241,8 @@ class TxInfo {
 @index({ daoAddress: 1, network: 1, blockTimestamp: -1 })
 @index({ pluginAddress: 1, network: 1, blockTimestamp: -1 })
 @index({ incrementalId: -1, id: -1 })
+@index({ daoAddress: 1, network: 1, incrementalId: -1, id: -1 })
+@index({ pluginAddress: 1, network: 1, incrementalId: -1, id: -1 })
 export default class Proposal extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string

--- a/src/models/schema/vote.ts
+++ b/src/models/schema/vote.ts
@@ -50,6 +50,8 @@ export class VoteCleared {
 @index({ network: 1, transactionHash: 1 })
 @index({ 'voteCleared.status': 1, 'voteCleared.transactionHash': 1, 'voteCleared.blockNumber': 1 })
 @index({ daoAddress: 1 })
+@index({ network: 1, pluginAddress: 1, proposalIndex: 1, blockNumber: -1, id: -1 })
+@index({ daoAddress: 1, blockNumber: -1, id: -1 })
 export default class Vote extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string


### PR DESCRIPTION
## 📝 Summary

This pull request adds new compound indexes to the `Proposal` and `Vote` models to improve query performance for common access patterns involving DAOs, plugins, and network-related fields.

**Database indexing improvements:**

* Added compound indexes to the `Proposal` model for efficient querying by `daoAddress`, `network`, `incrementalId`, and `id`, as well as by `pluginAddress`, `network`, `incrementalId`, and `id`.
* Added compound indexes to the `Vote` model for efficient querying by `network`, `pluginAddress`, `proposalIndex`, `blockNumber`, and `id`, as well as by `daoAddress`, `blockNumber`, and `id`.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
