### PR TITLE
chore(deps): bump github actions pins and mongodb-memory-server to 11.2.0

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -20,7 +20,7 @@ runs:
       run: corepack enable
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"

--- a/.github/workflows/api-monitor.yml
+++ b/.github/workflows/api-monitor.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Load Slack secrets
         id: slack-secrets
         if: needs.validate.outputs.environment == 'staging' || needs.validate.outputs.environment == 'production'
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 #v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
         with:
           export-env: false
         env:
@@ -145,7 +145,7 @@ jobs:
       # Step 3: Load server connection secrets
       - name: Load server connection secrets
         id: server-secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 #v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
         with:
           export-env: false
         env:
@@ -155,7 +155,7 @@ jobs:
 
       # Step 4: Checkout source code
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate.outputs.branch }}
           fetch-depth: 0  # Full history for better debugging
@@ -185,7 +185,7 @@ jobs:
       # Step 7: Generate changelog for staging deploys
       - name: Setup Node.js
         if: needs.validate.outputs.environment == 'staging'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -539,7 +539,7 @@ jobs:
 
     steps:
       - name: Checkout for composite actions
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
@@ -568,7 +568,7 @@ jobs:
       - name: Load Slack secrets
         id: slack-secrets
         if: needs.deploy.outputs.deploy-thread-ts != ''
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 #v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [meta, deploy-prod]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
@@ -88,7 +88,7 @@ jobs:
       - name: Load Slack secrets
         id: secrets
         if: needs.meta.outputs.thread-ts != ''
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/build-container-and-sca.yaml
+++ b/.github/workflows/build-container-and-sca.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -87,7 +87,7 @@ jobs:
           outputs: type=docker,dest=docker-oci-tar-${{ steps.myvars.outputs.CONTAINER_TAG }}
 
       - name: Upload Container Img Tarball as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: docker-img-${{ steps.myvars.outputs.CONTAINER_TAG }}
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Vuln scan in Repo (html)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -156,14 +156,14 @@ jobs:
           trivy sonarqube trivy-results-repo-${{ needs.build.outputs.GIT_HASH_SHORT }}.json --filePath=Dockerfile > trivy-results-repo-${{ needs.build.outputs.GIT_HASH_SHORT }}.sonarqube.json
 
       - name: Upload Repo scan results as Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: trivy-reports-repo-${{ needs.build.outputs.DATE_IN_SECS }}
           path: trivy-results-repo-${{ needs.build.outputs.GIT_HASH_SHORT }}.*
 
       - name: Load Repo scan results to Github (junit)
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         id: trivy-results-junit
         if: always()
         with:
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download Container Img Tarball as Artifact
         uses: actions/download-artifact@v4
@@ -244,14 +244,14 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Docker scan results as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: trivy-reports-docker-${{ needs.build.outputs.DATE_IN_SECS }}
           path: trivy-results-docker-${{ needs.build.outputs.GIT_HASH_SHORT }}.*
 
       - name: Load Docker scan results to Github (junit)
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         id: trivy-results-junit
         if: always()
         with:
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -286,7 +286,7 @@ jobs:
           path: _tmp/
 
       - name: Delete uploaded Docker Tarball from Github Artifact
-        uses: geekyeggo/delete-artifact@65041433121f7239077fa20be14c0690f70569de # v4.1.0
+        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: docker-img-*
           failOnError: false ## 'false' avoids stop execution and errors are logged

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -61,14 +61,14 @@ jobs:
     outputs:
       ts: ${{ steps.gate.outputs.ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
             .github/workflows/scripts
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -151,7 +151,7 @@ jobs:
 
       - name: Load server connection secrets
         id: server-secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -160,7 +160,7 @@ jobs:
           SERVER_URL: ${{ steps.configure.outputs.server_url }}
 
       - name: Checkout source at ref
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -274,14 +274,14 @@ jobs:
     if: always() && (inputs.environment == 'staging' || inputs.environment == 'production')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
             .github/workflows/scripts
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/hotfix-start.yml
+++ b/.github/workflows/hotfix-start.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -65,7 +65,7 @@ jobs:
           SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
 
       - name: Checkout base (TARGET_BRANCH)
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
           # Hotfix branches from the branch it targets (TARGET_BRANCH = main).

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 #v3.0.0

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/release-cancel.yml
+++ b/.github/workflows/release-cancel.yml
@@ -54,14 +54,14 @@ jobs:
        startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
             .github/workflows/scripts
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -49,7 +49,7 @@ jobs:
           SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
 
       - name: Checkout merged SHA
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0

--- a/.github/workflows/release-hotfix-cherrypick.yml
+++ b/.github/workflows/release-hotfix-cherrypick.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Checkout release branch
         if: steps.rel.outputs.branch != ''
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.rel.outputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,7 +39,7 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       thread-ts: ${{ steps.ts.outputs.ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
@@ -64,7 +64,7 @@ jobs:
     needs: meta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup-pnpm
@@ -92,7 +92,7 @@ jobs:
     needs: [meta, deploy-staging]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
@@ -106,7 +106,7 @@ jobs:
       - name: Load Slack secrets
         id: secrets
         if: needs.meta.outputs.thread-ts != ''
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:
@@ -51,7 +51,7 @@ jobs:
           LINEAR_API_TOKEN: op://kv_backend2_infra/LINEAR_API_TOKEN/credential
 
       - name: Checkout base
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
           ref: ${{ inputs.base_commit || github.ref_name }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -32,7 +32,7 @@ jobs:
       # leading `v` itself, so passing the raw tag would render as `vv1.4.0`).
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Verify tag exists
@@ -69,13 +69,13 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/actions
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/unit-dep.yml
+++ b/.github/workflows/unit-dep.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set variables
         id: set-variables
@@ -25,7 +25,7 @@ jobs:
 
       - name: Load secrets
         id: op-server-secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 #v4.0.0
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
         with:
           export-env: false
         env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install OpenSSL 1.1 and create symlink for libcrypto.so.1.1
         run: |
           sudo apt-get update

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "chai-as-promised": "^8.0.2",
     "husky": "^9.1.7",
     "mocha": "^11.7.6",
-    "mongodb-memory-server": "11.1.0",
+    "mongodb-memory-server": "11.2.0",
     "nyc": "^18.0.0",
     "proxyquire": "^2.1.3",
     "semantic-release": "^25.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: ^11.7.6
         version: 11.7.6
       mongodb-memory-server:
-        specifier: 11.1.0
-        version: 11.1.0(supports-color@8.1.1)
+        specifier: 11.2.0
+        version: 11.2.0
       nyc:
         specifier: ^18.0.0
         version: 18.0.0(supports-color@8.1.1)
@@ -1196,9 +1196,6 @@ packages:
   bson@7.2.0:
     resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
     engines: {node: '>=20.19.0'}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2448,12 +2445,12 @@ packages:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
 
-  mongodb-memory-server-core@11.1.0:
-    resolution: {integrity: sha512-GwpnJVIiUyXdi5BoTsExrvLupSt3sJzCSX5P6fxlr0dCrJkhumiq8SQIqtTBqTu2mMpFMCHdjSS0QMUvFMpbWw==}
+  mongodb-memory-server-core@11.2.0:
+    resolution: {integrity: sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==}
     engines: {node: '>=20.19.0'}
 
-  mongodb-memory-server@11.1.0:
-    resolution: {integrity: sha512-x9psV1KXRgG5t14AmsrfcWCqlNXvPOzcyroMSeRU5vkAm8jxEF5WiLGdGCONLOgeCNjRnpg6igyDum/eTwiooA==}
+  mongodb-memory-server@11.2.0:
+    resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
     engines: {node: '>=20.19.0'}
 
   mongodb@7.2.0:
@@ -3609,8 +3606,8 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@3.3.0:
-    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yn@3.1.1:
@@ -3662,7 +3659,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -3693,7 +3690,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3703,7 +3700,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3728,7 +3725,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4588,7 +4585,7 @@ snapshots:
 
   axios@1.17.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -4679,8 +4676,6 @@ snapshots:
       base-x: 3.0.11
 
   bson@7.2.0: {}
-
-  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -5216,7 +5211,7 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -5425,7 +5420,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -5936,20 +5931,20 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@11.1.0(supports-color@8.1.1):
+  mongodb-memory-server-core@11.2.0:
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       find-cache-dir: 3.3.2
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
       mongodb: 7.2.0
-      new-find-package-json: 2.0.0(supports-color@8.1.1)
+      new-find-package-json: 2.0.0
       semver: 7.8.3
       tar-stream: 3.2.0
       tslib: 2.8.1
-      yauzl: 3.3.0
+      yauzl: 3.4.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5963,9 +5958,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@11.1.0(supports-color@8.1.1):
+  mongodb-memory-server@11.2.0:
     dependencies:
-      mongodb-memory-server-core: 11.1.0(supports-color@8.1.1)
+      mongodb-memory-server-core: 11.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -6069,7 +6064,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  new-find-package-json@2.0.0(supports-color@8.1.1):
+  new-find-package-json@2.0.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -7112,9 +7107,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yauzl@3.3.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
       pend: 1.2.0
 
   yn@3.1.1: {}


### PR DESCRIPTION
## 📝 Summary

This pull request updates several GitHub Actions workflows to use the latest major versions of key third-party actions, improving security, maintainability, and compatibility. The primary changes are version bumps for `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, and `1password/load-secrets-action`, as well as a few other related actions.

**Key updates by theme:**

**1. GitHub Actions version upgrades:**
- Updated all usages of `actions/checkout` to version `v6` (from various previous versions like `v5` and `v6.0.2`) across all workflow files for consistency and to leverage the latest features and fixes. [[1]](diffhunk://#diff-e62e3eb871a0788c92bc4806a670516589a1097a4067017a3d4db641fc463caeL34-R34) [[2]](diffhunk://#diff-3fe6d1d392eba6f6dd57180dc95b9e76823faedd6148e9521e9fbeedfeb22036L158-R158) [[3]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L31-R31) [[4]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L107-R107) [[5]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L190-R190) [[6]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L277-R277) [[7]](diffhunk://#diff-2bd049b08a2d7b76216d7210c94d398127459e19f795b63aae3e96c5ab8ec6a3L77-R77) [[8]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L64-R71) [[9]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L163-R163) [[10]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L277-R284) [[11]](diffhunk://#diff-cb72157178deb161661596bd5f2d8def1c17c66d08bff19294c10614ef9db9f3L68-R68) [[12]](diffhunk://#diff-65ae1168eecd2c82b28b52c8a2c70866716e326bfa781144b33f0d74909103d9L20-R20) [[13]](diffhunk://#diff-2c9f02ec60bfdb92fc84266400bd47d3a7a468e16bf07ca091dc3a16110ad19bL57-R64) [[14]](diffhunk://#diff-803e3233d59a31b01bed9aa027a3b722ac7f2f60bfdf5e2f8216a3f5aacf6557L52-R52) [[15]](diffhunk://#diff-d2a65f937bb09c3dede0bdc9103f5459bd09d2e2235cb2860f2ca66d43901d45L62-R62) [[16]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L42-R42) [[17]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L67-R67) [[18]](diffhunk://#diff-6d2776058621d57e67ee850e7db85691f8747f8bfa43021c3eb0663e78c8f2e8L95-R95)
- Updated all usages of `actions/setup-node` to version `v6` (from `v5`) and updated the custom `setup-pnpm` action to use `setup-node@v6`. [[1]](diffhunk://#diff-99a2d4a826671774d44928d766d783f741b914b5f3024a9279929939e89901bcL23-R23) [[2]](diffhunk://#diff-3fe6d1d392eba6f6dd57180dc95b9e76823faedd6148e9521e9fbeedfeb22036L188-R188)

**2. Secrets management improvements:**
- Upgraded `1password/load-secrets-action` from `v4.0.0` to `v4.0.1` in all workflows, ensuring the latest security patches and features are applied. [[1]](diffhunk://#diff-3fe6d1d392eba6f6dd57180dc95b9e76823faedd6148e9521e9fbeedfeb22036L83-R83) [[2]](diffhunk://#diff-3fe6d1d392eba6f6dd57180dc95b9e76823faedd6148e9521e9fbeedfeb22036L148-R148) [[3]](diffhunk://#diff-3fe6d1d392eba6f6dd57180dc95b9e76823faedd6148e9521e9fbeedfeb22036L571-R571) [[4]](diffhunk://#diff-2bd049b08a2d7b76216d7210c94d398127459e19f795b63aae3e96c5ab8ec6a3L91-R91) [[5]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L64-R71) [[6]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L154-R154) [[7]](diffhunk://#diff-9cf7c2a0c4f80876dec2934f8b0daeb9e9d0abd5bfa7cb1cf98046f943502a94L277-R284) [[8]](diffhunk://#diff-cb72157178deb161661596bd5f2d8def1c17c66d08bff19294c10614ef9db9f3L56-R56) [[9]](diffhunk://#diff-723cf31106ae8133bdebfe12cccd01cc805f52a9818816627744e75c84c71240L35-R35) [[10]](diffhunk://#diff-2c9f02ec60bfdb92fc84266400bd47d3a7a468e16bf07ca091dc3a16110ad19bL57-R64) [[11]](diffhunk://#diff-803e3233d59a31b01bed9aa027a3b722ac7f2f60bfdf5e2f8216a3f5aacf6557L42-R42) [[12]](diffhunk://#diff-d2a65f937bb09c3dede0bdc9103f5459bd09d2e2235cb2860f2ca66d43901d45L38-R38)

**3. Artifact and test result handling:**
- Updated `actions/upload-artifact` from `v4` to `v7` and `EnricoMi/publish-unit-test-result-action` from `v2.23.0` to `v2.24.0` for improved artifact management and test reporting. [[1]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L90-R90) [[2]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L159-R166) [[3]](diffhunk://#diff-7e22b87108c5c317c50a341255d0f3f98d37a41ea1e1ca18b7fe5bc499741a63L247-R254)
- Updated `geekyeggo/delete-artifact` from `v4.1.0` to `v6.0.0` for artifact cleanup.

These updates help keep our CI/CD pipelines secure and up-to-date with the latest best practices.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
