### PR TITLE
feat(APP-1006): Add proposalCreationConditionAddress to Safe bodies in SPP settings

### DIFF
--- a/src/artifacts/RuledCondition.ts
+++ b/src/artifacts/RuledCondition.ts
@@ -1,0 +1,57 @@
+export const RuledCondition = {
+  abi: [
+    {
+      inputs: [],
+      name: 'getRules',
+      outputs: [
+        {
+          components: [
+            {
+              internalType: 'uint8',
+              name: 'id',
+              type: 'uint8',
+            },
+            {
+              internalType: 'uint8',
+              name: 'op',
+              type: 'uint8',
+            },
+            {
+              internalType: 'uint240',
+              name: 'value',
+              type: 'uint240',
+            },
+            {
+              internalType: 'bytes32',
+              name: 'permissionId',
+              type: 'bytes32',
+            },
+          ],
+          internalType: 'struct RuledCondition.Rule[]',
+          name: '',
+          type: 'tuple[]',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ],
+}
+
+export const SafeOwnerCondition = {
+  abi: [
+    {
+      inputs: [],
+      name: 'safe',
+      outputs: [
+        {
+          internalType: 'contract IOwnerManager',
+          name: '',
+          type: 'address',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ],
+}

--- a/src/handlers/pluginSettingHandler.ts
+++ b/src/handlers/pluginSettingHandler.ts
@@ -9,6 +9,7 @@ import GovernanceVeHelper from '@helpers/governanceVe'
 import MultisigHelper from '@helpers/multisig'
 import PluginDetector from '@helpers/pluginDetector'
 import PolicyHelper from '@helpers/policyHelper'
+import SppBodyConditionHelper from '@helpers/sppBodyCondition'
 import utils from '@helpers/utils'
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
@@ -26,6 +27,8 @@ import {
   IPolicyStrategyType,
   ISettingStatus,
   type ISettingVotingEscrow,
+  type NetworksEnum,
+  VotingBodyBrandIdentity,
 } from '@types'
 import { type LogDescription, type TransactionReceipt } from 'ethers'
 
@@ -384,6 +387,8 @@ export const PluginSettingHandler = {
       }
     }
 
+    await PluginSettingHandler.attachExternalBodyConditions(relatedPlugin, formattedStages, network)
+
     const settingLog = {
       blockNumber,
       blockTimestamp: (await Web3Helper.getBlockTimestamp(blockNumber, network)) || undefined,
@@ -454,6 +459,39 @@ export const PluginSettingHandler = {
         }),
       }
     })
+  },
+
+  /**
+   * Resolves and sets proposalCreationConditionAddress on external stage bodies. Only Safe bodies can have condition as of now.
+   * Internal bodies are skipped: they have their own Plugin document carrying the condition.
+   * Never throws - a failed resolution leaves the field null so settings indexing is not blocked.
+   */
+  attachExternalBodyConditions: async (sppPlugin: Plugin, stages: any[], network: NetworksEnum): Promise<void> => {
+    try {
+      const externalBodies: any[] = []
+      for (const stage of stages) {
+        for (const stagePlugin of stage.plugins || []) {
+          if (stagePlugin.brandId === VotingBodyBrandIdentity.SAFE) externalBodies.push(stagePlugin)
+        }
+      }
+
+      if (!externalBodies.length) return
+
+      const conditions = await SppBodyConditionHelper.resolveExternalBodyConditions(
+        sppPlugin.proposalCreationConditionAddress,
+        externalBodies.map(body => body.address),
+        network,
+      )
+
+      for (const body of externalBodies) {
+        body.proposalCreationConditionAddress = conditions.get(body.address.toLowerCase()) ?? null
+      }
+    } catch (error) {
+      logger.warn(
+        'Failed to attach external body conditions',
+        llo({ pluginAddress: sppPlugin.address, network, error }),
+      )
+    }
   },
 
   /**

--- a/src/helpers/sppBodyCondition.ts
+++ b/src/helpers/sppBodyCondition.ts
@@ -53,27 +53,33 @@ const SppBodyConditionHelper = {
       if (BigInt(rule.id) !== CONDITION_RULE_ID) continue
 
       try {
-        const conditionAddressFromRuleValue = getAddress(toBeHex(rule.value, 20)) as HexAddress;
+        const conditionAddressFromRuleValue = getAddress(toBeHex(rule.value, 20)) as HexAddress
         subConditions.push(conditionAddressFromRuleValue)
       } catch (error) {
         logger.warn('Invalid sub-condition rule value', llo({ sppRuleConditionAddress, network, rule, error }))
       }
     }
 
-    for (const conditionAddress of subConditions) {
-      if (resolved.size === bodiesByLowercase.size) break
-
-      try {
-        const condition = new Contract(conditionAddress, SafeOwnerCondition.abi, provider)
-        const safeAddress = await retryRequest(async () =>
-          BottleneckModule.getNodeLimiter(network).schedule(async () => condition.safe()),
-        )
-
-        if (bodiesByLowercase.has(String(safeAddress).toLowerCase())) {
-          resolved.set(String(safeAddress).toLowerCase(), conditionAddress)
+    // Probe every sub-condition in parallel; there are only a handful per SPP and the Bottleneck
+    // limiter still caps the actual RPC concurrency.
+    const probes = await Promise.all(
+      subConditions.map(async conditionAddress => {
+        try {
+          const condition = new Contract(conditionAddress, SafeOwnerCondition.abi, provider)
+          const safeAddress = await retryRequest(async () =>
+            BottleneckModule.getNodeLimiter(network).schedule(async () => condition.safe()),
+          )
+          return { conditionAddress, safeAddress: String(safeAddress).toLowerCase() }
+        } catch (_error) {
+          // Not a SafeOwnerCondition (e.g. an internal body's member-list condition) - skip
+          return null
         }
-      } catch (_error) {
-        // Not a SafeOwnerCondition (e.g. an internal body's member-list condition) - skip
+      }),
+    )
+
+    for (const probe of probes) {
+      if (probe && bodiesByLowercase.has(probe.safeAddress)) {
+        resolved.set(probe.safeAddress, probe.conditionAddress)
       }
     }
 

--- a/src/helpers/sppBodyCondition.ts
+++ b/src/helpers/sppBodyCondition.ts
@@ -1,0 +1,84 @@
+import { RuledCondition, SafeOwnerCondition } from '@artifacts/RuledCondition'
+import { retryRequest } from '@helpers/retryRequest'
+import logger from '@logger'
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+import { type HexAddress, type NetworksEnum } from '@types'
+import { Contract, getAddress, toBeHex, ZeroAddress } from 'ethers'
+
+const llo = logger.logMeta.bind(null, { service: 'helper:SppBodyCondition' })
+
+// RuledCondition rule id referencing a sub-condition contract
+const CONDITION_RULE_ID = 202n
+
+const SppBodyConditionHelper = {
+  /**
+   * Maps external SPP bodies (e.g. Safe wallets) to the condition contract deployed for them.
+   *
+   * External bodies are not OSx plugins, so no CREATE_PROPOSAL_PERMISSION grant exists for them.
+   * Their condition (e.g. SafeOwnerCondition) is only discoverable as a sub-condition rule
+   * (id 202) inside the SPP's own rule condition, matched back to a body via `safe()`.
+   *
+   * @param sppRuleConditionAddress The SPP plugin's proposalCreationConditionAddress (a RuledCondition)
+   * @param externalBodyAddresses Stage body addresses without a Plugin document
+   * @param network
+   * @returns Map of lowercased body address -> condition contract address
+   */
+  async resolveExternalBodyConditions(
+    sppRuleConditionAddress: HexAddress | null | undefined,
+    externalBodyAddresses: HexAddress[],
+    network: NetworksEnum,
+  ): Promise<Map<string, HexAddress>> {
+    const resolved = new Map<string, HexAddress>()
+
+    if (!externalBodyAddresses.length) return resolved
+    if (!sppRuleConditionAddress || sppRuleConditionAddress === ZeroAddress) return resolved
+
+    const bodiesByLowercase = new Map(externalBodyAddresses.map(address => [address.toLowerCase(), address]))
+    const provider = ProviderModule.getAnyRpcProvider(network)
+
+    let rules: Array<{ id: bigint; value: bigint }>
+    try {
+      const ruleCondition = new Contract(sppRuleConditionAddress, RuledCondition.abi, provider)
+      rules = await retryRequest(async () =>
+        BottleneckModule.getNodeLimiter(network).schedule(async () => ruleCondition.getRules()),
+      )
+    } catch (error) {
+      logger.warn('Failed to read rules from SPP rule condition', llo({ sppRuleConditionAddress, network, error }))
+      return resolved
+    }
+
+    const subConditions: HexAddress[] = []
+    for (const rule of rules) {
+      if (BigInt(rule.id) !== CONDITION_RULE_ID) continue
+
+      try {
+        const conditionAddressFromRuleValue = getAddress(toBeHex(rule.value, 20)) as HexAddress;
+        subConditions.push(conditionAddressFromRuleValue)
+      } catch (error) {
+        logger.warn('Invalid sub-condition rule value', llo({ sppRuleConditionAddress, network, rule, error }))
+      }
+    }
+
+    for (const conditionAddress of subConditions) {
+      if (resolved.size === bodiesByLowercase.size) break
+
+      try {
+        const condition = new Contract(conditionAddress, SafeOwnerCondition.abi, provider)
+        const safeAddress = await retryRequest(async () =>
+          BottleneckModule.getNodeLimiter(network).schedule(async () => condition.safe()),
+        )
+
+        if (bodiesByLowercase.has(String(safeAddress).toLowerCase())) {
+          resolved.set(String(safeAddress).toLowerCase(), conditionAddress)
+        }
+      } catch (_error) {
+        // Not a SafeOwnerCondition (e.g. an internal body's member-list condition) - skip
+      }
+    }
+
+    return resolved
+  },
+}
+
+export default SppBodyConditionHelper

--- a/src/migrations/20260717100000-addExternalBodyProposalCondition.ts
+++ b/src/migrations/20260717100000-addExternalBodyProposalCondition.ts
@@ -1,0 +1,76 @@
+import { Models } from '@dbModels'
+import { PluginSettingHandler } from '@handlers/pluginSettingHandler'
+import logger from '@logger'
+import type Setting from '@models/schema/setting'
+import DBCrawler from '@models/utils/crawler'
+import { type IMigration, ISettingStatus, VotingBodyBrandIdentity } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: addExternalBodyProposalCondition' })
+
+export const addExternalBodyProposalConditionMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: '20260717100000-addExternalBodyProposalCondition' }))
+
+    const crawler = new DBCrawler({
+      model: Models.Setting,
+      onDocument: async (setting: Setting) => {
+        const sppPlugin = await Models.Plugin.findByAddress(setting.pluginAddress, setting.network)
+        if (!sppPlugin?.proposalCreationConditionAddress) {
+          logger.warn(
+            'SPP plugin or its rule condition not found, skipping setting',
+            llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
+          )
+          return
+        }
+
+        const stages = setting.toObject().stages
+        await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, setting.network)
+        await setting.update({ stages })
+
+        logger.verbose(
+          'Processed document',
+          llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
+        )
+      },
+      onError: (error: any, document: any) => {
+        logger.error(
+          'Error backfilling external body condition',
+          llo({
+            error,
+            pluginAddress: document.pluginAddress,
+            network: document.network,
+          }),
+        )
+      },
+
+      where: {
+        status: ISettingStatus.active,
+        stages: {
+          $elemMatch: {
+            plugins: {
+              $elemMatch: {
+                brandId: VotingBodyBrandIdentity.SAFE,
+                $or: [
+                  { proposalCreationConditionAddress: null },
+                  { proposalCreationConditionAddress: { $exists: false } },
+                ],
+              },
+            },
+          },
+        },
+      },
+      batchSize: 200,
+      concurrency: 10,
+    })
+
+    await crawler.crawl()
+    logger.info(
+      'Migration completed successfully',
+      llo({ migration: '20260717100000-addExternalBodyProposalCondition' }),
+    )
+  },
+
+  stop: async () => {},
+}
+
+export default addExternalBodyProposalConditionMigration

--- a/src/migrations/20260717100000-addExternalBodyProposalCondition.ts
+++ b/src/migrations/20260717100000-addExternalBodyProposalCondition.ts
@@ -7,15 +7,25 @@ import { type IMigration, ISettingStatus, VotingBodyBrandIdentity } from '@types
 
 const llo = logger.logMeta.bind(null, { service: 'Migration: addExternalBodyProposalCondition' })
 
+const MIGRATION_NAME = '20260717100000-addExternalBodyProposalCondition'
+
 export const addExternalBodyProposalConditionMigration: IMigration = {
   start: async () => {
-    logger.info('Starting migration', llo({ migration: '20260717100000-addExternalBodyProposalCondition' }))
+    logger.info('Starting migration', llo({ migration: MIGRATION_NAME }))
+
+    let processed = 0
+    let updated = 0
+    let skipped = 0
+    let errored = 0
 
     const crawler = new DBCrawler({
       model: Models.Setting,
       onDocument: async (setting: Setting) => {
+        processed++
+
         const sppPlugin = await Models.Plugin.findByAddress(setting.pluginAddress, setting.network)
         if (!sppPlugin?.proposalCreationConditionAddress) {
+          skipped++
           logger.warn(
             'SPP plugin or its rule condition not found, skipping setting',
             llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
@@ -26,13 +36,12 @@ export const addExternalBodyProposalConditionMigration: IMigration = {
         const stages = setting.toObject().stages
         await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, setting.network)
         await setting.update({ stages })
+        updated++
 
-        logger.verbose(
-          'Processed document',
-          llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
-        )
+        logger.verbose('Processed document', llo({ pluginAddress: setting.pluginAddress, network: setting.network }))
       },
       onError: (error: any, document: any) => {
+        errored++
         logger.error(
           'Error backfilling external body condition',
           llo({
@@ -64,10 +73,13 @@ export const addExternalBodyProposalConditionMigration: IMigration = {
     })
 
     await crawler.crawl()
-    logger.info(
-      'Migration completed successfully',
-      llo({ migration: '20260717100000-addExternalBodyProposalCondition' }),
-    )
+
+    const summary = { migration: MIGRATION_NAME, processed, updated, skipped, errored }
+    if (skipped > 0 || errored > 0) {
+      logger.error('Migration completed with unprocessed settings', llo(summary))
+    } else {
+      logger.info('Migration completed successfully', llo(summary))
+    }
   },
 
   stop: async () => {},

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -179,6 +179,10 @@ export class PluginSetting {
 
   @prop({ type: () => String, enum: VotingBodyBrandIdentity, default: VotingBodyBrandIdentity.OTHER })
   public brandId!: VotingBodyBrandIdentity
+
+  // Only set for Safe external bodies. Internal bodies expose it via their own Plugin document by looking for CREATE_PROPOSAL_PERMISSION.
+  @prop({ type: () => String, default: null })
+  public proposalCreationConditionAddress?: HexAddress
 }
 
 export class Stages {

--- a/test/unit/handlers/pluginSettingHandler.spec.ts
+++ b/test/unit/handlers/pluginSettingHandler.spec.ts
@@ -5,6 +5,7 @@ import GovernanceVeHelper from '@helpers/governanceVe'
 import MultisigHelper from '@helpers/multisig'
 import PluginDetector from '@helpers/pluginDetector'
 import PolicyHelper from '@helpers/policyHelper'
+import SppBodyConditionHelper from '@helpers/sppBodyCondition'
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
@@ -1102,6 +1103,119 @@ describe('Indexer: PluginSettingHandler', () => {
       expect(savedSettings.stages[0].plugins[0].brandId).to.equal(VotingBodyBrandIdentity.SAFE)
       expect(savedSettings.stages[0].plugins[1].brandId).to.equal(VotingBodyBrandIdentity.EOA)
       expect(savedSettings.stages[0].plugins[2].brandId).to.equal(VotingBodyBrandIdentity.OTHER)
+    })
+
+    it('should attach external body conditions to the formatted stages', async () => {
+      const parsedEvent = {
+        args: {
+          stages: [
+            {
+              minAdvance: 10,
+              maxAdvance: 20,
+              approvalThreshold: 50,
+              vetoThreshold: 60,
+              cancelable: true,
+              plugins: [{ pluginAddress: '0xsafe-address', isManual: true, allowedBody: false, proposalType: 1 }],
+            },
+          ],
+        },
+      } as any
+
+      const info = {
+        address: '0xplugin',
+        transactionHash: '0x123',
+        blockNumber: 1,
+        network: NetworksEnum.ethereumMainnet,
+      } as any
+
+      const plugin = {
+        address: '0xplugin',
+        daoAddress: '0xdao',
+        subdomain: 'sub.plugin',
+        tokenAddress: '0xtoken',
+        proposalCreationConditionAddress: '0xrule-condition',
+      } as any
+
+      sandbox.stub(Models.Plugin, 'findByAddress').resolves(plugin)
+      sandbox.stub(Models.Setting, 'findExistingLog').resolves(null)
+      sandbox.stub(Models.Setting, 'findActive').resolves(null)
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(1620000000)
+      sandbox.stub(Models.LogMetadata, 'getLatestMetadata').resolves(null)
+      sandbox.stub(PluginDetector, 'detectAddressType').resolves(VotingBodyBrandIdentity.SAFE)
+      sandbox.stub(DbOperations, 'createDocument')
+      sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
+      sandbox.stub(PluginSettingHandler, 'isSupported').resolves()
+
+      const attachStub = sandbox.stub(PluginSettingHandler, 'attachExternalBodyConditions').resolves()
+
+      await PluginSettingHandler.sppSettingsUpdated(parsedEvent, info)
+
+      expect(attachStub.calledOnce).to.be.true
+      expect(attachStub.firstCall.args[0]).to.deep.equal(plugin)
+      expect(attachStub.firstCall.args[2]).to.equal(info.network)
+    })
+  })
+
+  describe('attachExternalBodyConditions', () => {
+    const network = NetworksEnum.ethereumMainnet
+    const sppPlugin = {
+      address: '0xplugin',
+      proposalCreationConditionAddress: '0xrule-condition',
+    } as any
+
+    it('should set proposalCreationConditionAddress on external safe bodies', async () => {
+      const stages = [
+        {
+          plugins: [
+            { address: '0xSafeBody', brandId: VotingBodyBrandIdentity.SAFE },
+            { address: '0xinternal', brandId: VotingBodyBrandIdentity.OTHER },
+          ],
+        },
+      ]
+
+      const resolveStub = sandbox
+        .stub(SppBodyConditionHelper, 'resolveExternalBodyConditions')
+        .resolves(new Map([['0xsafebody', '0xsafe-condition']]))
+
+      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+
+      expect(resolveStub.calledOnceWith('0xrule-condition', ['0xSafeBody'], network)).to.be.true
+      expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.equal('0xsafe-condition')
+      expect((stages[0].plugins[1] as any).proposalCreationConditionAddress).to.be.undefined
+    })
+
+    it('should set null for unresolved safe bodies and skip non-safe bodies', async () => {
+      const stages = [
+        {
+          plugins: [
+            { address: '0xSafeBody', brandId: VotingBodyBrandIdentity.SAFE },
+            { address: '0xExternalBody', brandId: VotingBodyBrandIdentity.OTHER },
+          ],
+        },
+      ]
+
+      sandbox.stub(SppBodyConditionHelper, 'resolveExternalBodyConditions').resolves(new Map())
+
+      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+
+      expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.be.null
+      // non-safe bodies are untouched in memory; the schema default persists null for them
+      expect((stages[0].plugins[1] as any).proposalCreationConditionAddress).to.be.undefined
+    })
+
+    it('should not throw when the resolver fails', async () => {
+      const stages = [
+        {
+          plugins: [{ address: '0xSafeBody', brandId: VotingBodyBrandIdentity.SAFE }],
+        },
+      ]
+
+      sandbox.stub(SppBodyConditionHelper, 'resolveExternalBodyConditions').rejects(new Error('rpc down'))
+      const loggerStub = sandbox.stub(logger, 'warn')
+
+      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+
+      expect(loggerStub.calledOnce).to.be.true
     })
   })
 

--- a/test/unit/helpers/sppBodyCondition.spec.ts
+++ b/test/unit/helpers/sppBodyCondition.spec.ts
@@ -1,0 +1,144 @@
+import BottleneckModule from '@modules/bottleneck'
+import ProviderModule from '@modules/provider'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { getAddress, toBeHex, ZeroAddress } from 'ethers'
+import proxyquire from 'proxyquire'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+const RULE_CONDITION_ADDRESS = '0xb28a9D4463c03790eC7CA725eDb7A46b0dB6dAaa'
+const INTERNAL_BODY_CONDITION = '0x2ccB021608200E534ebDeCe4FcEE15FD7D5B61aA'
+const SAFE_BODY_CONDITION = getAddress('0xdb7d1c47a4b3a4b8cfce0a7cf1be36d3fc45277e')
+const SAFE_BODY_ADDRESS = '0xeB88A1D01306Bd9d8442673ee78770f2665B008F'
+
+const CONDITION_RULE_ID = 202n
+const LOGIC_OP_RULE_ID = 203n
+
+const buildRules = () => [
+  { id: LOGIC_OP_RULE_ID, op: 10n, value: 0x200000001n, permissionId: 0n },
+  { id: CONDITION_RULE_ID, op: 1n, value: BigInt(INTERNAL_BODY_CONDITION), permissionId: 0n },
+  { id: CONDITION_RULE_ID, op: 1n, value: BigInt(SAFE_BODY_CONDITION), permissionId: 0n },
+]
+
+describe('Helpers: SppBodyConditionHelper', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({})
+    sandbox.stub(BottleneckModule, 'getNodeLimiter').returns({ schedule: (fn: any) => fn() } as any)
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  const mockHelper = (contractsByAddress: Record<string, any>) => {
+    const { default: MockedHelper } = proxyquire.noCallThru()('@helpers/sppBodyCondition', {
+      ethers: {
+        Contract: function (address: string) {
+          return contractsByAddress[getAddress(address)] || {}
+        },
+        getAddress,
+        toBeHex,
+        ZeroAddress,
+      },
+    })
+    return MockedHelper
+  }
+
+  describe('resolveExternalBodyConditions', () => {
+    it('should map a safe body to its SafeOwnerCondition and skip internal conditions', async () => {
+      const getRulesStub = sandbox.stub().resolves(buildRules())
+      const internalSafeStub = sandbox.stub().rejects(new Error('execution reverted'))
+      const safeStub = sandbox.stub().resolves(SAFE_BODY_ADDRESS)
+
+      const helper = mockHelper({
+        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
+        [getAddress(INTERNAL_BODY_CONDITION)]: { safe: internalSafeStub },
+        [getAddress(SAFE_BODY_CONDITION)]: { safe: safeStub },
+      })
+
+      const result = await helper.resolveExternalBodyConditions(
+        RULE_CONDITION_ADDRESS,
+        [SAFE_BODY_ADDRESS],
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(result.size).to.equal(1)
+      expect(result.get(SAFE_BODY_ADDRESS.toLowerCase())).to.equal(getAddress(SAFE_BODY_CONDITION))
+      expect(getRulesStub.calledOnce).to.be.true
+    })
+
+    it('should return an empty map when the rule condition address is missing or zero', async () => {
+      const helper = mockHelper({})
+
+      const missing = await helper.resolveExternalBodyConditions(
+        null,
+        [SAFE_BODY_ADDRESS],
+        NetworksEnum.ethereumSepolia,
+      )
+      const zero = await helper.resolveExternalBodyConditions(
+        ZeroAddress,
+        [SAFE_BODY_ADDRESS],
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(missing.size).to.equal(0)
+      expect(zero.size).to.equal(0)
+    })
+
+    it('should return an empty map when there are no external bodies', async () => {
+      const getRulesStub = sandbox.stub().resolves(buildRules())
+      const helper = mockHelper({
+        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
+      })
+
+      const result = await helper.resolveExternalBodyConditions(
+        RULE_CONDITION_ADDRESS,
+        [],
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(result.size).to.equal(0)
+      expect(getRulesStub.notCalled).to.be.true
+    })
+
+    it('should return an empty map when getRules fails', async () => {
+      const getRulesStub = sandbox.stub().rejects(new Error('rpc error'))
+      const helper = mockHelper({
+        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
+      })
+
+      const result = await helper.resolveExternalBodyConditions(
+        RULE_CONDITION_ADDRESS,
+        [SAFE_BODY_ADDRESS],
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(result.size).to.equal(0)
+    })
+
+    it('should leave bodies unmapped when no sub-condition matches them', async () => {
+      const otherSafe = '0x1111111111111111111111111111111111111111'
+      const getRulesStub = sandbox.stub().resolves(buildRules())
+      const internalSafeStub = sandbox.stub().rejects(new Error('execution reverted'))
+      const safeStub = sandbox.stub().resolves(otherSafe)
+
+      const helper = mockHelper({
+        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
+        [getAddress(INTERNAL_BODY_CONDITION)]: { safe: internalSafeStub },
+        [getAddress(SAFE_BODY_CONDITION)]: { safe: safeStub },
+      })
+
+      const result = await helper.resolveExternalBodyConditions(
+        RULE_CONDITION_ADDRESS,
+        [SAFE_BODY_ADDRESS],
+        NetworksEnum.ethereumSepolia,
+      )
+
+      expect(result.size).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
## 📝 Summary

SPP (Staged Proposal Processor) plugin responses expose `proposalCreationConditionAddress` for internal stage bodies (e.g. multisig), but external bodies such as Safe wallets came back without it — just `{address, proposalType, brandId}`. Internal bodies get the field from their own OSx `Plugin` document (derived from the `CREATE_PROPOSAL_PERMISSION` grant); external bodies never go through an OSx install, so no permission record exists.

The condition data does exist on-chain: the SPP's own rule condition (`RuledCondition`) holds one sub-condition rule per body, and a Safe body's sub-condition is a `SafeOwnerCondition` whose `safe()` returns the body address. This PR resolves that mapping at indexing time and persists it on the stored stage-body sub-documents, so the API serves it with no extra runtime calls.

**Task:** [APP-1006](https://aragonassociation.atlassian.net/browse/APP-1006)

## 🔄 What Changed

- **Schema** (`setting.ts`): added `proposalCreationConditionAddress` to the embedded `PluginSetting` (stage body).
- **Resolver** (`helpers/sppBodyCondition.ts`): reads `getRules()` on the SPP rule condition, extracts the sub-condition addresses (rule id 202), and probes each `SafeOwnerCondition.safe()` in parallel to map condition → Safe body. Rate-limited via the existing Bottleneck limiter.
- **Artifact** (`artifacts/RuledCondition.ts`): minimal ABIs for `getRules()` and `SafeOwnerCondition.safe()`.
- **Indexer** (`handlers/pluginSettingHandler.ts`): `attachExternalBodyConditions` runs during `sppSettingsUpdated`, sets the field on Safe-brand bodies, and never throws so a resolution failure can't block settings indexing. The existing API aggregation passes the stored field through unchanged.
- **Migration** (`migrations/20260717100000-addExternalBodyProposalCondition.ts`): backfills existing active SPP settings that have Safe bodies missing the field; tracks per-outcome counters and logs an error-level summary if any settings were skipped or errored.
- **Tests**: unit coverage for the resolver (using the real Sepolia rule shapes) and for `attachExternalBodyConditions`.

Verified end-to-end against Sepolia (SPP `0xcbC0B652…`, DAO `0x360C363b…`): the Safe body resolves to its `SafeOwnerCondition` `0xDb7D1c47…`, and the internal multisig body keeps its own condition.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [x] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)