### PR TITLE
fix(ci): write semantic-release dry-run log to RUNNER_TEMP to keep tree clean

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -94,13 +94,15 @@ jobs:
           # so the dry-run computes the next version from this base.
           # NOTE: re-validate this log parse whenever semantic-release is upgraded —
           # the "next release version is X.Y.Z" line format can change across majors.
-          pnpm exec semantic-release --dry-run --branches "$BASE" > sr.log 2>&1 || true
-          VERSION=$(grep -oiE 'next release version is [0-9]+\.[0-9]+\.[0-9]+' sr.log \
+          # Write the dry-run log outside the working tree so it doesn't leave an
+          # untracked file that trips pnpm's clean-tree check in the bump step.
+          pnpm exec semantic-release --dry-run --branches "$BASE" > "$RUNNER_TEMP/sr.log" 2>&1 || true
+          VERSION=$(grep -oiE 'next release version is [0-9]+\.[0-9]+\.[0-9]+' "$RUNNER_TEMP/sr.log" \
             | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
           if [ -z "$VERSION" ]; then
             echo "❌ Could not determine next version from semantic-release dry-run." >&2
             echo "   (No releasable commits, or output format changed.)" >&2
-            tail -n 50 sr.log >&2 || true
+            tail -n 50 "$RUNNER_TEMP/sr.log" >&2 || true
             exit 1
           fi
           # Guard against stale tag lineage: if BASE diverged from the production


### PR DESCRIPTION
## 📝 Summary

This pull request makes a small but important improvement to the release workflow by ensuring that temporary log files generated during the semantic-release dry-run are written outside the working tree. This prevents untracked files from interfering with pnpm's clean-tree checks later in the process.

- Workflow improvement:
  * Updated the semantic-release dry-run step in `.github/workflows/release-start.yml` to write its log to the `$RUNNER_TEMP` directory instead of the working tree, preventing untracked files from affecting subsequent steps.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
