### PR TITLE
feat(APP-1002): implement incremental caches for DAO addresses and token eligibility

### DIFF
--- a/src/models/schema/dao.ts
+++ b/src/models/schema/dao.ts
@@ -78,6 +78,7 @@ class Metrics {
 @index({ address: 1, subdomain: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, subdomain: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, transactionHash: 1, isActive: 1, isHidden: 1 })
+@index({ network: 1, createdAt: 1 })
 @index({ address: 1, name: 1, isActive: 1, isHidden: 1 })
 @index({ address: 1, ens: 1, isActive: 1, isHidden: 1 })
 @index({ network: 1, description: 1, isActive: 1, isHidden: 1 })

--- a/src/models/schema/plugin.ts
+++ b/src/models/schema/plugin.ts
@@ -104,6 +104,7 @@ class Link {
 @index({ conditionAddress: 1, network: 1, status: 1 })
 @index({ network: 1, 'votingEscrow.exitQueueAddress': 1 })
 @index({ daoAddress: 1, network: 1, status: 1, isPolicy: 1, blockNumber: -1 })
+@index({ network: 1, updatedAt: 1 })
 export default class Plugin extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string

--- a/src/models/schema/token.ts
+++ b/src/models/schema/token.ts
@@ -37,6 +37,7 @@ const customName = ICollectionNames.Token
 @index({ address: 1, ignoreTransfer: 1, network: 1 })
 @index({ skipFetchRate: 1, isSpam: 1, network: 1, nextFetchRateAt: 1, lastUpdatedAt: 1 })
 @index({ spamSource: 1 })
+@index({ network: 1, updatedAt: 1 })
 export default class Token extends Model {
   @prop({ type: () => String, required: true, unique: true })
   public id!: string

--- a/src/modules/daoAddressCache.ts
+++ b/src/modules/daoAddressCache.ts
@@ -1,0 +1,82 @@
+import { Models } from '@dbModels'
+import type { INetworkCacheState, NetworksEnum } from '@types'
+
+/**
+ * Re-read window when advancing the cursor, to absorb clock skew between
+ * writer processes and same-millisecond inserts. Deltas re-fetch this much
+ * history on every refresh; Map inserts are idempotent so overlap is free.
+ */
+const CURSOR_OVERLAP_MS = 60 * 1000
+
+/**
+ * Incremental per-network cache of DAO addresses.
+ *
+ * First refresh loads the full address list for the network; every later
+ * refresh only fetches DAOs created since the cursor (an indexed range scan
+ * that is almost always empty). This keeps per-tick freshness identical to
+ * querying Mongo directly while avoiding a distinct + large $in per tick and
+ * the per-log checksum computation: membership is tested on the lowercase
+ * form and the stored checksummed string is returned verbatim.
+ *
+ * DAO documents are never hard-deleted, so the cache is add-only.
+ */
+class DaoAddressCache {
+  private readonly states = new Map<NetworksEnum, INetworkCacheState>()
+
+  private getState(network: NetworksEnum): INetworkCacheState {
+    let state = this.states.get(network)
+    if (!state) {
+      state = { byLower: new Map(), cursor: null, refreshing: null }
+      this.states.set(network, state)
+    }
+    return state
+  }
+
+  async refresh(network: NetworksEnum): Promise<void> {
+    const state = this.getState(network)
+    if (state.refreshing) return state.refreshing
+
+    state.refreshing = this.doRefresh(network, state).finally(() => {
+      state.refreshing = null
+    })
+    return state.refreshing
+  }
+
+  private async doRefresh(network: NetworksEnum, state: INetworkCacheState): Promise<void> {
+    const query: Record<string, any> = { network }
+
+    if (state.cursor) {
+      query.createdAt = { $gte: new Date(state.cursor.getTime() - CURSOR_OVERLAP_MS) }
+    }
+
+    const queryStartedAt = new Date()
+    const daos = await Models.Dao.find(query, { address: 1, createdAt: 1 }).lean()
+
+    /**
+     * Advance the cursor to at least queryStartedAt (not just the newest
+     * document timestamp): with the fixed overlap this keeps the delta window
+     * bounded instead of permanently re-fetching the tail on quiet networks,
+     * while anything the query raced with stays inside the next window.
+     */
+    let cursor = state.cursor && state.cursor > queryStartedAt ? state.cursor : queryStartedAt
+    for (const dao of daos as unknown as Array<{ address: string; createdAt?: Date }>) {
+      state.byLower.set(dao.address.toLowerCase(), dao.address)
+      if (dao.createdAt && dao.createdAt > cursor) cursor = dao.createdAt
+    }
+    state.cursor = cursor
+  }
+
+  /**
+   * Returns the checksummed DAO address as stored in the DB, or undefined if
+   * the address is not a known DAO on this network. Accepts any casing.
+   */
+  getChecksummed(network: NetworksEnum, address: string): string | undefined {
+    return this.getState(network).byLower.get(address.toLowerCase())
+  }
+
+  clear(): void {
+    this.states.clear()
+  }
+}
+
+export default new DaoAddressCache()

--- a/src/modules/poolingCrawler.ts
+++ b/src/modules/poolingCrawler.ts
@@ -1,14 +1,15 @@
 import { DAO } from '@artifacts/dao'
 import { GovernanceERC20 } from '@artifacts/GovernanceERC20'
 import config from '@config'
-import { Models } from '@dbModels'
 import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
 import { GovernanceVeBatchHandler, VE_TOPICS } from '@handlers/governanceVeBatchHandler'
 import utils from '@helpers/utils'
 import configIndexer from '@indexer/configIndexer'
 import logger from '@logger'
 import { BlockchainLogCrawler } from '@modules/crawlers'
-import { IPluginInterfaceType, IPluginStatus, type LogServicePattern, NetworksEnum } from '@types'
+import DaoAddressCache from '@modules/daoAddressCache'
+import TokenEligibilityCache from '@modules/tokenEligibilityCache'
+import { type LogServicePattern, NetworksEnum } from '@types'
 import { ethers, Interface, type Log } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'module:PoolingFilter' })
@@ -70,11 +71,6 @@ const PoolingCrawler = {
     }
   },
 
-  _getUniqueArrayItems: (array: any[]) => {
-    const uniqueArray = new Set(array)
-    return Array.from(uniqueArray)
-  },
-
   async filterLogs(logs: Log[], network: NetworksEnum, includeTransfer = false) {
     try {
       if (includeTransfer) {
@@ -107,33 +103,27 @@ const PoolingCrawler = {
       }
     }
 
-    const transferLogCache = new Map<Log, string | null>()
+    if (transferLogs.length !== 0 || nativeTokenDepositedLogs.length !== 0) {
+      await DaoAddressCache.refresh(network)
+    }
 
-    const getDecodedTransferAddresses = (logs: Log[]): string[] =>
-      logs
-        .map(log => {
-          if (transferLogCache.has(log)) return transferLogCache.get(log)
-          const address = PoolingCrawler._getReceiverAddress(log)
-          if (!address) return false
-          transferLogCache.set(log, address)
-          return transferLogCache.get(log)
-        })
-        .filter(Boolean) as string[]
+    /**
+     * Membership is tested on the raw lowercase hex (no per-log checksum);
+     * the set holds the checksummed addresses exactly as stored in the DB.
+     */
+    const daoAddressesSet = new Set<string>()
 
-    const tokenTransferReceiverAddresses = PoolingCrawler._getUniqueArrayItems(
-      getDecodedTransferAddresses(transferLogs),
-    )
+    for (const log of transferLogs) {
+      const receiver = PoolingCrawler._getReceiverAddressRaw(log)
+      if (!receiver) continue
+      const daoAddress = DaoAddressCache.getChecksummed(network, receiver)
+      if (daoAddress) daoAddressesSet.add(daoAddress)
+    }
 
-    const nativeTransferReceiverAddresses = PoolingCrawler._getUniqueArrayItems(
-      nativeTokenDepositedLogs.map(log => ethers.getAddress(log.address)),
-    )
-
-    const daoAddresses = await Models.Dao.distinct('address', {
-      address: { $in: [...tokenTransferReceiverAddresses, ...nativeTransferReceiverAddresses] },
-      network,
-    })
-
-    const daoAddressesSet = new Set(daoAddresses)
+    for (const log of nativeTokenDepositedLogs) {
+      const daoAddress = DaoAddressCache.getChecksummed(network, log.address)
+      if (daoAddress) daoAddressesSet.add(daoAddress)
+    }
 
     if (daoAddressesSet.size !== 0) {
       process.nextTick(async () => {
@@ -150,45 +140,21 @@ const PoolingCrawler = {
   },
 
   async _filterDelegateVotesLogs(logs: Log[], network: NetworksEnum) {
-    const delegateVotesChangedLogs: Log[] = []
-
-    let i = logs.length
-    while (i--) {
-      const log = logs[i]
-      if (log.topics.length === 0) continue
-
-      if (log.topics[0] === delegateVotesChangedTopic) {
-        delegateVotesChangedLogs.push(log)
-      }
+    const hasDelegateVotesChangedLogs = logs.some(
+      log => log.topics.length > 0 && log.topics[0] === delegateVotesChangedTopic,
+    )
+    if (hasDelegateVotesChangedLogs) {
+      await TokenEligibilityCache.refresh(network)
     }
 
-    const delegateVotesChangedTokenAddresses = PoolingCrawler._getUniqueArrayItems(
-      delegateVotesChangedLogs.map(log => ethers.getAddress(log.address)),
-    )
-
-    // Query to find valid token addresses for DelegateVotesChanged
-    const [pluginTokenAddresses, validTokenAddresses] = await Promise.all([
-      Models.Plugin.distinct('tokenAddress', {
-        tokenAddress: { $in: delegateVotesChangedTokenAddresses },
-        status: IPluginStatus.installed,
-        isSupported: true,
-        interfaceType: IPluginInterfaceType.tokenVoting,
-        network,
-      }),
-      Models.Token.distinct('address', {
-        address: { $in: delegateVotesChangedTokenAddresses },
-        ignoreTransfer: { $ne: true },
-        hasDelegate: true, // only tokens that have delegate votes need to be synced
-        network,
-      }),
-    ])
-
-    const tokenAddresses = pluginTokenAddresses.filter(addr => validTokenAddresses.includes(addr))
-    const tokenAddressesSet = new Set(tokenAddresses)
-
+    /**
+     * Eligibility (installed tokenVoting plugin token ∩ syncable delegate
+     * token) is answered by the incremental cache on the raw lowercase hex —
+     * no per-log checksum and no per-tick distinct/$in queries.
+     */
     return logs.filter(log => {
       if (log.topics[0] !== delegateVotesChangedTopic) return true
-      return log.topics[0] === delegateVotesChangedTopic && tokenAddressesSet.has(ethers.getAddress(log.address))
+      return TokenEligibilityCache.getChecksummed(network, log.address) !== undefined
     })
   },
 
@@ -230,6 +196,13 @@ const PoolingCrawler = {
         return ethers.getAddress(`0x${log.topics[2].slice(-40)}`)
       }
     } catch (_error) {}
+    return null
+  },
+
+  _getReceiverAddressRaw: (log: Log) => {
+    if (log.topics.length === 3) {
+      return `0x${log.topics[2].slice(-40)}`
+    }
     return null
   },
 }

--- a/src/modules/tokenEligibilityCache.ts
+++ b/src/modules/tokenEligibilityCache.ts
@@ -1,0 +1,195 @@
+import { Models } from '@dbModels'
+import { IPluginInterfaceType, IPluginStatus, type ITokenEligibilityCacheState, type NetworksEnum } from '@types'
+
+/**
+ * Re-read window when advancing the cursors, to absorb clock skew between
+ * writer processes and same-millisecond updates. Deltas re-fetch this much
+ * history on every refresh; map upserts/removals are idempotent so overlap
+ * is free.
+ */
+const CURSOR_OVERLAP_MS = 60 * 1000
+
+const pluginEligibility = {
+  status: IPluginStatus.installed,
+  isSupported: true,
+  interfaceType: IPluginInterfaceType.tokenVoting,
+}
+
+const tokenEligibility = {
+  ignoreTransfer: { $ne: true },
+  hasDelegate: true, // only tokens that have delegate votes need to be synced
+}
+
+/**
+ * Incremental per-network cache of token addresses whose DelegateVotesChanged
+ * events must be processed.
+ *
+ * Eligibility mirrors the previous per-tick queries: the token must be the
+ * tokenAddress of an installed/supported tokenVoting Plugin AND a Token with
+ * hasDelegate and not ignoreTransfer — the intersection is evaluated at
+ * lookup time from two maps.
+ *
+ * Unlike DAO addresses, Plugin/Token eligibility mutates (status, flags), so
+ * the cursors track `updatedAt` and each changed document is re-verified with
+ * the eligibility filters to be added or REMOVED from its map. Membership is
+ * tested on the lowercase form; the stored checksummed string is returned
+ * verbatim so DB queries and handlers never receive a lowercased address.
+ */
+class TokenEligibilityCache {
+  private readonly states = new Map<NetworksEnum, ITokenEligibilityCacheState>()
+
+  private getState(network: NetworksEnum): ITokenEligibilityCacheState {
+    let state = this.states.get(network)
+    if (!state) {
+      state = {
+        pluginTokensByLower: new Map(),
+        tokensByLower: new Map(),
+        pluginCursor: null,
+        tokenCursor: null,
+        refreshing: null,
+      }
+      this.states.set(network, state)
+    }
+    return state
+  }
+
+  async refresh(network: NetworksEnum): Promise<void> {
+    const state = this.getState(network)
+    if (state.refreshing) return state.refreshing
+
+    state.refreshing = this.doRefresh(network, state).finally(() => {
+      state.refreshing = null
+    })
+    return state.refreshing
+  }
+
+  private async doRefresh(network: NetworksEnum, state: ITokenEligibilityCacheState): Promise<void> {
+    await Promise.all([this.refreshPluginTokens(network, state), this.refreshTokens(network, state)])
+  }
+
+  private async refreshPluginTokens(network: NetworksEnum, state: ITokenEligibilityCacheState): Promise<void> {
+    /**
+     * Snapshot BEFORE the query so the initial cursor can never be newer than
+     * a document the scan raced with (see DaoAddressCache for the rationale).
+     */
+    const queryStartedAt = new Date()
+
+    if (!state.pluginCursor) {
+      const addresses = await Models.Plugin.distinct('tokenAddress', { ...pluginEligibility, network })
+      for (const address of addresses) {
+        if (address) state.pluginTokensByLower.set(address.toLowerCase(), address)
+      }
+      state.pluginCursor = queryStartedAt
+      return
+    }
+
+    const changed = await Models.Plugin.find(
+      { network, updatedAt: { $gte: new Date(state.pluginCursor.getTime() - CURSOR_OVERLAP_MS) } },
+      { tokenAddress: 1, updatedAt: 1 },
+    ).lean()
+
+    /**
+     * Advance the cursor to at least queryStartedAt (not just the newest
+     * document timestamp) so the delta window stays bounded instead of
+     * permanently re-fetching the tail; the overlap keeps races covered.
+     */
+    const changedAddresses = new Set<string>()
+    let cursor = state.pluginCursor > queryStartedAt ? state.pluginCursor : queryStartedAt
+    for (const plugin of changed as unknown as Array<{ tokenAddress?: string; updatedAt?: Date }>) {
+      if (plugin.tokenAddress) changedAddresses.add(plugin.tokenAddress)
+      if (plugin.updatedAt && plugin.updatedAt > cursor) cursor = plugin.updatedAt
+    }
+    state.pluginCursor = cursor
+
+    if (changedAddresses.size === 0) return
+
+    /**
+     * Re-verify each changed tokenAddress against the full eligibility filter:
+     * another still-eligible plugin may share the same token, so removal is
+     * only correct when NO eligible plugin references it anymore.
+     */
+    const eligible = await Models.Plugin.distinct('tokenAddress', {
+      ...pluginEligibility,
+      tokenAddress: { $in: [...changedAddresses] },
+      network,
+    })
+    const eligibleLower = new Set(eligible.map(address => address.toLowerCase()))
+
+    for (const address of changedAddresses) {
+      const lower = address.toLowerCase()
+      if (eligibleLower.has(lower)) {
+        state.pluginTokensByLower.set(lower, address)
+      } else {
+        state.pluginTokensByLower.delete(lower)
+      }
+    }
+  }
+
+  private async refreshTokens(network: NetworksEnum, state: ITokenEligibilityCacheState): Promise<void> {
+    const queryStartedAt = new Date()
+
+    if (!state.tokenCursor) {
+      const addresses = await Models.Token.distinct('address', { ...tokenEligibility, network })
+      for (const address of addresses) {
+        if (address) state.tokensByLower.set(address.toLowerCase(), address)
+      }
+      state.tokenCursor = queryStartedAt
+      return
+    }
+
+    const changed = await Models.Token.find(
+      { network, updatedAt: { $gte: new Date(state.tokenCursor.getTime() - CURSOR_OVERLAP_MS) } },
+      { address: 1, updatedAt: 1 },
+    ).lean()
+
+    /**
+     * Advance the cursor to at least queryStartedAt (not just the newest
+     * document timestamp) so the delta window stays bounded instead of
+     * permanently re-fetching the tail; the overlap keeps races covered.
+     */
+    const changedAddresses = new Set<string>()
+    let cursor = state.tokenCursor > queryStartedAt ? state.tokenCursor : queryStartedAt
+    for (const token of changed as unknown as Array<{ address?: string; updatedAt?: Date }>) {
+      if (token.address) changedAddresses.add(token.address)
+      if (token.updatedAt && token.updatedAt > cursor) cursor = token.updatedAt
+    }
+    state.tokenCursor = cursor
+
+    if (changedAddresses.size === 0) return
+
+    const eligible = await Models.Token.distinct('address', {
+      ...tokenEligibility,
+      address: { $in: [...changedAddresses] },
+      network,
+    })
+    const eligibleLower = new Set(eligible.map(address => address.toLowerCase()))
+
+    for (const address of changedAddresses) {
+      const lower = address.toLowerCase()
+      if (eligibleLower.has(lower)) {
+        state.tokensByLower.set(lower, address)
+      } else {
+        state.tokensByLower.delete(lower)
+      }
+    }
+  }
+
+  /**
+   * Returns the checksummed token address as stored in the DB when the token
+   * is eligible on this network (present in both maps), otherwise undefined.
+   * Accepts any casing.
+   */
+  getChecksummed(network: NetworksEnum, address: string): string | undefined {
+    const state = this.getState(network)
+    const lower = address.toLowerCase()
+    const token = state.tokensByLower.get(lower)
+    if (!token) return undefined
+    return state.pluginTokensByLower.has(lower) ? token : undefined
+  }
+
+  clear(): void {
+    this.states.clear()
+  }
+}
+
+export default new TokenEligibilityCache()

--- a/src/modules/tokenEligibilityCache.ts
+++ b/src/modules/tokenEligibilityCache.ts
@@ -113,12 +113,16 @@ class TokenEligibilityCache {
       tokenAddress: { $in: [...changedAddresses] },
       network,
     })
-    const eligibleLower = new Set(eligible.map(address => address.toLowerCase()))
+    const eligibleByLower = new Map<string, string>()
+    for (const address of eligible) {
+      if (address) eligibleByLower.set(address.toLowerCase(), address)
+    }
 
     for (const address of changedAddresses) {
       const lower = address.toLowerCase()
-      if (eligibleLower.has(lower)) {
-        state.pluginTokensByLower.set(lower, address)
+      const canonical = eligibleByLower.get(lower)
+      if (canonical) {
+        state.pluginTokensByLower.set(lower, canonical)
       } else {
         state.pluginTokensByLower.delete(lower)
       }
@@ -162,12 +166,16 @@ class TokenEligibilityCache {
       address: { $in: [...changedAddresses] },
       network,
     })
-    const eligibleLower = new Set(eligible.map(address => address.toLowerCase()))
+    const eligibleByLower = new Map<string, string>()
+    for (const address of eligible) {
+      if (address) eligibleByLower.set(address.toLowerCase(), address)
+    }
 
     for (const address of changedAddresses) {
       const lower = address.toLowerCase()
-      if (eligibleLower.has(lower)) {
-        state.tokensByLower.set(lower, address)
+      const canonical = eligibleByLower.get(lower)
+      if (canonical) {
+        state.tokensByLower.set(lower, canonical)
       } else {
         state.tokensByLower.delete(lower)
       }

--- a/src/types/crawler.ts
+++ b/src/types/crawler.ts
@@ -190,6 +190,35 @@ export interface IProgressInfo {
   exists: boolean
 }
 
+/**
+ * Per-network state held by the incremental DAO address cache
+ */
+export interface INetworkCacheState {
+  /**
+   * Lowercase address -> checksummed address exactly as stored in the DB.
+   * DB queries and handlers must always receive the checksummed value.
+   */
+  byLower: Map<string, string>
+  cursor: Date | null
+  refreshing: Promise<void> | null
+}
+
+/**
+ * Per-network state held by the incremental token eligibility cache.
+ * A token is eligible when present in BOTH maps (installed tokenVoting
+ * plugin token ∩ syncable delegate token), mirroring the previous
+ * Plugin.distinct/Token.distinct intersection.
+ */
+export interface ITokenEligibilityCacheState {
+  /** Lowercase tokenAddress -> checksummed value of eligible tokenVoting plugins */
+  pluginTokensByLower: Map<string, string>
+  /** Lowercase address -> checksummed value of syncable delegate tokens */
+  tokensByLower: Map<string, string>
+  pluginCursor: Date | null
+  tokenCursor: Date | null
+  refreshing: Promise<void> | null
+}
+
 // ============================================
 // Indexer Configuration Types
 // ============================================

--- a/test/unit/modules/daoAddressCache.spec.ts
+++ b/test/unit/modules/daoAddressCache.spec.ts
@@ -1,0 +1,99 @@
+import { Models } from '@dbModels'
+import DaoAddressCache from '@modules/daoAddressCache'
+import { DaoList } from '@test/mock/fakeDao'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { type SinonSandbox } from 'sinon'
+
+const { createdAt: _createdAt, ...daoFixture } = DaoList[0]
+
+const createDao = (address: string, network: NetworksEnum) => Models.Dao.create({ ...daoFixture, address, network })
+
+describe('Module: DaoAddressCache', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    DaoAddressCache.clear()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    DaoAddressCache.clear()
+  })
+
+  it('should load existing DAO addresses on first refresh and resolve any casing to the stored value', async () => {
+    const dao = await createDao('0xf2d594F3C93C19D7B1a6F15B5489FFcE4B01f7dA', NetworksEnum.ethereumMainnet)
+
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.ethereumMainnet, dao.address.toLowerCase())).to.equal(
+      dao.address,
+    )
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.ethereumMainnet, dao.address)).to.equal(dao.address)
+  })
+
+  it('should return undefined for unknown addresses', async () => {
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.ethereumMainnet, '0xf2d594f3c93c19d7b1a6f15b5489ffce4b01f7da'))
+      .to.be.undefined
+  })
+
+  it('should pick up DAOs created after the initial load via the cursor delta', async () => {
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    const dao = await createDao('0xf2d594F3C93C19D7B1a6F15B5489FFcE4B01f7dA', NetworksEnum.ethereumMainnet)
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.ethereumMainnet, dao.address.toLowerCase())).to.equal(
+      dao.address,
+    )
+  })
+
+  it('should keep networks isolated', async () => {
+    const dao = await createDao('0xf2d594F3C93C19D7B1a6F15B5489FFcE4B01f7dA', NetworksEnum.polygonMainnet)
+
+    await DaoAddressCache.refresh(NetworksEnum.polygonMainnet)
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.polygonMainnet, dao.address)).to.equal(dao.address)
+    expect(DaoAddressCache.getChecksummed(NetworksEnum.ethereumMainnet, dao.address)).to.be.undefined
+  })
+
+  it('should only query the delta window on subsequent refreshes', async () => {
+    const findSpy = sandbox.spy(Models.Dao, 'find')
+
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    expect(findSpy.calledTwice).to.be.true
+    expect(findSpy.firstCall.args[0]).to.not.have.property('createdAt')
+    expect(findSpy.secondCall.args[0]).to.have.property('createdAt')
+  })
+
+  it('should not duplicate entries when the overlap window re-returns the same DAO', async () => {
+    const dao = await createDao('0xf2d594F3C93C19D7B1a6F15B5489FFcE4B01f7dA', NetworksEnum.ethereumMainnet)
+
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+    // Cursor sits at the DAO's createdAt, so the 60s overlap re-returns it
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+    await DaoAddressCache.refresh(NetworksEnum.ethereumMainnet)
+
+    const state = (DaoAddressCache as any).states.get(NetworksEnum.ethereumMainnet)
+    expect(state.byLower.size).to.equal(1)
+    expect(state.byLower.get(dao.address.toLowerCase())).to.equal(dao.address)
+  })
+
+  it('should not run concurrent refreshes for the same network', async () => {
+    const findSpy = sandbox.spy(Models.Dao, 'find')
+
+    await Promise.all([
+      DaoAddressCache.refresh(NetworksEnum.ethereumMainnet),
+      DaoAddressCache.refresh(NetworksEnum.ethereumMainnet),
+    ])
+
+    expect(findSpy.calledOnce).to.be.true
+  })
+})

--- a/test/unit/modules/poolingCrawler.spec.ts
+++ b/test/unit/modules/poolingCrawler.spec.ts
@@ -5,7 +5,10 @@ import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
 import utils from '@helpers/utils'
 import logger from '@logger'
 import { BlockchainLogCrawler } from '@modules/crawlers'
+import DaoAddressCache from '@modules/daoAddressCache'
 import PoolingCrawler from '@modules/poolingCrawler'
+import TokenEligibilityCache from '@modules/tokenEligibilityCache'
+import { DaoList } from '@test/mock/fakeDao'
 import { PluginList } from '@test/mock/fakePlugins'
 import { FakeToken } from '@test/mock/fakeToken'
 import { IPluginInterfaceType, ITokenType, NetworksEnum } from '@types'
@@ -19,11 +22,15 @@ describe('Module: PoolingCrawler', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
+    DaoAddressCache.clear()
+    TokenEligibilityCache.clear()
   })
 
   afterEach(() => {
     sandbox.restore()
     PoolingCrawler.instances.clear()
+    DaoAddressCache.clear()
+    TokenEligibilityCache.clear()
   })
 
   describe('start', () => {
@@ -107,6 +114,10 @@ describe('Module: PoolingCrawler', () => {
     const nativeTokenDepositedTopic = daoInterface.getEvent('NativeTokenDeposited')?.topicHash!
 
     it('should filter logs based on topics', async () => {
+      const daoAddress = ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94')
+      const { createdAt: _createdAt, ...daoFixture } = DaoList[0]
+      await Models.Dao.create({ ...daoFixture, address: daoAddress, network: NetworksEnum.ethereumMainnet })
+
       const mockLogs = [
         { topics: [transferTopic], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95' },
         { topics: [nativeTokenDepositedTopic], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94' },
@@ -114,14 +125,6 @@ describe('Module: PoolingCrawler', () => {
         { topics: ['0xDelegateVotesChangedTopic'], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f92' },
         { topics: ['0xDelegateVotesChangedTopi'], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f91' },
       ]
-
-      sandbox.stub(PoolingCrawler, '_getReceiverAddress').returns('0xDecodedAddress')
-
-      sandbox.stub(Models.Dao, 'distinct').resolves([ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94')])
-      sandbox
-        .stub(Models.Plugin, 'distinct')
-        .resolves([ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95')])
-      sandbox.stub(Models.Token, 'distinct').resolves([ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95')])
 
       const nativeTransferStub = sandbox.stub(DaoRegistryHandler, 'nativeTransfer').resolves()
 
@@ -132,8 +135,35 @@ describe('Module: PoolingCrawler', () => {
       await new Promise(resolve => process.nextTick(resolve))
 
       expect(nativeTransferStub.calledOnce).to.be.true
+      expect(nativeTransferStub.firstCall.args[1].address).to.equal(daoAddress)
 
       expect(result).to.have.lengthOf(2)
+    })
+
+    it('should detect DAO transfer receivers from raw topic data', async () => {
+      const daoAddress = ethers.getAddress('0x74b7da0c6d1c063ab31c09a1d899abbafba2612b')
+      const { createdAt: _createdAt, ...daoFixture } = DaoList[0]
+      await Models.Dao.create({ ...daoFixture, address: daoAddress, network: NetworksEnum.ethereumMainnet })
+
+      const mockLogs = [
+        {
+          topics: [transferTopic, '0xTopic2', '0x00000000000000000000000074b7da0c6d1c063ab31c09a1d899abbafba2612b'],
+          address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95',
+        },
+      ]
+
+      const nativeTransferStub = sandbox.stub(DaoRegistryHandler, 'nativeTransfer').resolves()
+
+      sandbox.stub(utils, 'wait')
+
+      const result = await PoolingCrawler.filterLogs(mockLogs as any, NetworksEnum.ethereumMainnet, true)
+
+      await new Promise(resolve => process.nextTick(resolve))
+
+      expect(nativeTransferStub.calledOnce).to.be.true
+      expect(nativeTransferStub.firstCall.args[1].address).to.equal(daoAddress)
+
+      expect(result).to.have.lengthOf(0)
     })
 
     it('should return only syncable tokens when filtering for transfer logs', async () => {
@@ -184,12 +214,11 @@ describe('Module: PoolingCrawler', () => {
       const daoInterface = new Interface(DAO.abi)
       const nativeTokenDepositedTopic = daoInterface.getEvent('NativeTokenDeposited')?.topicHash!
 
-      const mockLogs = [{ topics: [nativeTokenDepositedTopic], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94' }]
+      const daoAddress = ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94')
+      const { createdAt: _createdAt, ...daoFixture } = DaoList[0]
+      await Models.Dao.create({ ...daoFixture, address: daoAddress, network: NetworksEnum.peaqMainnet })
 
-      sandbox.stub(PoolingCrawler, '_getReceiverAddress').returns('0xDecodedAddress')
-      sandbox.stub(Models.Dao, 'distinct').resolves([ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94')])
-      sandbox.stub(Models.Plugin, 'distinct').resolves([])
-      sandbox.stub(Models.Token, 'distinct').resolves([])
+      const mockLogs = [{ topics: [nativeTokenDepositedTopic], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f94' }]
 
       const nativeTransferStub = sandbox.stub(DaoRegistryHandler, 'nativeTransfer').resolves()
       const waitStub = sandbox.stub(utils, 'wait').resolves()
@@ -244,7 +273,8 @@ describe('Module: PoolingCrawler', () => {
     })
 
     it('should handle errors in filterLogs and return original logs', async () => {
-      const mockLogs = [{ topics: ['0xSomeTopic'], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95' }]
+      const delegateVotesChangedTopic = govTokenInterface.getEvent('DelegateVotesChanged')?.topicHash!
+      const mockLogs = [{ topics: [delegateVotesChangedTopic], address: '0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95' }]
 
       sandbox.stub(Models.Plugin, 'distinct').rejects(new Error('Database error'))
       const loggerStub = sandbox.stub(logger, 'error')

--- a/test/unit/modules/tokenEligibilityCache.spec.ts
+++ b/test/unit/modules/tokenEligibilityCache.spec.ts
@@ -1,0 +1,168 @@
+import { Models } from '@dbModels'
+import TokenEligibilityCache from '@modules/tokenEligibilityCache'
+import { PluginList } from '@test/mock/fakePlugins'
+import { FakeToken } from '@test/mock/fakeToken'
+import { IPluginInterfaceType, IPluginStatus, ITokenType, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { ethers } from 'ethers'
+import * as sinon from 'sinon'
+import { type SinonSandbox } from 'sinon'
+
+const tokenAddress = ethers.getAddress('0x4838b106fce9647bdf1e7877bf73ce8b0bad5f95')
+const network = NetworksEnum.ethereumMainnet
+
+/**
+ * The fixtures carry hardcoded 2024 timestamps; strip them so created docs get
+ * real ones — the cursor-delta tests depend on creation time being "now".
+ */
+const { createdAt: _pc, updatedAt: _pu, ...pluginFixture } = PluginList[0] as Record<string, any>
+const { createdAt: _tc, updatedAt: _tu, ...tokenFixture } = FakeToken as Record<string, any>
+
+const createPlugin = (overrides: Record<string, any> = {}) =>
+  Models.Plugin.create({
+    ...pluginFixture,
+    interfaceType: IPluginInterfaceType.tokenVoting,
+    status: IPluginStatus.installed,
+    isSupported: true,
+    tokenAddress,
+    network,
+    ...overrides,
+  })
+
+const createToken = (overrides: Record<string, any> = {}) =>
+  Models.Token.create({
+    ...tokenFixture,
+    address: tokenAddress,
+    ignoreTransfer: false,
+    type: ITokenType.ERC20,
+    hasDelegate: true,
+    network,
+    ...overrides,
+  })
+
+describe('Module: TokenEligibilityCache', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    TokenEligibilityCache.clear()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    TokenEligibilityCache.clear()
+  })
+
+  it('should resolve an eligible token from any casing to the stored checksummed value', async () => {
+    await createPlugin()
+    await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress.toLowerCase())).to.equal(tokenAddress)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+  })
+
+  it('should not be eligible without a matching tokenVoting plugin', async () => {
+    await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+  })
+
+  it('should not be eligible without a matching syncable token', async () => {
+    await createPlugin()
+
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+  })
+
+  it('should revoke eligibility when the token stops being syncable', async () => {
+    await createPlugin()
+    const token = await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    await token.update({ ignoreTransfer: true })
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+  })
+
+  it('should revoke eligibility when the only plugin is uninstalled', async () => {
+    const plugin = await createPlugin()
+    await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    await plugin.update({ status: IPluginStatus.uninstalled })
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+  })
+
+  it('should keep eligibility while another eligible plugin still references the token', async () => {
+    const plugin = await createPlugin()
+    await createPlugin({
+      id: 'second-plugin-id',
+      address: '0xBf8dE4316E2778E26b12dad8906467b23BB9A200',
+      transactionHash: '0x6f3e8a941b2140d72e402e35078fd459478222e146aa6d6bd6832d322de5dd00',
+    })
+    await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+    await plugin.update({ status: IPluginStatus.uninstalled })
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+  })
+
+  it('should pick up eligibility created after the initial load via the cursor delta', async () => {
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    await createPlugin()
+    await createToken()
+    await TokenEligibilityCache.refresh(network)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+  })
+
+  it('should keep networks isolated', async () => {
+    await createPlugin()
+    await createToken()
+
+    await TokenEligibilityCache.refresh(network)
+    await TokenEligibilityCache.refresh(NetworksEnum.polygonMainnet)
+
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+    expect(TokenEligibilityCache.getChecksummed(NetworksEnum.polygonMainnet, tokenAddress)).to.be.undefined
+  })
+
+  it('should only query the delta window on subsequent refreshes', async () => {
+    const pluginFindSpy = sandbox.spy(Models.Plugin, 'find')
+    const tokenFindSpy = sandbox.spy(Models.Token, 'find')
+
+    await TokenEligibilityCache.refresh(network)
+    expect(pluginFindSpy.called).to.be.false
+    expect(tokenFindSpy.called).to.be.false
+
+    await TokenEligibilityCache.refresh(network)
+    expect(pluginFindSpy.calledOnce).to.be.true
+    expect(pluginFindSpy.firstCall.args[0]).to.have.property('updatedAt')
+    expect(tokenFindSpy.calledOnce).to.be.true
+    expect(tokenFindSpy.firstCall.args[0]).to.have.property('updatedAt')
+  })
+
+  it('should not run concurrent refreshes for the same network', async () => {
+    const distinctSpy = sandbox.spy(Models.Token, 'distinct')
+
+    await Promise.all([TokenEligibilityCache.refresh(network), TokenEligibilityCache.refresh(network)])
+
+    expect(distinctSpy.calledOnce).to.be.true
+  })
+})


### PR DESCRIPTION
## 🎫 Linear

[APP-1002](https://linear.app/aragon/issue/APP-1002/reduce-constant-high-cpu-usage-in-transfer-and-indexer-services)

## 📝 Summary

This pull request introduces incremental, in-memory caches for DAO addresses and token eligibility, significantly optimizing log filtering in the `PoolingCrawler` by eliminating repeated database queries on every tick. The caches are kept up-to-date using efficient delta queries and are used to filter logs in a more performant and scalable way. The PR also includes new unit tests for the DAO address cache and adds supporting indexes to the schema.

**Caching and Query Optimization:**

* Introduced `DaoAddressCache` and `TokenEligibilityCache` modules, which maintain per-network, incremental, in-memory caches of DAO addresses and eligible token addresses, respectively. These caches use efficient delta queries to keep themselves up-to-date and replace repeated `$in`/`distinct` DB queries during log filtering. (`src/modules/daoAddressCache.ts` [[1]](diffhunk://#diff-c7c1f897a1179e0fad60f412bea240b291b130b6748668e794aeb07fcf088144R1-R82) `src/modules/tokenEligibilityCache.ts` [[2]](diffhunk://#diff-ee8940480926892a3bab90837f9afd1c2e8d0dc793399504e238ea0da21b22b5R1-R195)
* Refactored `PoolingCrawler` to use these caches for DAO and token eligibility checks, removing per-tick DB queries and custom deduplication logic. (`src/modules/poolingCrawler.ts` [[1]](diffhunk://#diff-b5d246a9cbcacf7eb68bb19c55bec9813efa00cd34ec445fec673c5903cae177L4-R12) [[2]](diffhunk://#diff-b5d246a9cbcacf7eb68bb19c55bec9813efa00cd34ec445fec673c5903cae177L73-L77) [[3]](diffhunk://#diff-b5d246a9cbcacf7eb68bb19c55bec9813efa00cd34ec445fec673c5903cae177L110-R126) [[4]](diffhunk://#diff-b5d246a9cbcacf7eb68bb19c55bec9813efa00cd34ec445fec673c5903cae177L153-R157) [[5]](diffhunk://#diff-b5d246a9cbcacf7eb68bb19c55bec9813efa00cd34ec445fec673c5903cae177R201-R207)

**Schema and Indexing:**

* Added new compound indexes on `{ network, createdAt }` for DAOs, `{ network, updatedAt }` for Plugins and Tokens to support efficient incremental queries for the caches. (`src/models/schema/dao.ts` [[1]](diffhunk://#diff-3e7918bf47e60737eb53214e32ec877b25405f7f015abe246efbab44fe9014efR81) `src/models/schema/plugin.ts` [[2]](diffhunk://#diff-98e960000c4c0dfbec5d3b8aaf87c165e0896e18d0e2a1333b1e4504294024aaR107) `src/models/schema/token.ts` [[3]](diffhunk://#diff-6f8dd3d305ea35fdac9e3f633fd733fe0019dda52aa91a48dcbc0a2250a2b06aR40)

**Types and Interfaces:**

* Added new TypeScript interfaces `INetworkCacheState` and `ITokenEligibilityCacheState` to describe the internal state of the caches. (`src/types/crawler.ts` [src/types/crawler.tsR193-R221](diffhunk://#diff-f08c325ce2ac5b04b6c82b61ecee69215676749a377fe7be393f7adf1313bf82R193-R221))

**Testing:**

* Added comprehensive unit tests for the DAO address cache, covering initial load, delta refresh, network isolation, deduplication, and concurrency. (`test/unit/modules/daoAddressCache.spec.ts` [test/unit/modules/daoAddressCache.spec.tsR1-R99](diffhunk://#diff-55cb9dfbbf937a0576e88f573a6fdd869769790979fe5f7ec4437ab0e32c6cc1R1-R99))

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)

