### PR TITLE
fix(api): reject non-field sort values in pagination validation

### DIFF
--- a/src/helpers/validationSchema.ts
+++ b/src/helpers/validationSchema.ts
@@ -118,7 +118,11 @@ const ValidationSchema = {
     pageSize: Joi.number().integer().min(1).max(50).optional().default(10),
     page: Joi.number().integer().greater(-1).min(1).optional().default(1),
     order: Joi.string().valid('asc', 'desc').optional().default('asc'),
-    sort: Joi.string().optional().default('createdAt'),
+    sort: Joi.string()
+      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
+      .invalid('__proto__', 'prototype', 'constructor')
+      .optional()
+      .default('createdAt'),
     startDateProp: Joi.string()
       .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
       .invalid('__proto__', 'prototype', 'constructor')

--- a/src/helpers/validationSchema.ts
+++ b/src/helpers/validationSchema.ts
@@ -9,6 +9,10 @@ import { ErrorKeyEnum, NetworksEnum } from '@types'
 import { getAddress } from 'ethers'
 import Joi from 'joi'
 
+// Dot-separated document field path, each segment starting with a letter.
+// Shared by the sort/startDateProp/endDateProp pagination params so they stay aligned.
+const FIELD_PATH_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*$/
+
 const ValidationSchema = {
   Joi,
   joiUuid: Joi.string().regex(/^[0-9a-fA-F]{24}$/),
@@ -119,18 +123,12 @@ const ValidationSchema = {
     page: Joi.number().integer().greater(-1).min(1).optional().default(1),
     order: Joi.string().valid('asc', 'desc').optional().default('asc'),
     sort: Joi.string()
-      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
+      .pattern(FIELD_PATH_PATTERN)
       .invalid('__proto__', 'prototype', 'constructor')
       .optional()
       .default('createdAt'),
-    startDateProp: Joi.string()
-      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
-      .invalid('__proto__', 'prototype', 'constructor')
-      .optional(),
-    endDateProp: Joi.string()
-      .pattern(/^[a-zA-Z][a-zA-Z0-9_.]*$/)
-      .invalid('__proto__', 'prototype', 'constructor')
-      .optional(),
+    startDateProp: Joi.string().pattern(FIELD_PATH_PATTERN).invalid('__proto__', 'prototype', 'constructor').optional(),
+    endDateProp: Joi.string().pattern(FIELD_PATH_PATTERN).invalid('__proto__', 'prototype', 'constructor').optional(),
     startDate: Joi.alternatives()
       .try(Joi.number(), Joi.date())
       .optional()

--- a/test/unit/helpers/validationSchema.spec.ts
+++ b/test/unit/helpers/validationSchema.spec.ts
@@ -199,7 +199,7 @@ describe('Helpers:ValidationSchema', () => {
     })
 
     it('generateJoiPagination rejects operator and prototype sorts', async () => {
-      for (const sort of ['$gt', '$where', '.createdAt', '1createdAt']) {
+      for (const sort of ['$gt', '$where', '.createdAt', '1createdAt', 'metrics.', 'metrics..tvlUSD', 'metrics.$gt']) {
         await expect(PaginationSchema.getPagination.validateAsync({ sort })).to.be.rejectedWith(
           Error,
           '"sort" with value',
@@ -211,6 +211,24 @@ describe('Helpers:ValidationSchema', () => {
           Error,
           '"sort" contains an invalid value',
         )
+      }
+    })
+
+    it('generateJoiPagination applies the same field path rules to date props', async () => {
+      const result = await PaginationSchema.getPagination.validateAsync({
+        startDateProp: 'blockTimestamp',
+        endDateProp: 'metrics.updatedAt',
+      })
+      expect(result.startDateProp).to.eq('blockTimestamp')
+      expect(result.endDateProp).to.eq('metrics.updatedAt')
+
+      for (const prop of ['startDateProp', 'endDateProp']) {
+        for (const value of ['$gt', 'metrics.', 'metrics..updatedAt']) {
+          await expect(PaginationSchema.getPagination.validateAsync({ [prop]: value })).to.be.rejectedWith(
+            Error,
+            `"${prop}" with value`,
+          )
+        }
       }
     })
 

--- a/test/unit/helpers/validationSchema.spec.ts
+++ b/test/unit/helpers/validationSchema.spec.ts
@@ -190,6 +190,30 @@ describe('Helpers:ValidationSchema', () => {
       expect(result.order).to.eq('asc')
     })
 
+    it('generateJoiPagination accepts field name sorts', async () => {
+      const result = await PaginationSchema.getPagination.validateAsync({ sort: 'metrics.tvlUSD' })
+      expect(result.sort).to.eq('metrics.tvlUSD')
+
+      const defaulted = await PaginationSchema.getPagination.validateAsync({})
+      expect(defaulted.sort).to.eq('createdAt')
+    })
+
+    it('generateJoiPagination rejects operator and prototype sorts', async () => {
+      for (const sort of ['$gt', '$where', '.createdAt', '1createdAt']) {
+        await expect(PaginationSchema.getPagination.validateAsync({ sort })).to.be.rejectedWith(
+          Error,
+          '"sort" with value',
+        )
+      }
+
+      for (const sort of ['__proto__', 'prototype', 'constructor']) {
+        await expect(PaginationSchema.getPagination.validateAsync({ sort })).to.be.rejectedWith(
+          Error,
+          '"sort" contains an invalid value',
+        )
+      }
+    })
+
     it('joiSlug', async () => {
       const validSlug = 'pluginType-123'
       const result = await ValidationSchema.joiSlug.validateAsync(validSlug)


### PR DESCRIPTION
## Summary

Paginated endpoints accepted any string as `sort`. The value is used as a Mongo `$sort` key, so a non-field value such as `$gt` reached the database and failed the request with a 500 that carried the raw driver response — including internal cluster state — into the response, logs, and alert notifications.

`sort` now uses the same guard already applied to the sibling `startDateProp` / `endDateProp` fields in `generateJoiPagination`: a field-name pattern plus the prototype-pollution denylist. Invalid values are rejected as a 400 before reaching the database.

An enum allowlist was not used because `generateJoiPagination` is shared by every paginated endpoint and each has a different sortable set. All 20 configured `paginationSort` defaults satisfy the pattern, including dotted paths like `metrics.tvlUSD`.

## Testing

`test/unit/helpers/validationSchema.spec.ts` — two cases added, covering accepted field names (including dotted paths and the default) and rejected values (`$gt`, `$where`, leading dot, leading digit, and the prototype keys). Suite passes.

## Notes

Found via the `errors_production` alert on 26 July 2026. The same burst also showed the campaign upload endpoint returning 500 for invalid file input; that is not addressed here.

Resolves APP-1024