### PR TITLE
feat(plugin-settings): implement backfill for missing settings on proposal creation (DRAFT)

### DIFF
--- a/src/handlers/pluginSettingHandler.ts
+++ b/src/handlers/pluginSettingHandler.ts
@@ -234,7 +234,7 @@ export const PluginSettingHandler = {
     if (!sppPlugin) return
 
     const sppSettings = await Models.Setting.findActive({
-      network: info.network,
+      network: relatedPlugin.network,
       pluginAddress: sppPlugin.address,
     })
 

--- a/src/handlers/pluginSettingHandler.ts
+++ b/src/handlers/pluginSettingHandler.ts
@@ -83,6 +83,161 @@ export const PluginSettingHandler = {
     }
   },
 
+  /**
+   * Backfills a missing Setting doc by reading the plugin config on-chain. Used at proposalCreated time
+   * when no Setting exists for the plugin (e.g. a SettingsUpdated event was never emitted/replayed), so
+   * proposals would otherwise persist with settings = null. Reads on-chain per interface type, then persists.
+   */
+  backfillSettingByType: async (plugin: Plugin, info: ILogInfo): Promise<Setting | undefined> => {
+    const { address: pluginAddress, network } = info
+    let fields: Record<string, any> | undefined
+
+    switch (plugin.interfaceType) {
+      case IPluginInterfaceType.multisig: {
+        const settings = await MultisigHelper.findSettings(pluginAddress, network)
+        if (!settings) break
+        fields = { onlyListed: settings.onlyListed, minApprovals: settings.minApprovals || 0 }
+        break
+      }
+      case IPluginInterfaceType.tokenVoting: {
+        const settings = await Web3Helper.getVotingSettings(pluginAddress, network)
+        if (!settings) break
+        fields = {
+          tokenAddress: plugin.tokenAddress,
+          votingMode: Number(settings.votingMode),
+          supportThreshold: Number(settings.supportThreshold),
+          minParticipation: Number(settings.minParticipation),
+          minDuration: Number(settings.minDuration),
+          minProposerVotingPower: settings.minProposerVotingPower.toString(),
+        }
+        break
+      }
+      case IPluginInterfaceType.lockToVote: {
+        const settings = await Web3Helper.getLockToVoteSettings(pluginAddress, network)
+        if (!settings) break
+        fields = {
+          tokenAddress: plugin.tokenAddress,
+          votingMode: Number(settings.votingMode),
+          supportThreshold: Number(settings.supportThresholdRatio),
+          minParticipation: Number(settings.minParticipationRatio),
+          approvalThreshold: Number(settings.minApprovalRatio),
+          minProposerVotingPower: settings.minProposerVotingPower.toString(),
+          minDuration: Number(settings.proposalDuration),
+        }
+        break
+      }
+      case IPluginInterfaceType.spp: {
+        const stages = await Web3Helper.getSppStages(pluginAddress, network)
+        if (!stages) break
+        const formattedStages = PluginSettingHandler.formatSppSetings(stages)
+        for (const stage of formattedStages) {
+          for (const subPlugin of stage.plugins) {
+            subPlugin.brandId = await PluginDetector.detectAddressType(subPlugin.address, network)
+          }
+        }
+        const sppMetadata = await Models.LogMetadata.getLatestMetadata(network, pluginAddress)
+        if (sppMetadata?.stageNames && sppMetadata.stageNames.length === formattedStages.length) {
+          formattedStages.forEach((stage: any, index: number) => {
+            stage.name = sppMetadata.stageNames[index]
+          })
+        }
+        fields = { tokenAddress: plugin.tokenAddress, stages: formattedStages }
+        break
+      }
+      default:
+        return
+    }
+
+    if (!fields) {
+      logger.warn('Backfill setting skipped - on-chain read failed', llo(info))
+      return
+    }
+
+    return PluginSettingHandler.persistBackfilledSetting(plugin, fields, info)
+  },
+
+  /**
+   * Persists a backfilled Setting doc. Because this only runs when no Setting exists at/before the
+   * proposal block, any currently-active Setting is necessarily NEWER: keep it active and store the
+   * backfill as an historical (inactive) record so chronology stays correct.
+   */
+  persistBackfilledSetting: async (
+    plugin: Plugin,
+    fields: Record<string, any>,
+    info: ILogInfo,
+  ): Promise<Setting | undefined> => {
+    const { address: pluginAddress, transactionHash, blockNumber, network } = info
+
+    const existingLog = await Models.Setting.findExistingLog({ transactionHash, pluginAddress })
+    if (existingLog) return
+
+    const newerActiveSetting = await Models.Setting.findActive({ network, pluginAddress })
+
+    const settingLog = {
+      blockNumber,
+      blockTimestamp: (await Web3Helper.getBlockTimestamp(blockNumber, network)) || undefined,
+      transactionHash,
+      status: newerActiveSetting ? ISettingStatus.inactive : ISettingStatus.active,
+      inactiveAtBlockNumber: newerActiveSetting ? newerActiveSetting.blockNumber : undefined,
+      daoAddress: plugin.daoAddress,
+      pluginAddress,
+      pluginSubdomain: plugin.subdomain,
+      network,
+      ...fields,
+    }
+
+    return DbOperations.createDocument(Models.Setting, settingLog, info, 'Backfilled Setting - proposalCreated', llo)
+  },
+
+  /**
+   * Marks the previously-active Setting of a plugin as inactive once a newer Setting has been created.
+   * No-op when there is no active setting. The log message is passed in to keep per-handler log labels.
+   */
+  deactivatePreviousSetting: async (
+    activePluginSetting: Setting | null,
+    blockNumber: number,
+    info: ILogInfo,
+    logMsg: string,
+  ) => {
+    if (!activePluginSetting) return
+
+    await DbOperations.updateDocument(
+      activePluginSetting,
+      {
+        inactiveAtBlockNumber: blockNumber,
+        status: ISettingStatus.inactive,
+      },
+      { logId: activePluginSetting.id, info },
+      logMsg,
+      llo,
+    )
+  },
+
+  /**
+   * If the plugin is a sub-plugin of an installed SPP, (re)pairs it with that parent SPP's active setting.
+   * No-op when the plugin has no parent SPP or the parent has no active setting.
+   */
+  pairWithParentSpp: async (relatedPlugin: Plugin, info: ILogInfo) => {
+    const sppPlugin = await Models.Plugin.findOne({
+      daoAddress: relatedPlugin.daoAddress,
+      network: relatedPlugin.network,
+      interfaceType: IPluginInterfaceType.spp,
+      status: IPluginStatus.installed,
+      'subPlugins.addresses': { $in: [relatedPlugin.address] },
+    })
+
+    if (!sppPlugin) return
+
+    const sppSettings = await Models.Setting.findActive({
+      network: info.network,
+      pluginAddress: sppPlugin.address,
+    })
+
+    if (sppSettings) {
+      await PluginSettingHandler.pairSppPlugins(sppPlugin, sppSettings, info)
+    }
+  },
+
   lockToVoteSettingsUpdated: async (parsedEvent: LogDescription, info: ILogInfo): Promise<Plugin | undefined> => {
     const { address: pluginAddress, transactionHash, blockNumber, network } = info
     const relatedPlugin = await Models.Plugin.findByAddress(pluginAddress, network)
@@ -129,39 +284,16 @@ export const PluginSettingHandler = {
 
     await DbOperations.createDocument(Models.Setting, settingLog, info, 'New Setting - lockToVoteSettingsUpdated', llo)
 
-    if (activePluginSetting) {
-      await DbOperations.updateDocument(
-        activePluginSetting,
-        {
-          inactiveAtBlockNumber: blockNumber,
-          status: ISettingStatus.inactive,
-        },
-        { logId: activePluginSetting.id, info },
-        'Update lockToVote inactive plugin',
-        llo,
-      )
-    }
+    await PluginSettingHandler.deactivatePreviousSetting(
+      activePluginSetting,
+      blockNumber,
+      info,
+      'Update lockToVote inactive plugin',
+    )
 
     await PluginSettingHandler.isSupported(relatedPlugin, info)
 
-    const sppPlugin = await Models.Plugin.findOne({
-      daoAddress: relatedPlugin.daoAddress,
-      network: relatedPlugin.network,
-      interfaceType: IPluginInterfaceType.spp,
-      status: IPluginStatus.installed,
-      'subPlugins.addresses': { $in: [pluginAddress] },
-    })
-
-    if (sppPlugin) {
-      const sppSettings = await Models.Setting.findActive({
-        network: info.network,
-        pluginAddress: sppPlugin.address,
-      })
-
-      if (sppSettings) {
-        await PluginSettingHandler.pairSppPlugins(sppPlugin, sppSettings, info)
-      }
-    }
+    await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
   },
 
   votingSettingsUpdated: async (parsedEvent: LogDescription, info: ILogInfo): Promise<Plugin | undefined> => {
@@ -212,18 +344,12 @@ export const PluginSettingHandler = {
 
     await DbOperations.createDocument(Models.Setting, settingLog, info, 'New Setting - tokenVotingSettingsUpdated', llo)
 
-    if (activePluginSetting) {
-      await DbOperations.updateDocument(
-        activePluginSetting,
-        {
-          inactiveAtBlockNumber: blockNumber,
-          status: ISettingStatus.inactive,
-        },
-        { logId: activePluginSetting.id, info },
-        'Update tokenVoting inactive plugin',
-        llo,
-      )
-    }
+    await PluginSettingHandler.deactivatePreviousSetting(
+      activePluginSetting,
+      blockNumber,
+      info,
+      'Update tokenVoting inactive plugin',
+    )
 
     const tokenDb = await ProxyToken.saveAndGetToken(relatedPlugin.tokenAddress, relatedPlugin.network)
 
@@ -233,25 +359,7 @@ export const PluginSettingHandler = {
 
     if (tokenDb?.isGovernance) {
       await PluginSettingHandler.isSupported(relatedPlugin, info)
-
-      const sppPlugin = await Models.Plugin.findOne({
-        daoAddress: relatedPlugin.daoAddress,
-        network: relatedPlugin.network,
-        interfaceType: IPluginInterfaceType.spp,
-        status: IPluginStatus.installed,
-        'subPlugins.addresses': { $in: [pluginAddress] },
-      })
-
-      if (sppPlugin) {
-        const sppSettings = await Models.Setting.findActive({
-          network: info.network,
-          pluginAddress: sppPlugin.address,
-        })
-
-        if (sppSettings) {
-          await PluginSettingHandler.pairSppPlugins(sppPlugin, sppSettings, info)
-        }
-      }
+      await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
     }
 
     return relatedPlugin
@@ -296,39 +404,16 @@ export const PluginSettingHandler = {
 
     await DbOperations.createDocument(Models.Setting, settingLog, info, 'New Setting - multisigSettingsUpdated', llo)
 
-    if (activePluginSetting) {
-      await DbOperations.updateDocument(
-        activePluginSetting,
-        {
-          inactiveAtBlockNumber: blockNumber,
-          status: ISettingStatus.inactive,
-        },
-        { logId: activePluginSetting.id, info },
-        'Update multisig inactive plugin',
-        llo,
-      )
-    }
+    await PluginSettingHandler.deactivatePreviousSetting(
+      activePluginSetting,
+      blockNumber,
+      info,
+      'Update multisig inactive plugin',
+    )
 
     if (findSettings !== undefined) {
       await PluginSettingHandler.isSupported(relatedPlugin, info)
-
-      const sppPlugin = await Models.Plugin.findOne({
-        daoAddress: relatedPlugin.daoAddress,
-        network: relatedPlugin.network,
-        interfaceType: IPluginInterfaceType.spp,
-        status: IPluginStatus.installed,
-        'subPlugins.addresses': { $in: [pluginAddress] },
-      })
-
-      if (sppPlugin) {
-        const sppSettings = await Models.Setting.findActive({
-          network: info.network,
-          pluginAddress: sppPlugin.address,
-        })
-        if (sppSettings) {
-          await PluginSettingHandler.pairSppPlugins(sppPlugin, sppSettings, info)
-        }
-      }
+      await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
     }
 
     return relatedPlugin
@@ -413,18 +498,12 @@ export const PluginSettingHandler = {
       llo,
     )
 
-    if (activePluginSetting) {
-      await DbOperations.updateDocument(
-        activePluginSetting,
-        {
-          inactiveAtBlockNumber: blockNumber,
-          status: ISettingStatus.inactive,
-        },
-        { logId: activePluginSetting.id, info },
-        'Update SPP inactive plugin',
-        llo,
-      )
-    }
+    await PluginSettingHandler.deactivatePreviousSetting(
+      activePluginSetting,
+      blockNumber,
+      info,
+      'Update SPP inactive plugin',
+    )
 
     // pair plugins
     await PluginSettingHandler.pairSppPlugins(relatedPlugin, settings, info)

--- a/src/handlers/pluginSettingHandler.ts
+++ b/src/handlers/pluginSettingHandler.ts
@@ -89,7 +89,7 @@ export const PluginSettingHandler = {
    * proposals would otherwise persist with settings = null. Reads on-chain per interface type, then persists.
    */
   backfillSettingByType: async (plugin: Plugin, info: ILogInfo): Promise<Setting | undefined> => {
-    const { address: pluginAddress, network } = info
+    const { address: pluginAddress, network } = plugin
     let fields: Record<string, any> | undefined
 
     switch (plugin.interfaceType) {
@@ -100,6 +100,10 @@ export const PluginSettingHandler = {
         break
       }
       case IPluginInterfaceType.tokenVoting: {
+        if (plugin.tokenAddress === null) {
+          logger.warn('Backfill setting skipped - token voting plugin has no token address', llo(info))
+          return
+        }
         const settings = await Web3Helper.getVotingSettings(pluginAddress, network)
         if (!settings) break
         fields = {
@@ -166,7 +170,8 @@ export const PluginSettingHandler = {
     fields: Record<string, any>,
     info: ILogInfo,
   ): Promise<Setting | undefined> => {
-    const { address: pluginAddress, transactionHash, blockNumber, network } = info
+    const { address: pluginAddress, network } = plugin
+    const { transactionHash, blockNumber } = info
 
     const existingLog = await Models.Setting.findExistingLog({ transactionHash, pluginAddress })
     if (existingLog) return

--- a/src/handlers/proposalHandler.ts
+++ b/src/handlers/proposalHandler.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import { assert } from '@errors'
 import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
+import { PluginSettingHandler } from '@handlers/pluginSettingHandler'
 import DecodeActions from '@helpers/decodeAction'
 import GovernanceErc20Helper from '@helpers/governanceErc20'
 import LockToVoteHelper from '@helpers/lockToVoteHelper'
@@ -57,7 +58,14 @@ export const ProposalHandler = {
         return { newProposal: undefined, relatedPlugin: undefined }
       }
 
-      const settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber)
+      let settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber)
+
+      // Self-healing from on-chain if the setting is not available
+      if (!settings) {
+        await PluginSettingHandler.backfillSettingByType(relatedPlugin, info)
+        settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber)
+      }
+
       const proposalMetadata = await ProposalHandler.fetchProposalMetadata(metadataUri, proposalIndex, info.network)
 
       let rawSettings: any = null

--- a/src/handlers/proposalHandler.ts
+++ b/src/handlers/proposalHandler.ts
@@ -58,12 +58,12 @@ export const ProposalHandler = {
         return { newProposal: undefined, relatedPlugin: undefined }
       }
 
-      let settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber)
+      let settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber, info.network)
 
       // Self-healing from on-chain if the setting is not available
       if (!settings) {
         await PluginSettingHandler.backfillSettingByType(relatedPlugin, info)
-        settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber)
+        settings = await Models.Setting.findLastSettingByBlockNumber(pluginAddress, info.blockNumber, info.network)
       }
 
       const proposalMetadata = await ProposalHandler.fetchProposalMetadata(metadataUri, proposalIndex, info.network)

--- a/src/helpers/decodeAction.ts
+++ b/src/helpers/decodeAction.ts
@@ -435,7 +435,11 @@ class DecodeActions {
       return
     }
 
-    const settings = await Models.Setting.findLastSettingByBlockNumber(pluginDetails.address, document.blockNumber!)
+    const settings = await Models.Setting.findLastSettingByBlockNumber(
+      pluginDetails.address,
+      document.blockNumber!,
+      pluginDetails.network,
+    )
 
     const existingSettings = settings
       ? {
@@ -499,6 +503,7 @@ class DecodeActions {
     const activeSettings = await Models.Setting.findLastSettingByBlockNumber(
       pluginDetails.address,
       document.blockNumber!,
+      pluginDetails.network,
     )
 
     const existingSettings = activeSettings
@@ -538,6 +543,7 @@ class DecodeActions {
     const activeSettings = await Models.Setting.findLastSettingByBlockNumber(
       pluginDetails.address,
       document.blockNumber!,
+      pluginDetails.network,
     )
 
     const existingSettings = activeSettings

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -329,7 +329,10 @@ const Web3Helper = {
 
     try {
       return await retryRequest(async () =>
-        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getStages()),
+        BottleneckModule.getNodeLimiter(network).schedule(async () => {
+          const configIndex = await contract.getCurrentConfigIndex()
+          return contract.getStages(configIndex)
+        }),
       )
     } catch (error) {
       logger.warn('Error getting spp stages', llo({ error, address }))

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -1,7 +1,9 @@
 import { ERC20 } from '@artifacts/ERC20'
 import { ERC721 } from '@artifacts/ERC721'
 import { GaugeVoter } from '@artifacts/GaugeVoter'
+import { LockToVote } from '@artifacts/LockToVote'
 import { Multisig } from '@artifacts/Multisig'
+import { StagedProposalProcessor } from '@artifacts/stagedProposalProcessor'
 import { TokenVoting } from '@artifacts/TokenVoting'
 import { VotingEscrow } from '@artifacts/VotingEscrow'
 import config from '@config'
@@ -282,6 +284,55 @@ const Web3Helper = {
       )
     } catch (error) {
       logger.warn('Error getting multisig settings', llo({ error, address }))
+    }
+  },
+
+  async getVotingSettings(address: HexAddress, network: NetworksEnum) {
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    const contract = new Contract(address, TokenVoting.abi, provider)
+
+    try {
+      return await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => {
+          const [votingMode, supportThreshold, minParticipation, minDuration, minProposerVotingPower] =
+            await Promise.all([
+              contract.votingMode(),
+              contract.supportThreshold(),
+              contract.minParticipation(),
+              contract.minDuration(),
+              contract.minProposerVotingPower(),
+            ])
+          return { votingMode, supportThreshold, minParticipation, minDuration, minProposerVotingPower }
+        }),
+      )
+    } catch (error) {
+      logger.warn('Error getting voting settings', llo({ error, address }))
+    }
+  },
+
+  async getLockToVoteSettings(address: HexAddress, network: NetworksEnum) {
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    const contract = new Contract(address, LockToVote.abi, provider)
+
+    try {
+      return await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getVotingSettings()),
+      )
+    } catch (error) {
+      logger.warn('Error getting lockToVote settings', llo({ error, address }))
+    }
+  },
+
+  async getSppStages(address: HexAddress, network: NetworksEnum) {
+    const provider = ProviderModule.getAnyRpcProvider(network)
+    const contract = new Contract(address, StagedProposalProcessor.abi, provider)
+
+    try {
+      return await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => contract.getStages()),
+      )
+    } catch (error) {
+      logger.warn('Error getting spp stages', llo({ error, address }))
     }
   },
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -9,7 +9,7 @@ const format = winston.format.combine(...[Formats.formatError(), winston.format.
 
 const externalLogger: any = new ExternalLogger({
   name: 'external-logger',
-  level: EnumLogLevel.VERBOSE,
+  level: (config.LOG.LEVEL as EnumLogLevel) || EnumLogLevel.VERBOSE,
 })
 
 const consoleFormat = winston.format.combine(

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -360,9 +360,10 @@ export default class Setting extends Model {
     return await this.findOne(params).exec()
   }
 
-  static async findLastSettingByBlockNumber(pluginAddress: HexAddress, blockNumber: number) {
+  static async findLastSettingByBlockNumber(pluginAddress: HexAddress, blockNumber: number, network: NetworksEnum) {
     return await this.findOne({
       pluginAddress,
+      network,
       blockNumber: { $lte: blockNumber },
     })
       .sort({ blockNumber: -1 })

--- a/src/services/aragon-dao/proposalMetrics.ts
+++ b/src/services/aragon-dao/proposalMetrics.ts
@@ -26,6 +26,7 @@ export const ProposalMetrics = {
 
         if (!proposal.settings?.minApprovals) {
           logger.warn('MinApprovals not found - multisig metrics', llo({ proposalIndex, pluginAddress, network }))
+          return
         }
 
         const votes = await Models.Vote.findVotes({ proposalIndex, pluginAddress, network }, { session })

--- a/test/unit/handlers/pluginSettingHandler.spec.ts
+++ b/test/unit/handlers/pluginSettingHandler.spec.ts
@@ -162,6 +162,240 @@ describe('Indexer: PluginSettingHandler', () => {
     })
   })
 
+  describe('backfillSettingByType', () => {
+    const info = {
+      address: '0xplugin',
+      transactionHash: '0xtx',
+      blockNumber: 10,
+      network: NetworksEnum.ethereumMainnet,
+    } as any
+
+    it('should backfill multisig settings from on-chain', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.multisig } as any
+      const findSettingsStub = sandbox
+        .stub(MultisigHelper, 'findSettings')
+        .resolves({ minApprovals: 3, onlyListed: true })
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({ id: 's' } as any)
+
+      const result = await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(findSettingsStub.calledOnceWith('0xplugin', NetworksEnum.ethereumMainnet)).to.be.true
+      expect(persistStub.calledOnce).to.be.true
+      expect(persistStub.firstCall.args[1]).to.deep.equal({ onlyListed: true, minApprovals: 3 })
+      expect(result).to.deep.equal({ id: 's' })
+    })
+
+    it('should backfill tokenVoting settings, coercing types', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.tokenVoting, tokenAddress: '0xtoken' } as any
+      sandbox.stub(Web3Helper, 'getVotingSettings').resolves({
+        votingMode: 2n,
+        supportThreshold: 150n,
+        minParticipation: 222n,
+        minDuration: 1312312125n,
+        minProposerVotingPower: 10n,
+      } as any)
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+
+      await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(persistStub.firstCall.args[1]).to.deep.equal({
+        tokenAddress: '0xtoken',
+        votingMode: 2,
+        supportThreshold: 150,
+        minParticipation: 222,
+        minDuration: 1312312125,
+        minProposerVotingPower: '10',
+      })
+    })
+
+    it('should backfill lockToVote settings, coercing types', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.lockToVote, tokenAddress: '0xtoken' } as any
+      sandbox.stub(Web3Helper, 'getLockToVoteSettings').resolves({
+        votingMode: 1n,
+        supportThresholdRatio: 200n,
+        minParticipationRatio: 300n,
+        minApprovalRatio: 150n,
+        minProposerVotingPower: 100n,
+        proposalDuration: 86400n,
+      } as any)
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+
+      await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(persistStub.firstCall.args[1]).to.deep.equal({
+        tokenAddress: '0xtoken',
+        votingMode: 1,
+        supportThreshold: 200,
+        minParticipation: 300,
+        approvalThreshold: 150,
+        minProposerVotingPower: '100',
+        minDuration: 86400,
+      })
+    })
+
+    it('should backfill spp settings with formatted stages and brandIds', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.spp, tokenAddress: '0xtoken' } as any
+      sandbox.stub(Web3Helper, 'getSppStages').resolves([
+        {
+          minAdvance: 10,
+          maxAdvance: 20,
+          approvalThreshold: 50,
+          vetoThreshold: 60,
+          cancelable: true,
+          plugins: [{ address: '0xsub', isManual: false, allowedBody: true, proposalType: 1 }],
+        },
+      ] as any)
+      sandbox.stub(PluginDetector, 'detectAddressType').resolves(VotingBodyBrandIdentity.SAFE)
+      sandbox.stub(Models.LogMetadata, 'getLatestMetadata').resolves(null)
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+
+      await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      const fields = persistStub.firstCall.args[1]
+      expect(fields.tokenAddress).to.eq('0xtoken')
+      expect(fields.stages).to.have.length(1)
+      expect(fields.stages[0].plugins[0].brandId).to.eq(VotingBodyBrandIdentity.SAFE)
+    })
+
+    it('should skip and warn when on-chain read fails', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.multisig } as any
+      sandbox.stub(MultisigHelper, 'findSettings').resolves(undefined)
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+      const warnStub = sandbox.stub(logger, 'warn')
+
+      const result = await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(persistStub.notCalled).to.be.true
+      expect(warnStub.calledOnceWith('Backfill setting skipped - on-chain read failed' as any)).to.be.true
+      expect(result).to.be.undefined
+    })
+
+    it('should be a no-op for unsupported interface types', async () => {
+      const plugin = { interfaceType: IPluginInterfaceType.admin } as any
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+
+      const result = await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(persistStub.notCalled).to.be.true
+      expect(result).to.be.undefined
+    })
+  })
+
+  describe('persistBackfilledSetting', () => {
+    const plugin = { daoAddress: '0xdao', subdomain: 'test.dao' } as any
+    const info = {
+      address: '0xplugin',
+      transactionHash: '0xtx',
+      blockNumber: 10,
+      network: NetworksEnum.ethereumMainnet,
+    } as any
+
+    it('should return without creating when a log already exists', async () => {
+      sandbox.stub(Models.Setting, 'findExistingLog').resolves(true)
+      const createStub = sandbox.stub(DbOperations, 'createDocument').resolves()
+
+      const result = await PluginSettingHandler.persistBackfilledSetting(plugin, { minApprovals: 3 }, info)
+
+      expect(createStub.notCalled).to.be.true
+      expect(result).to.be.undefined
+    })
+
+    it('should create an active setting when no newer active setting exists', async () => {
+      sandbox.stub(Models.Setting, 'findExistingLog').resolves(false)
+      sandbox.stub(Models.Setting, 'findActive').resolves(null)
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(123)
+      const createStub = sandbox.stub(DbOperations, 'createDocument').resolves({ id: 'new' })
+
+      await PluginSettingHandler.persistBackfilledSetting(plugin, { minApprovals: 3 }, info)
+
+      const data = createStub.firstCall.args[1]
+      expect(data.status).to.eq(ISettingStatus.active)
+      expect(data.inactiveAtBlockNumber).to.be.undefined
+      expect(data.minApprovals).to.eq(3)
+      expect(data.pluginAddress).to.eq('0xplugin')
+      expect(createStub.firstCall.args[3]).to.eq('Backfilled Setting - proposalCreated')
+    })
+
+    it('should create an inactive historical setting and NOT touch the newer active one', async () => {
+      sandbox.stub(Models.Setting, 'findExistingLog').resolves(false)
+      sandbox.stub(Models.Setting, 'findActive').resolves({ id: 'newer', blockNumber: 50 })
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(123)
+      const createStub = sandbox.stub(DbOperations, 'createDocument').resolves({ id: 'new' })
+      const updateStub = sandbox.stub(DbOperations, 'updateDocument').resolves()
+
+      await PluginSettingHandler.persistBackfilledSetting(plugin, { minApprovals: 3 }, info)
+
+      const data = createStub.firstCall.args[1]
+      expect(data.status).to.eq(ISettingStatus.inactive)
+      expect(data.inactiveAtBlockNumber).to.eq(50)
+      expect(updateStub.notCalled).to.be.true
+    })
+  })
+
+  describe('deactivatePreviousSetting', () => {
+    const info = { blockNumber: 10, network: NetworksEnum.ethereumMainnet } as any
+
+    it('should be a no-op when there is no active setting', async () => {
+      const updateStub = sandbox.stub(DbOperations, 'updateDocument').resolves()
+
+      await PluginSettingHandler.deactivatePreviousSetting(null, 10, info, 'Update multisig inactive plugin')
+
+      expect(updateStub.notCalled).to.be.true
+    })
+
+    it('should deactivate the active setting with the given log message', async () => {
+      const activeSetting = { id: 'active-id' } as any
+      const updateStub = sandbox.stub(DbOperations, 'updateDocument').resolves()
+
+      await PluginSettingHandler.deactivatePreviousSetting(activeSetting, 10, info, 'Update multisig inactive plugin')
+
+      expect(
+        updateStub.calledOnceWith(
+          activeSetting,
+          { inactiveAtBlockNumber: 10, status: ISettingStatus.inactive },
+          { logId: 'active-id', info },
+          'Update multisig inactive plugin',
+        ),
+      ).to.be.true
+    })
+  })
+
+  describe('pairWithParentSpp', () => {
+    const relatedPlugin = { address: '0xplugin', daoAddress: '0xdao', network: NetworksEnum.ethereumMainnet } as any
+    const info = { network: NetworksEnum.ethereumMainnet } as any
+
+    it('should be a no-op when there is no parent SPP', async () => {
+      sandbox.stub(Models.Plugin, 'findOne').resolves(null)
+      const pairStub = sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
+
+      await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
+
+      expect(pairStub.notCalled).to.be.true
+    })
+
+    it('should be a no-op when the parent SPP has no active setting', async () => {
+      sandbox.stub(Models.Plugin, 'findOne').resolves({ address: '0xspp' })
+      sandbox.stub(Models.Setting, 'findActive').resolves(null)
+      const pairStub = sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
+
+      await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
+
+      expect(pairStub.notCalled).to.be.true
+    })
+
+    it('should pair with the parent SPP active setting', async () => {
+      const sppPlugin = { address: '0xspp' }
+      const sppSettings = { id: 'spp-settings', stages: [] }
+      sandbox.stub(Models.Plugin, 'findOne').resolves(sppPlugin)
+      sandbox.stub(Models.Setting, 'findActive').resolves(sppSettings)
+      const pairStub = sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
+
+      await PluginSettingHandler.pairWithParentSpp(relatedPlugin, info)
+
+      expect(pairStub.calledOnceWith(sppPlugin as any, sppSettings as any, info)).to.be.true
+    })
+  })
+
   describe('votingSettingsUpdated', () => {
     it('should return if plugin not found', async () => {
       const parsedEvent = {

--- a/test/unit/handlers/pluginSettingHandler.spec.ts
+++ b/test/unit/handlers/pluginSettingHandler.spec.ts
@@ -171,7 +171,11 @@ describe('Indexer: PluginSettingHandler', () => {
     } as any
 
     it('should backfill multisig settings from on-chain', async () => {
-      const plugin = { interfaceType: IPluginInterfaceType.multisig } as any
+      const plugin = {
+        interfaceType: IPluginInterfaceType.multisig,
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
       const findSettingsStub = sandbox
         .stub(MultisigHelper, 'findSettings')
         .resolves({ minApprovals: 3, onlyListed: true })
@@ -186,7 +190,12 @@ describe('Indexer: PluginSettingHandler', () => {
     })
 
     it('should backfill tokenVoting settings, coercing types', async () => {
-      const plugin = { interfaceType: IPluginInterfaceType.tokenVoting, tokenAddress: '0xtoken' } as any
+      const plugin = {
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: '0xtoken',
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
       sandbox.stub(Web3Helper, 'getVotingSettings').resolves({
         votingMode: 2n,
         supportThreshold: 150n,
@@ -208,8 +217,30 @@ describe('Indexer: PluginSettingHandler', () => {
       })
     })
 
+    it('should skip tokenVoting backfill when the plugin has no token address', async () => {
+      const plugin = {
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        tokenAddress: null,
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
+      const getSettingsStub = sandbox.stub(Web3Helper, 'getVotingSettings').resolves({} as any)
+      const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
+
+      const result = await PluginSettingHandler.backfillSettingByType(plugin, info)
+
+      expect(getSettingsStub.notCalled).to.be.true
+      expect(persistStub.notCalled).to.be.true
+      expect(result).to.be.undefined
+    })
+
     it('should backfill lockToVote settings, coercing types', async () => {
-      const plugin = { interfaceType: IPluginInterfaceType.lockToVote, tokenAddress: '0xtoken' } as any
+      const plugin = {
+        interfaceType: IPluginInterfaceType.lockToVote,
+        tokenAddress: '0xtoken',
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
       sandbox.stub(Web3Helper, 'getLockToVoteSettings').resolves({
         votingMode: 1n,
         supportThresholdRatio: 200n,
@@ -234,7 +265,12 @@ describe('Indexer: PluginSettingHandler', () => {
     })
 
     it('should backfill spp settings with formatted stages and brandIds', async () => {
-      const plugin = { interfaceType: IPluginInterfaceType.spp, tokenAddress: '0xtoken' } as any
+      const plugin = {
+        interfaceType: IPluginInterfaceType.spp,
+        tokenAddress: '0xtoken',
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
       sandbox.stub(Web3Helper, 'getSppStages').resolves([
         {
           minAdvance: 10,
@@ -258,7 +294,11 @@ describe('Indexer: PluginSettingHandler', () => {
     })
 
     it('should skip and warn when on-chain read fails', async () => {
-      const plugin = { interfaceType: IPluginInterfaceType.multisig } as any
+      const plugin = {
+        interfaceType: IPluginInterfaceType.multisig,
+        address: '0xplugin',
+        network: NetworksEnum.ethereumMainnet,
+      } as any
       sandbox.stub(MultisigHelper, 'findSettings').resolves(undefined)
       const persistStub = sandbox.stub(PluginSettingHandler, 'persistBackfilledSetting').resolves({} as any)
       const warnStub = sandbox.stub(logger, 'warn')
@@ -282,7 +322,12 @@ describe('Indexer: PluginSettingHandler', () => {
   })
 
   describe('persistBackfilledSetting', () => {
-    const plugin = { daoAddress: '0xdao', subdomain: 'test.dao' } as any
+    const plugin = {
+      daoAddress: '0xdao',
+      subdomain: 'test.dao',
+      address: '0xplugin',
+      network: NetworksEnum.ethereumMainnet,
+    } as any
     const info = {
       address: '0xplugin',
       transactionHash: '0xtx',

--- a/test/unit/handlers/proposalHandler.spec.ts
+++ b/test/unit/handlers/proposalHandler.spec.ts
@@ -2,6 +2,7 @@ import '@test/environment'
 import config from '@config'
 import { Models } from '@dbModels'
 import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
+import { PluginSettingHandler } from '@handlers/pluginSettingHandler'
 import { ProposalHandler } from '@handlers/proposalHandler'
 import DecodeActions from '@helpers/decodeAction'
 import GovernanceErc20Helper from '@helpers/governanceErc20'
@@ -38,12 +39,16 @@ describe('ProposalHandler', () => {
   let sandbox: SinonSandbox
   let intervalTime: number
   let network: NetworksEnum = NetworksEnum.ethereumMainnet
+  let backfillSettingStub: sinon.SinonStub
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox()
     network = NetworksEnum.ethereumMainnet
     intervalTime = config.NODES[utils.networkToAragon(network)].INTERVAL_BLOCK_TIME
     config.NODES[utils.networkToAragon(network)].INTERVAL_BLOCK_TIME = 0
+
+    // Keep proposalCreated deterministic: never hit the chain when settings are missing.
+    backfillSettingStub = sandbox.stub(PluginSettingHandler, 'backfillSettingByType').resolves(undefined)
 
     // Stub Models.Plugin.find for updateDaoMetrics to work
     if (!Models.Plugin.find) {
@@ -717,6 +722,90 @@ describe('ProposalHandler', () => {
       expect(savedProposal.settings).to.be.null
       expect(savedProposal.snapshot.totalSupply).to.be.eq('0')
       expect(stubWarn.calledOnceWith('Error ProposalHandler.proposalCreated - tokenAddress is missing' as any))
+    })
+
+    it('should backfill settings on-chain when none exist and persist the re-queried settings', async () => {
+      const metadataUri = 'ipfs://metadata-uri'
+      const info: ILogInfo = {
+        transactionHash: '0xbackfill-tx',
+        address: '0xplugin-address',
+        blockNumber: 100,
+        network,
+        eventName: 'proposalCreated',
+        transactionIndex: 1,
+        logIndex: 1,
+        interfaceType: IPluginInterfaceType.multisig,
+      }
+
+      const fakeEvent = {
+        args: {
+          creator: '0x742d35cC6634c0532925A3b844bc9E7595F0beB1',
+          proposalId: 1n,
+          startDate: 1700000000n,
+          endDate: 1700086400n,
+          allowFailureMap: 0n,
+          metadata: metadataUri,
+          actions: [],
+        },
+      }
+
+      const plugin = {
+        address: '0xplugin-address',
+        daoAddress: '0xdao-address',
+        subdomain: 'dao.subdomain',
+        interfaceType: IPluginInterfaceType.multisig,
+      }
+
+      // Backfilled Setting surfaced by the second lookup, after backfillSettingByType runs.
+      const backfilledSetting = {
+        id: 'backfilled-setting-id',
+        transactionHash: '0xbackfill-tx',
+        blockNumber: 100,
+        network,
+        daoAddress: '0xdao-address',
+        pluginAddress: '0xplugin-address',
+        pluginSubdomain: 'dao.subdomain',
+        onlyListed: true,
+        minApprovals: 2,
+      }
+
+      sandbox.stub(Models.Plugin, 'findByAddress').resolves(plugin as any)
+      sandbox.stub(Models.PluginMember, 'findAllMembersOfPlugin').resolves([])
+      sandbox.stub(Models.Proposal, 'findExistingLog').resolves(null)
+      const findLastSettingStub = sandbox
+        .stub(Models.Setting, 'findLastSettingByBlockNumber')
+        .onFirstCall()
+        .resolves(null)
+        .onSecondCall()
+        .resolves(backfilledSetting as any)
+      sandbox.stub(Web3Utils, 'extractMetadataUri').returns(metadataUri)
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(1700000000)
+      sandbox.stub(ProposalHandler, 'fetchProposalMetadata').resolves({
+        title: 'Backfill Proposal',
+        description: 'Description',
+        summary: 'Summary',
+        resources: [],
+        media: {},
+      } as any)
+      sandbox.stub(Models.Proposal, 'getNextIncrementalId').resolves(1)
+      sandbox.stub(ProposalHandler, 'pairSppProposals').resolves()
+      sandbox.stub(RabbitMQHelper, 'sendMessage').resolves()
+      sandbox.stub(logger, 'verbose')
+
+      await ProposalHandler.proposalCreated(fakeEvent as any, info)
+
+      expect(backfillSettingStub.calledOnceWith(plugin as any, info)).to.be.true
+      expect(findLastSettingStub.calledTwice).to.be.true
+
+      const savedProposal = await Models.Proposal.findOne({
+        transactionHash: '0xbackfill-tx',
+        pluginAddress: '0xplugin-address',
+        proposalIndex: '1',
+      })
+
+      expect(savedProposal).to.exist
+      expect(savedProposal.settings.minApprovals).to.eq(2)
+      expect(savedProposal.settings.onlyListed).to.eq(true)
     })
 
     it('should handle when proposalMetadata is null', async () => {

--- a/test/unit/helpers/web3.spec.ts
+++ b/test/unit/helpers/web3.spec.ts
@@ -76,6 +76,124 @@ describe('Helpers:Web3', () => {
     })
   })
 
+  describe('getVotingSettings', () => {
+    it('should read token voting settings on-chain', async () => {
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return {
+              votingMode: sandbox.stub().resolves(1n),
+              supportThreshold: sandbox.stub().resolves(500000n),
+              minParticipation: sandbox.stub().resolves(100000n),
+              minDuration: sandbox.stub().resolves(86400n),
+              minProposerVotingPower: sandbox.stub().resolves(10n),
+            }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getVotingSettings('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.deep.equal({
+        votingMode: 1n,
+        supportThreshold: 500000n,
+        minParticipation: 100000n,
+        minDuration: 86400n,
+        minProposerVotingPower: 10n,
+      })
+    })
+
+    it('should return undefined when the on-chain read fails', async () => {
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return {
+              votingMode: sandbox.stub().rejects(new Error('fake-error')),
+              supportThreshold: sandbox.stub().resolves(500000n),
+              minParticipation: sandbox.stub().resolves(100000n),
+              minDuration: sandbox.stub().resolves(86400n),
+              minProposerVotingPower: sandbox.stub().resolves(10n),
+            }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getVotingSettings('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.be.undefined
+    })
+  })
+
+  describe('getLockToVoteSettings', () => {
+    it('should read lockToVote settings on-chain', async () => {
+      const settings = { votingMode: 1n, supportThresholdRatio: 200n, proposalDuration: 86400n }
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return { getVotingSettings: sandbox.stub().resolves(settings) }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getLockToVoteSettings('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.deep.equal(settings)
+    })
+
+    it('should return undefined when the on-chain read fails', async () => {
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return { getVotingSettings: sandbox.stub().rejects(new Error('fake-error')) }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getLockToVoteSettings('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.be.undefined
+    })
+  })
+
+  describe('getSppStages', () => {
+    it('should read the stages of the current config index', async () => {
+      const stages = [{ maxAdvance: 10n, minAdvance: 1n }]
+      const getStagesStub = sandbox.stub().resolves(stages)
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return {
+              getCurrentConfigIndex: sandbox.stub().resolves(2n),
+              getStages: getStagesStub,
+            }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getSppStages('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(getStagesStub.calledOnceWith(2n)).to.be.true
+      expect(result).to.deep.equal(stages)
+    })
+
+    it('should return undefined when the on-chain read fails', async () => {
+      const { default: MockedWeb3Helper } = proxyquire.noCallThru()('@helpers/web3', {
+        ethers: {
+          Contract: function () {
+            return {
+              getCurrentConfigIndex: sandbox.stub().rejects(new Error('fake-error')),
+              getStages: sandbox.stub().resolves([]),
+            }
+          },
+        },
+      })
+
+      const result = await MockedWeb3Helper.getSppStages('0xPluginAddress', NetworksEnum.ethereumMainnet)
+
+      expect(result).to.be.undefined
+    })
+  })
+
   describe('getBlockNumber', () => {
     it('should return latest block number when blockNumber is "latest"', async () => {
       const network = NetworksEnum.ethereumMainnet

--- a/test/unit/models/schema/setting.spec.ts
+++ b/test/unit/models/schema/setting.spec.ts
@@ -201,35 +201,38 @@ describe('Model: Setting', () => {
 
     let result: any
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 1)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 1, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(1)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 2)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 2, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(1)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 3)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 3, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(3)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 4)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 4, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(3)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 5)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 5, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(3)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 6)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 6, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(3)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 7)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 7, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(3)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 8)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 8, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(8)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 9)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 9, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(8)
 
-    result = await Models.Setting.findLastSettingByBlockNumber('0x', 15)
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 15, NetworksEnum.polygonMainnet)
     expect(result?.blockNumber).to.eq(15)
+
+    result = await Models.Setting.findLastSettingByBlockNumber('0x', 15, NetworksEnum.ethereumMainnet)
+    expect(result).to.be.null
   })
 
   it('Should update Setting', async () => {

--- a/test/unit/services/aragon-dao/proposalMetrics.spec.ts
+++ b/test/unit/services/aragon-dao/proposalMetrics.spec.ts
@@ -52,10 +52,10 @@ describe('AragonDao:ProposalMetrics', () => {
       expect(loggerStub.calledOnceWith('Proposal not found - multisig metrics' as any)).to.be.true
     })
 
-    it('should log an error if `minApprovals` is missing in the proposal settings', async () => {
+    it('should warn and skip metrics when `minApprovals` is missing in the proposal settings', async () => {
       const proposal = { id: 'proposal-id', settings: {} }
       sandbox.stub(Models.Proposal, 'findByProposalIndex').resolves(proposal as any)
-      sandbox.stub(Models.Vote, 'findVotes').resolves([])
+      const findVotesStub = sandbox.stub(Models.Vote, 'findVotes').resolves([])
       const loggerWarnStub = sandbox.stub(logger, 'warn')
       const loggerStub = sandbox.stub(logger, 'error')
 
@@ -66,7 +66,8 @@ describe('AragonDao:ProposalMetrics', () => {
       })
 
       expect(loggerWarnStub.calledOnceWith('MinApprovals not found - multisig metrics' as any)).to.be.true
-      expect(loggerStub.calledWith('Error updating multisig metrics' as any)).to.be.true
+      expect(findVotesStub.notCalled).to.be.true
+      expect(loggerStub.notCalled).to.be.true
     })
 
     it('should throw', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request introduces a "self-healing" mechanism for missing plugin settings by backfilling them from on-chain data, and refactors the plugin setting update logic for better code reuse and maintainability. It also adds new Web3 helper methods for reading on-chain settings and improves logging configuration. The most important changes are grouped below:

**Self-healing and Backfilling Plugin Settings:**
* Added `backfillSettingByType` and `persistBackfilledSetting` methods to `PluginSettingHandler`, allowing the system to reconstruct missing `Setting` documents by fetching data directly from the blockchain when none exist at proposal creation time. This ensures proposals are not persisted with `settings = null`.
* Updated `proposalHandler.ts` so that when a setting is missing at proposal creation, it triggers the backfill process and retries fetching the setting.

**Refactoring and Code Reuse:**
* Refactored plugin setting update handlers (for multisig, token voting, lock-to-vote, and SPP) to use the new `deactivatePreviousSetting` and `pairWithParentSpp` helper methods, removing duplicated logic and centralizing responsibility. [[1]](diffhunk://#diff-156d67f0fb168f824b8c48cbbb1816294e728a40a69d952a8ca17194f6a8b61fL132-R296) [[2]](diffhunk://#diff-156d67f0fb168f824b8c48cbbb1816294e728a40a69d952a8ca17194f6a8b61fL215-L226) [[3]](diffhunk://#diff-156d67f0fb168f824b8c48cbbb1816294e728a40a69d952a8ca17194f6a8b61fL236-R362) [[4]](diffhunk://#diff-156d67f0fb168f824b8c48cbbb1816294e728a40a69d952a8ca17194f6a8b61fL299-R416) [[5]](diffhunk://#diff-156d67f0fb168f824b8c48cbbb1816294e728a40a69d952a8ca17194f6a8b61fL416-L427)

**Web3 Helper Methods:**
* Added new methods to `Web3Helper` for reading on-chain settings: `getVotingSettings`, `getLockToVoteSettings`, and `getSppStages`, each encapsulating the logic for fetching contract state for different plugin types.

**Logging and Configuration:**
* Improved logger configuration to respect the configured log level from environment or config, defaulting to VERBOSE if not set.

**Bug Fix:**
* Fixed a potential crash in proposal metrics calculation by returning early if `minApprovals` is not found in multisig settings.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
