### PR TITLE
feat: Add external proposer Safes to SPP settings

### DIFF
--- a/src/handlers/pluginSettingHandler.ts
+++ b/src/handlers/pluginSettingHandler.ts
@@ -16,6 +16,7 @@ import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import type Plugin from '@models/schema/plugin'
 import type Setting from '@models/schema/setting'
+import type { ExternalProposer } from '@models/schema/setting'
 import DbOperations from '@models/utils/dbOperations'
 import { ProxyToken } from '@modules/proxyToken'
 import {
@@ -387,7 +388,11 @@ export const PluginSettingHandler = {
       }
     }
 
-    await PluginSettingHandler.attachExternalBodyConditions(relatedPlugin, formattedStages, network)
+    const externalProposers = await PluginSettingHandler.attachExternalBodyConditions(
+      relatedPlugin,
+      formattedStages,
+      network,
+    )
 
     const settingLog = {
       blockNumber,
@@ -400,6 +405,7 @@ export const PluginSettingHandler = {
       tokenAddress: relatedPlugin.tokenAddress,
       network,
       stages: formattedStages,
+      externalProposers,
     }
 
     const sppMetadata = await Models.LogMetadata.getLatestMetadata(network, pluginAddress)
@@ -462,35 +468,55 @@ export const PluginSettingHandler = {
   },
 
   /**
-   * Resolves and sets proposalCreationConditionAddress on external stage bodies. Only Safe bodies can have condition as of now.
-   * Internal bodies are skipped: they have their own Plugin document carrying the condition.
-   * Never throws - a failed resolution leaves the field null so settings indexing is not blocked.
+   * Resolves the SPP's proposal-creation conditions once and:
+   *  1. sets proposalCreationConditionAddress on each Safe stage body (mutates `stages` in place), and
+   *  2. returns the Safes that hold proposal-creation permission but are NOT stage bodies of the process
+   *     ("external proposers"), so the caller can persist them.
+   * Only Safe conditions are discoverable as of now. Internal bodies are skipped: they carry the
+   * condition on their own Plugin document.
+   * Never throws - a failed resolution returns undefined (as opposed to an empty array) so the
+   * caller can tell "resolution failed" apart from "resolved, zero proposers" and leave the field
+   * unset for a later retry (e.g. via migration) instead of persisting a false "no proposers".
    */
-  attachExternalBodyConditions: async (sppPlugin: Plugin, stages: any[], network: NetworksEnum): Promise<void> => {
+  attachExternalBodyConditions: async (
+    sppPlugin: Plugin,
+    stages: any[],
+    network: NetworksEnum,
+  ): Promise<ExternalProposer[] | undefined> => {
     try {
-      const externalBodies: any[] = []
-      for (const stage of stages) {
-        for (const stagePlugin of stage.plugins || []) {
-          if (stagePlugin.brandId === VotingBodyBrandIdentity.SAFE) externalBodies.push(stagePlugin)
-        }
-      }
-
-      if (!externalBodies.length) return
-
-      const conditions = await SppBodyConditionHelper.resolveExternalBodyConditions(
+      const conditions = await SppBodyConditionHelper.resolveSppProposerConditions(
         sppPlugin.proposalCreationConditionAddress,
-        externalBodies.map(body => body.address),
         network,
       )
 
-      for (const body of externalBodies) {
-        body.proposalCreationConditionAddress = conditions.get(body.address.toLowerCase()) ?? null
+      // Collect every stage body address while attaching the resolved condition to Safe bodies.
+      const bodyAddresses = new Set<string>()
+
+      for (const stage of stages) {
+        for (const stagePlugin of stage.plugins || []) {
+          bodyAddresses.add(stagePlugin.address.toLowerCase())
+
+          if (stagePlugin.brandId === VotingBodyBrandIdentity.SAFE) {
+            stagePlugin.proposalCreationConditionAddress =
+              conditions.get(stagePlugin.address.toLowerCase())?.conditionAddress ?? null
+          }
+        }
       }
+
+      const externalProposers: ExternalProposer[] = []
+      for (const [safeLowercase, { safeAddress, conditionAddress }] of conditions) {
+        if (!bodyAddresses.has(safeLowercase)) {
+          externalProposers.push({ address: safeAddress, proposalCreationConditionAddress: conditionAddress })
+        }
+      }
+
+      return externalProposers
     } catch (error) {
       logger.warn(
         'Failed to attach external body conditions',
         llo({ pluginAddress: sppPlugin.address, network, error }),
       )
+      return undefined
     }
   },
 

--- a/src/helpers/sppBodyCondition.ts
+++ b/src/helpers/sppBodyCondition.ts
@@ -11,30 +11,36 @@ const llo = logger.logMeta.bind(null, { service: 'helper:SppBodyCondition' })
 // RuledCondition rule id referencing a sub-condition contract
 const CONDITION_RULE_ID = 202n
 
+export interface SppProposerCondition {
+  /** Checksummed Safe address the sub-condition guards */
+  safeAddress: HexAddress
+  /** Checksummed sub-condition contract address (a SafeOwnerCondition) */
+  conditionAddress: HexAddress
+}
+
 const SppBodyConditionHelper = {
   /**
-   * Maps external SPP bodies (e.g. Safe wallets) to the condition contract deployed for them.
+   * Discovers every Safe granted proposal-creation permission on an SPP process.
    *
-   * External bodies are not OSx plugins, so no CREATE_PROPOSAL_PERMISSION grant exists for them.
-   * Their condition (e.g. SafeOwnerCondition) is only discoverable as a sub-condition rule
-   * (id 202) inside the SPP's own rule condition, matched back to a body via `safe()`.
+   * External bodies (and non-body proposers) are not OSx plugins, so no CREATE_PROPOSAL_PERMISSION
+   * grant exists for them. Each allowed Safe is only discoverable as a sub-condition rule (id 202)
+   * inside the SPP's own rule condition, whose guarded Safe is read via `safe()`.
+   *
+   * Returns every discovered Safe regardless of whether it is a stage body; the caller decides
+   * which are bodies and which are non-body "external proposers".
    *
    * @param sppRuleConditionAddress The SPP plugin's proposalCreationConditionAddress (a RuledCondition)
-   * @param externalBodyAddresses Stage body addresses without a Plugin document
    * @param network
-   * @returns Map of lowercased body address -> condition contract address
+   * @returns Map of lowercased Safe address -> { safeAddress, conditionAddress } (checksummed)
    */
-  async resolveExternalBodyConditions(
+  async resolveSppProposerConditions(
     sppRuleConditionAddress: HexAddress | null | undefined,
-    externalBodyAddresses: HexAddress[],
     network: NetworksEnum,
-  ): Promise<Map<string, HexAddress>> {
-    const resolved = new Map<string, HexAddress>()
+  ): Promise<Map<string, SppProposerCondition>> {
+    const resolved = new Map<string, SppProposerCondition>()
 
-    if (!externalBodyAddresses.length) return resolved
     if (!sppRuleConditionAddress || sppRuleConditionAddress === ZeroAddress) return resolved
 
-    const bodiesByLowercase = new Map(externalBodyAddresses.map(address => [address.toLowerCase(), address]))
     const provider = ProviderModule.getAnyRpcProvider(network)
 
     let rules: Array<{ id: bigint; value: bigint }>
@@ -45,7 +51,9 @@ const SppBodyConditionHelper = {
       )
     } catch (error) {
       logger.warn('Failed to read rules from SPP rule condition', llo({ sppRuleConditionAddress, network, error }))
-      return resolved
+      // Propagate: unlike "no rule condition" or "not a SafeOwnerCondition", this means we couldn't
+      // determine the proposers at all. The caller must not treat this the same as "zero proposers".
+      throw error
     }
 
     const subConditions: HexAddress[] = []
@@ -69,7 +77,7 @@ const SppBodyConditionHelper = {
           const safeAddress = await retryRequest(async () =>
             BottleneckModule.getNodeLimiter(network).schedule(async () => condition.safe()),
           )
-          return { conditionAddress, safeAddress: String(safeAddress).toLowerCase() }
+          return { conditionAddress, safeAddress: getAddress(String(safeAddress)) as HexAddress }
         } catch (_error) {
           // Not a SafeOwnerCondition (e.g. an internal body's member-list condition) - skip
           return null
@@ -78,8 +86,8 @@ const SppBodyConditionHelper = {
     )
 
     for (const probe of probes) {
-      if (probe && bodiesByLowercase.has(probe.safeAddress)) {
-        resolved.set(probe.safeAddress, probe.conditionAddress)
+      if (probe) {
+        resolved.set(probe.safeAddress.toLowerCase(), probe)
       }
     }
 

--- a/src/migrations/20260722120000-addSppExternalProposers.ts
+++ b/src/migrations/20260722120000-addSppExternalProposers.ts
@@ -1,0 +1,95 @@
+import { Models } from '@dbModels'
+import { PluginSettingHandler } from '@handlers/pluginSettingHandler'
+import logger from '@logger'
+import type Setting from '@models/schema/setting'
+import DBCrawler from '@models/utils/crawler'
+import { type IMigration, ISettingStatus } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: addSppExternalProposers' })
+
+const MIGRATION_NAME = '20260722120000-addSppExternalProposers'
+
+export const addSppExternalProposersMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: MIGRATION_NAME }))
+
+    let processed = 0
+    let updated = 0
+    let skipped = 0
+    let errored = 0
+
+    const crawler = new DBCrawler({
+      model: Models.Setting,
+      onDocument: async (setting: Setting) => {
+        processed++
+
+        const sppPlugin = await Models.Plugin.findByAddress(setting.pluginAddress, setting.network)
+        if (!sppPlugin?.proposalCreationConditionAddress) {
+          // No rule condition -> no external proposers possible. Set the field so it is not reprocessed.
+          await setting.update({ externalProposers: [] })
+          skipped++
+          logger.verbose(
+            'SPP plugin or its rule condition not found, no external proposers',
+            llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
+          )
+          return
+        }
+
+        const stages = setting.toObject().stages
+        const externalProposers = await PluginSettingHandler.attachExternalBodyConditions(
+          sppPlugin,
+          stages,
+          setting.network,
+        )
+
+        if (externalProposers === undefined) {
+          // Resolution failed - leave the field unset (not []) so this document is picked up again
+          // by a future backfill instead of being wrongly marked as "zero external proposers".
+          errored++
+          logger.warn(
+            'Failed to resolve external proposers, leaving unset for retry',
+            llo({ pluginAddress: setting.pluginAddress, network: setting.network }),
+          )
+          return
+        }
+
+        await setting.update({ externalProposers, stages })
+        updated++
+
+        logger.verbose('Processed document', llo({ pluginAddress: setting.pluginAddress, network: setting.network }))
+      },
+      onError: (error: any, document: any) => {
+        errored++
+        logger.error(
+          'Error backfilling external proposers',
+          llo({
+            error,
+            pluginAddress: document.pluginAddress,
+            network: document.network,
+          }),
+        )
+      },
+
+      where: {
+        status: ISettingStatus.active,
+        stages: { $exists: true, $ne: [] },
+        externalProposers: { $exists: false },
+      },
+      batchSize: 200,
+      concurrency: 10,
+    })
+
+    await crawler.crawl()
+
+    const summary = { migration: MIGRATION_NAME, processed, updated, skipped, errored }
+    if (errored > 0) {
+      logger.error('Migration completed with errors', llo(summary))
+    } else {
+      logger.info('Migration completed successfully', llo(summary))
+    }
+  },
+
+  stop: async () => {},
+}
+
+export default addSppExternalProposersMigration

--- a/src/migrations/20260722120000-addSppExternalProposers.ts
+++ b/src/migrations/20260722120000-addSppExternalProposers.ts
@@ -53,7 +53,7 @@ export const addSppExternalProposersMigration: IMigration = {
           return
         }
 
-        await setting.update({ externalProposers, stages })
+        await setting.update({ externalProposers })
         updated++
 
         logger.verbose('Processed document', llo({ pluginAddress: setting.pluginAddress, network: setting.network }))

--- a/src/models/schema/plugin.ts
+++ b/src/models/schema/plugin.ts
@@ -424,6 +424,7 @@ export default class Plugin extends Model {
           minDuration: 1,
           minProposerVotingPower: 1,
           stages: 1,
+          externalProposers: 1,
           votingEscrow: 1,
         },
       ),

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -185,6 +185,15 @@ export class PluginSetting {
   public proposalCreationConditionAddress?: HexAddress
 }
 
+// SPP plugin: a Safe granted proposal-creation permission that is NOT a stage body of the process.
+export class ExternalProposer {
+  @prop({ type: () => String, default: null })
+  public address!: HexAddress
+
+  @prop({ type: () => String, default: null })
+  public proposalCreationConditionAddress!: HexAddress
+}
+
 export class Stages {
   @prop({ type: () => Number })
   public stageIndex!: number
@@ -298,6 +307,12 @@ export default class Setting extends Model {
   // SPP plugin
   @prop({ type: () => [Stages], _id: false })
   public stages!: Stages[]
+
+  // SPP plugin: Safes granted proposal-creation permission that are NOT stage bodies.
+  // default: undefined (not []) so a failed resolution can leave the field unset for retry,
+  // distinguishable from a successful resolution that simply found zero external proposers.
+  @prop({ type: () => [ExternalProposer], _id: false, default: undefined })
+  public externalProposers!: ExternalProposer[]
 
   // Policy (Capital Router) plugin
   @prop({ type: () => PolicySetting, _id: false, default: undefined })

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -453,6 +453,7 @@ export default class Setting extends Model {
           minProposerVotingPower: 1,
           token: 1,
           stages: 1,
+          externalProposers: 1,
           votingEscrow: 1,
           policy: 1,
         },

--- a/src/models/utils/aggregation.ts
+++ b/src/models/utils/aggregation.ts
@@ -296,6 +296,7 @@ export const AggregationQueryHelper = {
             minDuration: 1,
             minProposerVotingPower: 1,
             stages: 1,
+            externalProposers: 1,
             votingEscrow: 1,
           },
         ),

--- a/src/types/aggregation.ts
+++ b/src/types/aggregation.ts
@@ -124,6 +124,7 @@ export interface IAggSettingProjectFields {
   minDuration?: 1
   minProposerVotingPower?: 1
   stages?: 1
+  externalProposers?: 1
   votingEscrow?: 1
   policy?: 1
 }

--- a/test/unit/handlers/pluginSettingHandler.spec.ts
+++ b/test/unit/handlers/pluginSettingHandler.spec.ts
@@ -1146,9 +1146,7 @@ describe('Indexer: PluginSettingHandler', () => {
       sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
       sandbox.stub(PluginSettingHandler, 'isSupported').resolves()
 
-      const externalProposers = [
-        { address: '0xOrphanSafe', proposalCreationConditionAddress: '0xorphan-condition' },
-      ]
+      const externalProposers = [{ address: '0xOrphanSafe', proposalCreationConditionAddress: '0xorphan-condition' }]
       const attachStub = sandbox
         .stub(PluginSettingHandler, 'attachExternalBodyConditions')
         .resolves(externalProposers as any)

--- a/test/unit/handlers/pluginSettingHandler.spec.ts
+++ b/test/unit/handlers/pluginSettingHandler.spec.ts
@@ -1142,17 +1142,26 @@ describe('Indexer: PluginSettingHandler', () => {
       sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(1620000000)
       sandbox.stub(Models.LogMetadata, 'getLatestMetadata').resolves(null)
       sandbox.stub(PluginDetector, 'detectAddressType').resolves(VotingBodyBrandIdentity.SAFE)
-      sandbox.stub(DbOperations, 'createDocument')
+      const createDocumentStub = sandbox.stub(DbOperations, 'createDocument')
       sandbox.stub(PluginSettingHandler, 'pairSppPlugins').resolves()
       sandbox.stub(PluginSettingHandler, 'isSupported').resolves()
 
-      const attachStub = sandbox.stub(PluginSettingHandler, 'attachExternalBodyConditions').resolves()
+      const externalProposers = [
+        { address: '0xOrphanSafe', proposalCreationConditionAddress: '0xorphan-condition' },
+      ]
+      const attachStub = sandbox
+        .stub(PluginSettingHandler, 'attachExternalBodyConditions')
+        .resolves(externalProposers as any)
 
       await PluginSettingHandler.sppSettingsUpdated(parsedEvent, info)
 
       expect(attachStub.calledOnce).to.be.true
       expect(attachStub.firstCall.args[0]).to.deep.equal(plugin)
       expect(attachStub.firstCall.args[2]).to.equal(info.network)
+
+      // the returned external proposers are persisted onto the new setting
+      expect(createDocumentStub.calledOnce).to.be.true
+      expect(createDocumentStub.firstCall.args[1].externalProposers).to.deep.equal(externalProposers)
     })
   })
 
@@ -1163,7 +1172,7 @@ describe('Indexer: PluginSettingHandler', () => {
       proposalCreationConditionAddress: '0xrule-condition',
     } as any
 
-    it('should set proposalCreationConditionAddress on external safe bodies', async () => {
+    it('should set proposalCreationConditionAddress on safe bodies and return no proposers when all discovered safes are bodies', async () => {
       const stages = [
         {
           plugins: [
@@ -1174,14 +1183,37 @@ describe('Indexer: PluginSettingHandler', () => {
       ]
 
       const resolveStub = sandbox
-        .stub(SppBodyConditionHelper, 'resolveExternalBodyConditions')
-        .resolves(new Map([['0xsafebody', '0xsafe-condition']]))
+        .stub(SppBodyConditionHelper, 'resolveSppProposerConditions')
+        .resolves(new Map([['0xsafebody', { safeAddress: '0xSafeBody', conditionAddress: '0xsafe-condition' }]]))
 
-      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+      const result = await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
 
-      expect(resolveStub.calledOnceWith('0xrule-condition', ['0xSafeBody'], network)).to.be.true
+      expect(resolveStub.calledOnceWith('0xrule-condition', network)).to.be.true
       expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.equal('0xsafe-condition')
       expect((stages[0].plugins[1] as any).proposalCreationConditionAddress).to.be.undefined
+      expect(result).to.deep.equal([])
+    })
+
+    it('should return discovered safes that are not stage bodies as external proposers', async () => {
+      const stages = [
+        {
+          plugins: [{ address: '0xSafeBody', brandId: VotingBodyBrandIdentity.SAFE }],
+        },
+      ]
+
+      sandbox.stub(SppBodyConditionHelper, 'resolveSppProposerConditions').resolves(
+        new Map([
+          ['0xsafebody', { safeAddress: '0xSafeBody', conditionAddress: '0xbody-condition' }],
+          ['0xorphansafe', { safeAddress: '0xOrphanSafe', conditionAddress: '0xorphan-condition' }],
+        ]),
+      )
+
+      const result = await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+
+      expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.equal('0xbody-condition')
+      expect(result).to.deep.equal([
+        { address: '0xOrphanSafe', proposalCreationConditionAddress: '0xorphan-condition' },
+      ])
     })
 
     it('should set null for unresolved safe bodies and skip non-safe bodies', async () => {
@@ -1194,28 +1226,33 @@ describe('Indexer: PluginSettingHandler', () => {
         },
       ]
 
-      sandbox.stub(SppBodyConditionHelper, 'resolveExternalBodyConditions').resolves(new Map())
+      sandbox.stub(SppBodyConditionHelper, 'resolveSppProposerConditions').resolves(new Map())
 
-      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+      const result = await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
 
+      // resolver returns an empty map -> safe body reset to null
       expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.be.null
       // non-safe bodies are untouched in memory; the schema default persists null for them
       expect((stages[0].plugins[1] as any).proposalCreationConditionAddress).to.be.undefined
+      expect(result).to.deep.equal([])
     })
 
-    it('should not throw when the resolver fails', async () => {
+    it('should not throw and return undefined when the resolver fails, leaving body conditions untouched', async () => {
       const stages = [
         {
           plugins: [{ address: '0xSafeBody', brandId: VotingBodyBrandIdentity.SAFE }],
         },
       ]
 
-      sandbox.stub(SppBodyConditionHelper, 'resolveExternalBodyConditions').rejects(new Error('rpc down'))
+      sandbox.stub(SppBodyConditionHelper, 'resolveSppProposerConditions').rejects(new Error('rpc down'))
       const loggerStub = sandbox.stub(logger, 'warn')
 
-      await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
+      const result = await PluginSettingHandler.attachExternalBodyConditions(sppPlugin, stages, network)
 
       expect(loggerStub.calledOnce).to.be.true
+      // undefined (not []) so the caller can tell "failed" apart from "resolved, zero proposers"
+      expect(result).to.be.undefined
+      expect((stages[0].plugins[0] as any).proposalCreationConditionAddress).to.be.undefined
     })
   })
 

--- a/test/unit/helpers/proxyContract.spec.ts
+++ b/test/unit/helpers/proxyContract.spec.ts
@@ -394,8 +394,13 @@ describe('Helpers:ProxyContractHelper', () => {
       expect(result).to.be.null
       expect(stubLogger.called).to.be.true
 
+      // Assert the message is among the warnings (not necessarily first) so an unrelated
+      // logger.warn (e.g. the toobusy event-loop-lag monitor) can't flake this by landing first.
       const loggerCalls = stubLogger.getCalls()
-      expect(loggerCalls[0].firstArg).to.be.eq('Maximum recursion depth reached for proxy resolution')
+      const warnedMaxDepth = loggerCalls.some(
+        call => call.firstArg === 'Maximum recursion depth reached for proxy resolution',
+      )
+      expect(warnedMaxDepth).to.be.true
     })
 
     it('should handle circular reference in beacon proxies', async () => {
@@ -426,9 +431,13 @@ describe('Helpers:ProxyContractHelper', () => {
       expect(result).to.be.null
       expect(stubLogger.called).to.be.true
 
-      // Check if any of the logger calls contains the expected message
+      // Check if any of the logger calls contains the expected message (not necessarily first,
+      // so an unrelated logger.warn such as the toobusy event-loop-lag monitor can't flake this).
       const loggerCalls = stubLogger.getCalls()
-      expect(loggerCalls[0].firstArg).to.be.eq('Circular reference detected in proxy resolution')
+      const warnedCircular = loggerCalls.some(
+        call => call.firstArg === 'Circular reference detected in proxy resolution',
+      )
+      expect(warnedCircular).to.be.true
     })
   })
 })

--- a/test/unit/helpers/sppBodyCondition.spec.ts
+++ b/test/unit/helpers/sppBodyCondition.spec.ts
@@ -48,8 +48,8 @@ describe('Helpers: SppBodyConditionHelper', () => {
     return MockedHelper
   }
 
-  describe('resolveExternalBodyConditions', () => {
-    it('should map a safe body to its SafeOwnerCondition and skip internal conditions', async () => {
+  describe('resolveSppProposerConditions', () => {
+    it('should map a discovered safe to its SafeOwnerCondition and skip internal conditions', async () => {
       const getRulesStub = sandbox.stub().resolves(buildRules())
       const internalSafeStub = sandbox.stub().rejects(new Error('execution reverted'))
       const safeStub = sandbox.stub().resolves(SAFE_BODY_ADDRESS)
@@ -60,85 +60,58 @@ describe('Helpers: SppBodyConditionHelper', () => {
         [getAddress(SAFE_BODY_CONDITION)]: { safe: safeStub },
       })
 
-      const result = await helper.resolveExternalBodyConditions(
-        RULE_CONDITION_ADDRESS,
-        [SAFE_BODY_ADDRESS],
-        NetworksEnum.ethereumSepolia,
-      )
+      const result = await helper.resolveSppProposerConditions(RULE_CONDITION_ADDRESS, NetworksEnum.ethereumSepolia)
 
       expect(result.size).to.equal(1)
-      expect(result.get(SAFE_BODY_ADDRESS.toLowerCase())).to.equal(getAddress(SAFE_BODY_CONDITION))
+      expect(result.get(SAFE_BODY_ADDRESS.toLowerCase())).to.deep.equal({
+        safeAddress: getAddress(SAFE_BODY_ADDRESS),
+        conditionAddress: getAddress(SAFE_BODY_CONDITION),
+      })
       expect(getRulesStub.calledOnce).to.be.true
+    })
+
+    it('should return every discovered safe regardless of whether it is a stage body', async () => {
+      const secondSafeCondition = getAddress('0x1111111111111111111111111111111111111111')
+      const secondSafeAddress = getAddress('0x2222222222222222222222222222222222222222')
+
+      const getRulesStub = sandbox.stub().resolves([
+        { id: CONDITION_RULE_ID, op: 1n, value: BigInt(SAFE_BODY_CONDITION), permissionId: 0n },
+        { id: CONDITION_RULE_ID, op: 1n, value: BigInt(secondSafeCondition), permissionId: 0n },
+      ])
+
+      const helper = mockHelper({
+        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
+        [getAddress(SAFE_BODY_CONDITION)]: { safe: sandbox.stub().resolves(SAFE_BODY_ADDRESS) },
+        [secondSafeCondition]: { safe: sandbox.stub().resolves(secondSafeAddress) },
+      })
+
+      const result = await helper.resolveSppProposerConditions(RULE_CONDITION_ADDRESS, NetworksEnum.ethereumSepolia)
+
+      expect(result.size).to.equal(2)
+      expect(result.get(SAFE_BODY_ADDRESS.toLowerCase())?.conditionAddress).to.equal(getAddress(SAFE_BODY_CONDITION))
+      expect(result.get(secondSafeAddress.toLowerCase())?.conditionAddress).to.equal(secondSafeCondition)
     })
 
     it('should return an empty map when the rule condition address is missing or zero', async () => {
       const helper = mockHelper({})
 
-      const missing = await helper.resolveExternalBodyConditions(
-        null,
-        [SAFE_BODY_ADDRESS],
-        NetworksEnum.ethereumSepolia,
-      )
-      const zero = await helper.resolveExternalBodyConditions(
-        ZeroAddress,
-        [SAFE_BODY_ADDRESS],
-        NetworksEnum.ethereumSepolia,
-      )
+      const missing = await helper.resolveSppProposerConditions(null, NetworksEnum.ethereumSepolia)
+      const zero = await helper.resolveSppProposerConditions(ZeroAddress, NetworksEnum.ethereumSepolia)
 
       expect(missing.size).to.equal(0)
       expect(zero.size).to.equal(0)
     })
 
-    it('should return an empty map when there are no external bodies', async () => {
-      const getRulesStub = sandbox.stub().resolves(buildRules())
+    it('should throw when getRules fails, instead of returning an empty map', async () => {
+      const rpcError = new Error('rpc error')
+      const getRulesStub = sandbox.stub().rejects(rpcError)
       const helper = mockHelper({
         [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
       })
 
-      const result = await helper.resolveExternalBodyConditions(
-        RULE_CONDITION_ADDRESS,
-        [],
-        NetworksEnum.ethereumSepolia,
-      )
-
-      expect(result.size).to.equal(0)
-      expect(getRulesStub.notCalled).to.be.true
-    })
-
-    it('should return an empty map when getRules fails', async () => {
-      const getRulesStub = sandbox.stub().rejects(new Error('rpc error'))
-      const helper = mockHelper({
-        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
-      })
-
-      const result = await helper.resolveExternalBodyConditions(
-        RULE_CONDITION_ADDRESS,
-        [SAFE_BODY_ADDRESS],
-        NetworksEnum.ethereumSepolia,
-      )
-
-      expect(result.size).to.equal(0)
-    })
-
-    it('should leave bodies unmapped when no sub-condition matches them', async () => {
-      const otherSafe = '0x1111111111111111111111111111111111111111'
-      const getRulesStub = sandbox.stub().resolves(buildRules())
-      const internalSafeStub = sandbox.stub().rejects(new Error('execution reverted'))
-      const safeStub = sandbox.stub().resolves(otherSafe)
-
-      const helper = mockHelper({
-        [getAddress(RULE_CONDITION_ADDRESS)]: { getRules: getRulesStub },
-        [getAddress(INTERNAL_BODY_CONDITION)]: { safe: internalSafeStub },
-        [getAddress(SAFE_BODY_CONDITION)]: { safe: safeStub },
-      })
-
-      const result = await helper.resolveExternalBodyConditions(
-        RULE_CONDITION_ADDRESS,
-        [SAFE_BODY_ADDRESS],
-        NetworksEnum.ethereumSepolia,
-      )
-
-      expect(result.size).to.equal(0)
+      await expect(
+        helper.resolveSppProposerConditions(RULE_CONDITION_ADDRESS, NetworksEnum.ethereumSepolia),
+      ).to.be.rejectedWith(rpcError)
     })
   })
 })


### PR DESCRIPTION
## 📝 Summary

An SPP (Staged Proposal Processor) process gates proposal creation through a single on-chain `RuledCondition`. A Safe can be granted permission to create proposals for a process **without being a body of any stage** in that process. The backend already resolved every such Safe internally (by walking the SPP's rule condition), but discarded any that didn't match a stage body. This PR persists those "external proposer" Safes so the backend has a record of who else can create proposals for a process.

## 🔄 What Changed

- Added `externalProposers` field to the SPP `Setting` document (sibling to `stages`), storing `{ address, proposalCreationConditionAddress }` for Safes with proposal-creation permission that are **not** stage bodies.
- Broadened `SppBodyConditionHelper.resolveExternalBodyConditions` → `resolveSppProposerConditions` to discover every Safe granted proposal-creation permission on an SPP, not just ones matching a stage body.
- `PluginSettingHandler.attachExternalBodyConditions` now returns the discovered non-body proposers (it still attaches conditions to Safe stage bodies as before). A failed resolution now returns `undefined` (not `[]`) so it's distinguishable from "resolved, zero proposers" and can be retried by a later backfill instead of being silently marked as done.
- Added backfill migration `20260722120000-addSppExternalProposers` to populate `externalProposers` on existing active SPP settings.
- Threaded `externalProposers` into the existing read aggregations that already project `stages` (`AggregationQueryHelper.plugin`, `Plugin.findByDaoAddressesWithDetails`, `Setting.findSetting`) so it's exposed alongside the existing SPP settings data.

Out of scope for this PR: wiring `externalProposers` into `canCreateProposal` eligibility checks (deferred as a follow-up).

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)