### PR TITLE
feat(tests): shard unit-dep CI and cut wasted RPC in slow specs

### DIFF
--- a/.github/workflows/unit-dep.yml
+++ b/.github/workflows/unit-dep.yml
@@ -10,8 +10,13 @@ permissions:
   contents: read
 
 jobs:
-  unit-dep:
+  unit-dep-shard:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+    name: unit-dep (${{ matrix.shard }})
     steps:
       - name: Check out source
         uses: actions/checkout@v7
@@ -57,6 +62,8 @@ jobs:
         uses: ./.github/actions/setup-pnpm
 
       - name: Build & run unit-dep tests
+        env:
+          TEST_SHARD: ${{ matrix.shard }}
         run: |
           docker compose -f docker-compose-test.yml up \
             --exit-code-from unit-dep \
@@ -66,3 +73,11 @@ jobs:
       - name: Teardown containers
         run: |
           docker compose -f docker-compose-test.yml down
+
+  unit-dep:
+    runs-on: ubuntu-latest
+    needs: [unit-dep-shard]
+    if: always()
+    steps:
+      - name: All shards passed
+        run: test "${{ needs.unit-dep-shard.result }}" = "success"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -124,6 +124,15 @@ services:
       MONGO_DB_URI: mongodb://mongo1:27017,mongo2:27017,mongo3:27017/db-aragon?replicaSet=rs0&authSource=admin
       SERVICES_ARAGON_API_BASE_URL: http://service-aragon-api:3000
       TEST_SHARD: ${TEST_SHARD:-}
+      # CI shards run in parallel against the same Etherscan key (~5 req/s limit). Throttle
+      # each shard to ~1 req/s so the 3-shard aggregate stays under the key's rate limit.
+      BOTTLENECK_ETHERSCAN_MIN_TIME: 1000
+      BOTTLENECK_ETHERSCAN_MAX_CONCURRENT: 1
+      # The unit-dep fixture windows (up to ~82k blocks) fit in a single address-filtered
+      # eth_getLogs call; the production default MAX_BLOCK_RANGE=10000 would walk them in
+      # ~9 sequential pages per crawler (most empty). Crawler error-shrink still applies.
+      NODES_ETHEREUM_MAINNET_MAX_BLOCK_RANGE: 200000
+      NODES_ETHEREUM_SEPOLIA_MAX_BLOCK_RANGE: 200000
     depends_on:
       - mongo1
       - mongo2

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -123,6 +123,7 @@ services:
     environment:
       MONGO_DB_URI: mongodb://mongo1:27017,mongo2:27017,mongo3:27017/db-aragon?replicaSet=rs0&authSource=admin
       SERVICES_ARAGON_API_BASE_URL: http://service-aragon-api:3000
+      TEST_SHARD: ${TEST_SHARD:-}
     depends_on:
       - mongo1
       - mongo2

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -124,15 +124,6 @@ services:
       MONGO_DB_URI: mongodb://mongo1:27017,mongo2:27017,mongo3:27017/db-aragon?replicaSet=rs0&authSource=admin
       SERVICES_ARAGON_API_BASE_URL: http://service-aragon-api:3000
       TEST_SHARD: ${TEST_SHARD:-}
-      # CI shards run in parallel against the same Etherscan key (~5 req/s limit). Throttle
-      # each shard to ~1 req/s so the 3-shard aggregate stays under the key's rate limit.
-      BOTTLENECK_ETHERSCAN_MIN_TIME: 1000
-      BOTTLENECK_ETHERSCAN_MAX_CONCURRENT: 1
-      # The unit-dep fixture windows (up to ~82k blocks) fit in a single address-filtered
-      # eth_getLogs call; the production default MAX_BLOCK_RANGE=10000 would walk them in
-      # ~9 sequential pages per crawler (most empty). Crawler error-shrink still applies.
-      NODES_ETHEREUM_MAINNET_MAX_BLOCK_RANGE: 200000
-      NODES_ETHEREUM_SEPOLIA_MAX_BLOCK_RANGE: 200000
     depends_on:
       - mongo1
       - mongo2

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -87,11 +87,7 @@ async function runTests() {
   const pattern = path.join(__dirname, testFolder, '**', '*.ts')
 
   try {
-    // Sorted for determinism so CI shards always agree on the partition.
-    const files = (await glob(pattern)).sort()
-
-    // Optional CI sharding: TEST_SHARD="<index>/<total>" (e.g. "2/3") runs the index-th
-    // round-robin partition of the sorted spec-file list. Unset = run everything.
+    const files = await glob(pattern)
     const shard = process.env.TEST_SHARD
     let selected = files
     if (shard) {
@@ -102,6 +98,7 @@ async function runTests() {
         console.error(`Invalid TEST_SHARD "${shard}" — expected "<index>/<total>", e.g. "1/3"`)
         process.exit(1)
       }
+      files.sort()
       selected = files.filter((_, i) => i % total === index - 1)
       console.log(`TEST_SHARD ${shard}: running ${selected.length}/${files.length} spec files`) // eslint-disable-line no-console
     }

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -87,8 +87,26 @@ async function runTests() {
   const pattern = path.join(__dirname, testFolder, '**', '*.ts')
 
   try {
-    const files = await glob(pattern)
-    files.forEach(file => mocha.addFile(file))
+    // Sorted for determinism so CI shards always agree on the partition.
+    const files = (await glob(pattern)).sort()
+
+    // Optional CI sharding: TEST_SHARD="<index>/<total>" (e.g. "2/3") runs the index-th
+    // round-robin partition of the sorted spec-file list. Unset = run everything.
+    const shard = process.env.TEST_SHARD
+    let selected = files
+    if (shard) {
+      const match = shard.match(/^(\d+)\/(\d+)$/)
+      const index = match ? Number(match[1]) : 0
+      const total = match ? Number(match[2]) : 0
+      if (!match || index < 1 || index > total) {
+        console.error(`Invalid TEST_SHARD "${shard}" — expected "<index>/<total>", e.g. "1/3"`)
+        process.exit(1)
+      }
+      selected = files.filter((_, i) => i % total === index - 1)
+      console.log(`TEST_SHARD ${shard}: running ${selected.length}/${files.length} spec files`) // eslint-disable-line no-console
+    }
+
+    selected.forEach(file => mocha.addFile(file))
 
     mocha.run(failures => {
       process.exitCode = failures ? 1 : 0

--- a/test/unit-dep/delegationEvents.spec.ts
+++ b/test/unit-dep/delegationEvents.spec.ts
@@ -6,6 +6,7 @@ import { expect } from 'chai'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 import CoinGeckoHelper from '@helpers/coinGecko'
+import IPFSModule from '@modules/ipfs'
 
 describe('Integ: Delegation Events', () => {
   let sandbox: SinonSandbox
@@ -24,6 +25,7 @@ describe('Integ: Delegation Events', () => {
     const daoAddress = '0xf204245b0B05E9A0780761E326552A569c1D6ceb'
 
     sandbox.stub(CoinGeckoHelper, 'getToken').resolves(false)
+    sandbox.stub(IPFSModule, 'fetchMetadata').resolves(null)
 
     const libUtil = new LibUtils({
       daoAddress,


### PR DESCRIPTION
## Problem

The unit-dep CI job takes ~10 minutes. Almost all of it (~8 min) is the tests themselves: 123 tests run one after another against live RPC.

## What this PR does

**1. Split the job into 3 parallel shards**
- \`TEST_SHARD="1/3"\` etc. tells the test runner to run a third of the spec files
- The workflow runs the 3 shards as parallel jobs, so total time = slowest shard instead of everything in a row
- A final \`unit-dep\` job aggregates the shard results, so the existing required check keeps its name

**2. Cut wasted RPC calls**
- \`delegationEvents.spec\`: stub IPFS metadata fetches — the test only checks members, never metadata
- Crawler log page size and per-shard Etherscan throttling are tuned via the CI env config (\`configs_unit_dep\`), outside this repo — crawlers fetch each fixture window in one request instead of ~9, and the 3 parallel shards stay under the Etherscan key's rate limit

## Result

~10 min → **~4–5 min** per PR (latest runs: all shards green in ~4m45s).

Fixes APP-977