### PR TITLE
fix(proposalMetrics): handle missing minApprovals gracefully in metrics logging

### DIFF
--- a/src/services/aragon-dao/proposalMetrics.ts
+++ b/src/services/aragon-dao/proposalMetrics.ts
@@ -26,6 +26,7 @@ export const ProposalMetrics = {
 
         if (!proposal.settings?.minApprovals) {
           logger.warn('MinApprovals not found - multisig metrics', llo({ proposalIndex, pluginAddress, network }))
+          return
         }
 
         const votes = await Models.Vote.findVotes({ proposalIndex, pluginAddress, network }, { session })

--- a/test/unit/services/aragon-dao/proposalMetrics.spec.ts
+++ b/test/unit/services/aragon-dao/proposalMetrics.spec.ts
@@ -52,12 +52,12 @@ describe('AragonDao:ProposalMetrics', () => {
       expect(loggerStub.calledOnceWith('Proposal not found - multisig metrics' as any)).to.be.true
     })
 
-    it('should log an error if `minApprovals` is missing in the proposal settings', async () => {
+    it('should log a warning and return early if `minApprovals` is missing in the proposal settings', async () => {
       const proposal = { id: 'proposal-id', settings: {} }
       sandbox.stub(Models.Proposal, 'findByProposalIndex').resolves(proposal as any)
-      sandbox.stub(Models.Vote, 'findVotes').resolves([])
+      const findVotesStub = sandbox.stub(Models.Vote, 'findVotes').resolves([])
       const loggerWarnStub = sandbox.stub(logger, 'warn')
-      const loggerStub = sandbox.stub(logger, 'error')
+      const loggerErrorStub = sandbox.stub(logger, 'error')
 
       await ProposalMetrics.proposalMultisigMetrics({
         proposalIndex: '1',
@@ -66,7 +66,8 @@ describe('AragonDao:ProposalMetrics', () => {
       })
 
       expect(loggerWarnStub.calledOnceWith('MinApprovals not found - multisig metrics' as any)).to.be.true
-      expect(loggerStub.calledWith('Error updating multisig metrics' as any)).to.be.true
+      expect(findVotesStub.called).to.be.false
+      expect(loggerErrorStub.called).to.be.false
     })
 
     it('should throw', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request makes a small change to the `ProposalMetrics` service. The change ensures that the function returns early if `minApprovals` is not found in the proposal settings, preventing further execution in this case.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
