### PR TITLE
fix(runner): skip PrometheusStore start when shutdown begins during service start

### DIFF
--- a/src/modules/runner.ts
+++ b/src/modules/runner.ts
@@ -76,6 +76,8 @@ async function runApp(app: IService) {
     // Start the service
     await app.start()
 
+    if (stopping) return
+
     if (app.name) {
       prometheusStore = PrometheusStore.getInstance(app.name)
       await prometheusStore.start()

--- a/test/unit/modules/runner.spec.ts
+++ b/test/unit/modules/runner.spec.ts
@@ -1,4 +1,3 @@
-import { TooBusyMonitor } from '@helpers/monitoring'
 import utils from '@helpers/utils'
 import Connections from '@modules/connections'
 import { PrometheusStore } from '@modules/prometheusStore'
@@ -133,7 +132,6 @@ describe('Module: runner - shutdown during start', () => {
   })
 
   it('does not start PrometheusStore when the app triggers stopApp during start()', async function () {
-    sandbox.stub(TooBusyMonitor.prototype, 'init')
     sandbox.stub(Connections, 'open').resolves()
     sandbox.stub(Connections, 'close').resolves()
     const exitStub = sandbox.stub(process, 'exit')

--- a/test/unit/modules/runner.spec.ts
+++ b/test/unit/modules/runner.spec.ts
@@ -1,7 +1,8 @@
+import { TooBusyMonitor } from '@helpers/monitoring'
 import utils from '@helpers/utils'
 import Connections from '@modules/connections'
 import { PrometheusStore } from '@modules/prometheusStore'
-import Runner from '@modules/runner'
+import Runner, { stopApp } from '@modules/runner'
 import { EnumConnection, EnumServiceName } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
@@ -106,5 +107,52 @@ describe.skip('Module: runner', () => {
     } catch (err: any) {
       expect(err.message).to.equal('Expected runApps to throw')
     }
+  })
+})
+
+describe('Module: runner - shutdown during start', () => {
+  const WATCHED_EVENTS = ['exit', 'SIGINT', 'SIGTERM', 'unhandledRejection', 'uncaughtException'] as const
+  let sandbox: SinonSandbox
+  let clock: sinon.SinonFakeTimers
+  let listenersBefore: Map<string, Function[]>
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    clock = sandbox.useFakeTimers()
+    listenersBefore = new Map(WATCHED_EVENTS.map(event => [event, process.listeners(event as any)]))
+  })
+
+  afterEach(() => {
+    for (const event of WATCHED_EVENTS) {
+      const before = listenersBefore.get(event)!
+      for (const listener of process.listeners(event as any)) {
+        if (!before.includes(listener)) process.removeListener(event as any, listener as any)
+      }
+    }
+    sandbox.restore()
+  })
+
+  it('does not start PrometheusStore when the app triggers stopApp during start()', async function () {
+    sandbox.stub(TooBusyMonitor.prototype, 'init')
+    sandbox.stub(Connections, 'open').resolves()
+    sandbox.stub(Connections, 'close').resolves()
+    const exitStub = sandbox.stub(process, 'exit')
+    const getInstanceStub = sandbox.stub(PrometheusStore, 'getInstance')
+
+    const appMock = {
+      name: EnumServiceName.ARAGON_MIGRATION,
+      stop: sandbox.stub().resolves(),
+      NEED_CONNECTIONS: [],
+      start: sandbox.stub().callsFake(async () => {
+        void stopApp(appMock as any, 0, 1000)
+      }),
+    }
+
+    Runner(appMock as any)
+    await clock.tickAsync(10)
+
+    expect(getInstanceStub.called).to.be.false
+    expect(appMock.stop.calledOnce).to.be.true
+    expect(exitStub.called).to.be.true
   })
 })


### PR DESCRIPTION
## Summary

After every production release, two false alerts fire:

- **Server Crash Alert Prod** (SEVERE) — trips on the graceful-shutdown `Exiting...` info log.
- **errors_production** (HIGH) — trips on a `MongoNotConnectedError` from the migration runner.

The migration runner's `onComplete` callback fires `stopApp()` without being awaited, so while the process is tearing down (closing Mongo), `runApp()` continues and starts `PrometheusStore`, whose first metrics write then fails against the closed connection.

## Changes

- `src/modules/runner.ts` — after `await app.start()`, return early if `stopping` is already set, so a service that initiated shutdown during `start()` never boots the metrics collector or logs a misleading "Service started successfully".
- `test/unit/modules/runner.spec.ts` — regression test reproducing the race (mock app calls `stopApp` inside `start()`, mirroring `runners/migration.ts`). Uses fake timers and cleans up process listeners so it can run un-skipped, unlike the legacy runner suite. Verified the test fails without the guard.

Fixes APP-980