### PR TITLE
fix(tokenEligibilityCache): commit cursor only after eligibility refresh completes

### DIFF
--- a/src/modules/tokenEligibilityCache.ts
+++ b/src/modules/tokenEligibilityCache.ts
@@ -89,9 +89,10 @@ class TokenEligibilityCache {
     ).lean()
 
     /**
-     * Advance the cursor to at least queryStartedAt (not just the newest
-     * document timestamp) so the delta window stays bounded instead of
-     * permanently re-fetching the tail; the overlap keeps races covered.
+     * Compute (but do not yet commit) the advanced cursor: at least
+     * queryStartedAt (not just the newest document timestamp) so the delta
+     * window stays bounded instead of permanently re-fetching the tail; the
+     * overlap keeps races covered.
      */
     const changedAddresses = new Set<string>()
     let cursor = state.pluginCursor > queryStartedAt ? state.pluginCursor : queryStartedAt
@@ -99,9 +100,11 @@ class TokenEligibilityCache {
       if (plugin.tokenAddress) changedAddresses.add(plugin.tokenAddress)
       if (plugin.updatedAt && plugin.updatedAt > cursor) cursor = plugin.updatedAt
     }
-    state.pluginCursor = cursor
 
-    if (changedAddresses.size === 0) return
+    if (changedAddresses.size === 0) {
+      state.pluginCursor = cursor
+      return
+    }
 
     /**
      * Re-verify each changed tokenAddress against the full eligibility filter:
@@ -127,6 +130,8 @@ class TokenEligibilityCache {
         state.pluginTokensByLower.delete(lower)
       }
     }
+
+    state.pluginCursor = cursor
   }
 
   private async refreshTokens(network: NetworksEnum, state: ITokenEligibilityCacheState): Promise<void> {
@@ -147,9 +152,10 @@ class TokenEligibilityCache {
     ).lean()
 
     /**
-     * Advance the cursor to at least queryStartedAt (not just the newest
-     * document timestamp) so the delta window stays bounded instead of
-     * permanently re-fetching the tail; the overlap keeps races covered.
+     * Compute (but do not yet commit) the advanced cursor: at least
+     * queryStartedAt (not just the newest document timestamp) so the delta
+     * window stays bounded instead of permanently re-fetching the tail; the
+     * overlap keeps races covered.
      */
     const changedAddresses = new Set<string>()
     let cursor = state.tokenCursor > queryStartedAt ? state.tokenCursor : queryStartedAt
@@ -157,9 +163,11 @@ class TokenEligibilityCache {
       if (token.address) changedAddresses.add(token.address)
       if (token.updatedAt && token.updatedAt > cursor) cursor = token.updatedAt
     }
-    state.tokenCursor = cursor
 
-    if (changedAddresses.size === 0) return
+    if (changedAddresses.size === 0) {
+      state.tokenCursor = cursor
+      return
+    }
 
     const eligible = await Models.Token.distinct('address', {
       ...tokenEligibility,
@@ -180,6 +188,8 @@ class TokenEligibilityCache {
         state.tokensByLower.delete(lower)
       }
     }
+
+    state.tokenCursor = cursor
   }
 
   /**

--- a/test/unit/modules/tokenEligibilityCache.spec.ts
+++ b/test/unit/modules/tokenEligibilityCache.spec.ts
@@ -158,6 +158,91 @@ describe('Module: TokenEligibilityCache', () => {
     expect(tokenFindSpy.firstCall.args[0]).to.have.property('updatedAt')
   })
 
+
+  const findGte = (call: sinon.SinonSpyCall): number => (call.args[0] as any).updatedAt.$gte.getTime()
+
+  it('should retry a newly eligible plugin after a failed revalidation without advancing the cursor', async () => {
+    await createToken()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    await createPlugin()
+    const findSpy = sandbox.spy(Models.Plugin, 'find')
+    const distinctStub = sandbox.stub(Models.Plugin, 'distinct').rejects(new Error('mongo down'))
+
+    await expect(TokenEligibilityCache.refresh(network)).to.be.rejectedWith('mongo down')
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    distinctStub.restore()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    expect(findSpy.calledTwice).to.be.true
+    expect(findGte(findSpy.secondCall)).to.equal(findGte(findSpy.firstCall))
+  })
+
+  it('should retry a newly eligible token after a failed revalidation without advancing the cursor', async () => {
+    await createPlugin()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    await createToken()
+    const findSpy = sandbox.spy(Models.Token, 'find')
+    const distinctStub = sandbox.stub(Models.Token, 'distinct').rejects(new Error('mongo down'))
+
+    await expect(TokenEligibilityCache.refresh(network)).to.be.rejectedWith('mongo down')
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    distinctStub.restore()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    expect(findSpy.calledTwice).to.be.true
+    expect(findGte(findSpy.secondCall)).to.equal(findGte(findSpy.firstCall))
+  })
+
+  it('should retry a plugin revocation after a failed revalidation without advancing the cursor', async () => {
+    const plugin = await createPlugin()
+    await createToken()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    await plugin.update({ status: IPluginStatus.uninstalled })
+    const findSpy = sandbox.spy(Models.Plugin, 'find')
+    const distinctStub = sandbox.stub(Models.Plugin, 'distinct').rejects(new Error('mongo down'))
+
+    await expect(TokenEligibilityCache.refresh(network)).to.be.rejectedWith('mongo down')
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    distinctStub.restore()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    expect(findSpy.calledTwice).to.be.true
+    expect(findGte(findSpy.secondCall)).to.equal(findGte(findSpy.firstCall))
+  })
+
+  it('should retry a token revocation after a failed revalidation without advancing the cursor', async () => {
+    await createPlugin()
+    const token = await createToken()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    await token.update({ ignoreTransfer: true })
+    const findSpy = sandbox.spy(Models.Token, 'find')
+    const distinctStub = sandbox.stub(Models.Token, 'distinct').rejects(new Error('mongo down'))
+
+    await expect(TokenEligibilityCache.refresh(network)).to.be.rejectedWith('mongo down')
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.equal(tokenAddress)
+
+    distinctStub.restore()
+    await TokenEligibilityCache.refresh(network)
+    expect(TokenEligibilityCache.getChecksummed(network, tokenAddress)).to.be.undefined
+
+    expect(findSpy.calledTwice).to.be.true
+    expect(findGte(findSpy.secondCall)).to.equal(findGte(findSpy.firstCall))
+  })
+
   it('should not run concurrent refreshes for the same network', async () => {
     const distinctSpy = sandbox.spy(Models.Token, 'distinct')
 

--- a/test/unit/modules/tokenEligibilityCache.spec.ts
+++ b/test/unit/modules/tokenEligibilityCache.spec.ts
@@ -158,7 +158,6 @@ describe('Module: TokenEligibilityCache', () => {
     expect(tokenFindSpy.firstCall.args[0]).to.have.property('updatedAt')
   })
 
-
   const findGte = (call: sinon.SinonSpyCall): number => (call.args[0] as any).updatedAt.$gte.getTime()
 
   it('should retry a newly eligible plugin after a failed revalidation without advancing the cursor', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request improves the reliability of the `TokenEligibilityCache` by ensuring that the cursor used for incremental updates is only advanced after successful revalidation, preventing loss of unprocessed changes if a database error occurs. It also adds comprehensive tests to verify correct cursor handling and retry behavior after failures.

**Bug Fixes and Reliability Improvements:**

* Refactored cursor advancement logic in `TokenEligibilityCache`: the `pluginCursor` and `tokenCursor` are now only updated after all revalidations succeed, ensuring that failed revalidations (e.g., due to database errors) do not cause the cache to skip necessary updates. The cursor is advanced immediately only if there are no changed addresses; otherwise, it's updated after successful processing. [[1]](diffhunk://#diff-ee8940480926892a3bab90837f9afd1c2e8d0dc793399504e238ea0da21b22b5L92-R107) [[2]](diffhunk://#diff-ee8940480926892a3bab90837f9afd1c2e8d0dc793399504e238ea0da21b22b5R133-R134) [[3]](diffhunk://#diff-ee8940480926892a3bab90837f9afd1c2e8d0dc793399504e238ea0da21b22b5L150-R170) [[4]](diffhunk://#diff-ee8940480926892a3bab90837f9afd1c2e8d0dc793399504e238ea0da21b22b5R191-R192)

**Testing Enhancements:**

* Added new unit tests to verify that the cache correctly retries eligibility and revocation changes after a failed revalidation, and that the cursor is not advanced prematurely. These tests simulate database failures and confirm that the cache state remains consistent and retries as expected.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
