### PR TITLE
feat: enrich permission entities

### DIFF
--- a/src/models/schema/daoPermission.ts
+++ b/src/models/schema/daoPermission.ts
@@ -1,5 +1,6 @@
 import { assert } from '@errors'
 import ModelUtils from '@models/utils/models'
+import { ALLOW_FLAG, PermissionEntityEnrichment } from '@modules/permissionEntities'
 import { index, modelOptions, prop } from '@typegoose/typegoose'
 import {
   HexAddress,
@@ -18,7 +19,6 @@ import * as _ from 'lodash'
 import { Model, type SaveOptions } from 'mongoose'
 
 const customName = ICollectionNames.DaoPermission
-const ALLOW_FLAG = '0x0000000000000000000000000000000000000002'
 
 @modelOptions({
   schemaOptions: {
@@ -380,7 +380,7 @@ export default class DaoPermission extends Model {
         totalPages,
         totalRecords: _totalRecords,
       },
-      data: data as IPermissionResponse[],
+      data: await PermissionEntityEnrichment.enrich(this.db, data as IPermissionResponse[], filter),
     }
   }
 }

--- a/src/modules/permissionEntities.ts
+++ b/src/modules/permissionEntities.ts
@@ -1,0 +1,359 @@
+import type { IPermissionEntityRef } from '@src/types/permission'
+import {
+  type HexAddress,
+  ICollectionNames,
+  type IPermissionResponse,
+  type IPluginInterfaceType,
+  IPluginStatus,
+  ISettingStatus,
+  type NetworksEnum,
+} from '@types'
+import type { Connection } from 'mongoose'
+
+export const ALLOW_FLAG = '0x0000000000000000000000000000000000000002'
+
+type PermissionEntityRole = NonNullable<IPermissionEntityRef['role']>
+
+interface PermissionEntityDaoDoc {
+  address?: HexAddress
+  name?: string
+  avatar?: string
+  linkedAccounts?: HexAddress[]
+  parentAccount?: HexAddress | null
+}
+
+interface PermissionEntitySubPluginDoc {
+  addresses?: HexAddress[]
+  stageIndex?: number
+}
+
+interface PermissionEntityPluginDoc {
+  blockNumber?: number
+  address?: HexAddress
+  daoAddress?: HexAddress
+  status?: IPluginStatus
+  interfaceType?: IPluginInterfaceType
+  name?: string
+  isBody?: boolean
+  isSubPlugin?: boolean
+  parentPlugin?: HexAddress
+  stageIndex?: number
+  subPlugins?: PermissionEntitySubPluginDoc[]
+  conditionAddress?: HexAddress
+  proposalCreationConditionAddress?: HexAddress
+}
+
+interface PermissionEntityExternalProposerDoc {
+  address?: HexAddress
+  proposalCreationConditionAddress?: HexAddress
+}
+
+interface PermissionEntityStagePluginDoc {
+  address?: HexAddress
+  proposalCreationConditionAddress?: HexAddress
+}
+
+interface PermissionEntityStageDoc {
+  stageIndex?: number
+  plugins?: PermissionEntityStagePluginDoc[]
+}
+
+interface PermissionEntitySettingDoc {
+  pluginAddress?: HexAddress
+  externalProposers?: PermissionEntityExternalProposerDoc[]
+  stages?: PermissionEntityStageDoc[]
+}
+
+interface PermissionEntityContractDoc {
+  address?: HexAddress
+  bytecode?: string
+}
+
+interface PermissionEntityParentContext {
+  address: HexAddress
+  name?: string
+  interfaceType?: IPluginInterfaceType
+  stageIndex?: number
+}
+
+interface PermissionEntityConditionContext {
+  parent?: PermissionEntityParentContext
+  status?: IPermissionEntityRef['status']
+}
+
+export const PermissionEntityEnrichment = {
+  pluginLifecycleStatus(status?: IPluginStatus): IPermissionEntityRef['status'] {
+    if (status === IPluginStatus.installed) return 'installed'
+    if (status === IPluginStatus.uninstalled) return 'uninstalled'
+    if (status) return 'historical'
+    return 'unknown'
+  },
+
+  createDaoEntity(address: HexAddress, role: PermissionEntityRole, dao?: PermissionEntityDaoDoc) {
+    const entity: IPermissionEntityRef = { address, layer: 'dao', role }
+    if (dao?.name) entity.label = dao.name
+    if (dao?.avatar) entity.avatarSrc = dao.avatar
+    return entity
+  },
+
+  createPluginEntity(
+    address: HexAddress,
+    role: PermissionEntityRole,
+    plugin: PermissionEntityPluginDoc,
+    layer: 'topLevelPlugin' | 'historicalPlugin',
+  ) {
+    const entity: IPermissionEntityRef = {
+      address,
+      layer,
+      role,
+      status: this.pluginLifecycleStatus(plugin.status),
+    }
+    const fallbackLabel = plugin.interfaceType || 'Plugin'
+    entity.label =
+      layer === 'historicalPlugin' ? `Historical ${plugin.name || fallbackLabel}` : plugin.name || fallbackLabel
+    if (plugin.interfaceType) entity.interfaceType = plugin.interfaceType
+    return entity
+  },
+
+  createParentedEntity(
+    address: HexAddress,
+    role: PermissionEntityRole,
+    layer: 'processInternal' | 'condition' | 'externalActor',
+    parent?: PermissionEntityParentContext,
+    plugin?: PermissionEntityPluginDoc,
+    status?: IPermissionEntityRef['status'],
+  ) {
+    const entity: IPermissionEntityRef = { address, layer, role }
+    if (layer === 'processInternal') entity.label = 'Process internal'
+    if (layer === 'condition') entity.label = address === ALLOW_FLAG ? 'Allow flag' : 'Condition contract'
+    if (layer === 'externalActor') entity.label = 'External proposer'
+    entity.status = status || (layer === 'condition' && address === ALLOW_FLAG ? 'unknown' : 'installed')
+    if (plugin?.interfaceType) entity.interfaceType = plugin.interfaceType
+    if (parent?.address) entity.parentPluginAddress = parent.address
+    if (parent?.name) entity.parentPluginName = parent.name
+    if (parent?.interfaceType) entity.parentInterfaceType = parent.interfaceType
+    if (parent?.stageIndex !== undefined) entity.stageIndex = parent.stageIndex
+    return entity
+  },
+
+  createFallbackEntity(address: HexAddress, role: PermissionEntityRole, contract?: PermissionEntityContractDoc) {
+    if (contract?.bytecode && contract.bytecode !== '0x') {
+      return {
+        address,
+        layer: 'contract',
+        label: 'Unresolved contract',
+        status: 'unknown',
+        role,
+      } satisfies IPermissionEntityRef
+    }
+    return {
+      address,
+      layer: 'unknown',
+      label: 'Unknown address',
+      status: 'unknown',
+      role,
+    } satisfies IPermissionEntityRef
+  },
+
+  async enrich(
+    db: Connection,
+    rows: IPermissionResponse[],
+    filter: { daoAddress: HexAddress; network: NetworksEnum },
+  ): Promise<IPermissionResponse[]> {
+    if (rows.length === 0) return rows
+
+    const addresses = [
+      ...new Set(
+        rows
+          .flatMap(row => [row.whoAddress, row.whereAddress, row.conditionAddress || ALLOW_FLAG])
+          .filter((address): address is HexAddress => Boolean(address)),
+      ),
+    ]
+    const daoLookupAddresses = [...new Set([...addresses, filter.daoAddress])]
+
+    const [daoDocs, plugins, settings, contracts] = await Promise.all([
+      db
+        .collection<PermissionEntityDaoDoc>(ICollectionNames.Dao)
+        .find({ network: filter.network, address: { $in: daoLookupAddresses } })
+        .toArray(),
+      db
+        .collection<PermissionEntityPluginDoc>(ICollectionNames.Plugin)
+        .find({ daoAddress: filter.daoAddress, network: filter.network })
+        .toArray(),
+      db
+        .collection<PermissionEntitySettingDoc>(ICollectionNames.Setting)
+        .find({ daoAddress: filter.daoAddress, network: filter.network, status: ISettingStatus.active })
+        .toArray(),
+      db
+        .collection<PermissionEntityContractDoc>(ICollectionNames.Contract)
+        .find({ network: filter.network, address: { $in: addresses } })
+        .toArray(),
+    ])
+
+    const daoByAddress = new Map<string, PermissionEntityDaoDoc>()
+    for (const dao of daoDocs) {
+      if (dao.address) daoByAddress.set(dao.address, dao)
+    }
+
+    const rootDao = daoByAddress.get(filter.daoAddress)
+    const daoEntityAddresses = new Set(
+      [filter.daoAddress, rootDao?.parentAccount, ...(rootDao?.linkedAccounts || [])].filter(
+        (address): address is string => Boolean(address),
+      ),
+    )
+
+    const sortedPlugins = [...plugins].sort((left, right) => {
+      const statusDelta =
+        (right.status === IPluginStatus.installed ? 1 : 0) - (left.status === IPluginStatus.installed ? 1 : 0)
+      if (statusDelta !== 0) return statusDelta
+      return (right.blockNumber || 0) - (left.blockNumber || 0)
+    })
+    const pluginByAddress = new Map<string, PermissionEntityPluginDoc>()
+    for (const plugin of sortedPlugins) {
+      if (plugin.address && !pluginByAddress.has(plugin.address)) pluginByAddress.set(plugin.address, plugin)
+    }
+
+    const contractByAddress = new Map<string, PermissionEntityContractDoc>()
+    for (const contract of contracts) {
+      if (contract.address) contractByAddress.set(contract.address, contract)
+    }
+
+    const parentContext = (
+      plugin?: PermissionEntityPluginDoc,
+      stageIndex?: number,
+    ): PermissionEntityParentContext | undefined => {
+      if (!plugin?.address) return undefined
+      return {
+        address: plugin.address,
+        name: plugin.name,
+        interfaceType: plugin.interfaceType,
+        stageIndex,
+      }
+    }
+
+    const processInternalByAddress = new Map<
+      string,
+      { parent?: PermissionEntityParentContext; plugin?: PermissionEntityPluginDoc }
+    >()
+    const conditionByAddress = new Map<string, PermissionEntityConditionContext>()
+    const externalActorByAddress = new Map<string, PermissionEntityParentContext | undefined>()
+
+    for (const plugin of sortedPlugins) {
+      const parentPlugin = plugin.parentPlugin ? pluginByAddress.get(plugin.parentPlugin) : undefined
+
+      if (
+        plugin.status === IPluginStatus.installed &&
+        plugin.address &&
+        (plugin.isBody || plugin.isSubPlugin || plugin.parentPlugin)
+      ) {
+        processInternalByAddress.set(plugin.address, {
+          parent: parentContext(parentPlugin, plugin.stageIndex),
+          plugin,
+        })
+      }
+
+      if (plugin.status === IPluginStatus.installed) {
+        for (const subPlugin of plugin.subPlugins || []) {
+          for (const address of subPlugin.addresses || []) {
+            if (address && !processInternalByAddress.has(address)) {
+              processInternalByAddress.set(address, {
+                parent: parentContext(plugin, subPlugin.stageIndex),
+              })
+            }
+          }
+        }
+      }
+
+      const pluginParent = parentContext(plugin)
+      for (const address of [plugin.conditionAddress, plugin.proposalCreationConditionAddress]) {
+        if (address && !conditionByAddress.has(address)) {
+          conditionByAddress.set(address, {
+            parent: pluginParent,
+            status: this.pluginLifecycleStatus(plugin.status),
+          })
+        }
+      }
+    }
+
+    for (const setting of settings) {
+      const parentPlugin = setting.pluginAddress ? pluginByAddress.get(setting.pluginAddress) : undefined
+      for (const proposer of setting.externalProposers || []) {
+        if (proposer.address) externalActorByAddress.set(proposer.address, parentContext(parentPlugin))
+
+        const conditionAddress = proposer.proposalCreationConditionAddress
+        if (conditionAddress && !conditionByAddress.has(conditionAddress)) {
+          conditionByAddress.set(conditionAddress, { parent: parentContext(parentPlugin), status: 'installed' })
+        }
+      }
+
+      for (const stage of setting.stages || []) {
+        for (const stagePlugin of stage.plugins || []) {
+          const address = stagePlugin.address
+          if (address && !processInternalByAddress.has(address)) {
+            processInternalByAddress.set(address, {
+              parent: parentContext(parentPlugin, stage.stageIndex),
+            })
+          }
+
+          const conditionAddress = stagePlugin.proposalCreationConditionAddress
+          if (conditionAddress && !conditionByAddress.has(conditionAddress)) {
+            conditionByAddress.set(conditionAddress, {
+              parent: parentContext(parentPlugin, stage.stageIndex),
+              status: 'installed',
+            })
+          }
+        }
+      }
+    }
+
+    const resolve = (address: HexAddress, role: PermissionEntityRole) => {
+      if (role === 'condition' && address === ALLOW_FLAG) {
+        return this.createParentedEntity(address, role, 'condition')
+      }
+
+      if (daoEntityAddresses.has(address)) {
+        return this.createDaoEntity(address, role, daoByAddress.get(address))
+      }
+
+      const directPlugin = pluginByAddress.get(address)
+      const internal = processInternalByAddress.get(address)
+      if (internal) {
+        return this.createParentedEntity(address, role, 'processInternal', internal.parent, internal.plugin)
+      }
+
+      const isTopLevelInstalledPlugin = Boolean(
+        directPlugin &&
+          directPlugin.status === IPluginStatus.installed &&
+          !directPlugin.isBody &&
+          !directPlugin.isSubPlugin &&
+          !directPlugin.parentPlugin,
+      )
+      if (isTopLevelInstalledPlugin && directPlugin) {
+        return this.createPluginEntity(address, role, directPlugin, 'topLevelPlugin')
+      }
+
+      const condition = conditionByAddress.get(address)
+      if (conditionByAddress.has(address)) {
+        return this.createParentedEntity(address, role, 'condition', condition?.parent, undefined, condition?.status)
+      }
+
+      const externalActor = externalActorByAddress.get(address)
+      if (externalActorByAddress.has(address)) {
+        return this.createParentedEntity(address, role, 'externalActor', externalActor, undefined, 'unknown')
+      }
+
+      if (directPlugin && directPlugin.status !== IPluginStatus.preInstall) {
+        return this.createPluginEntity(address, role, directPlugin, 'historicalPlugin')
+      }
+
+      return this.createFallbackEntity(address, role, contractByAddress.get(address))
+    }
+
+    return rows.map(row => ({
+      ...row,
+      who: resolve(row.whoAddress, 'who'),
+      where: resolve(row.whereAddress, 'where'),
+      conditionEntity: resolve(row.conditionAddress || ALLOW_FLAG, 'condition'),
+    }))
+  },
+}

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,3 +1,5 @@
+import type { HexAddress } from './networks'
+
 export enum IPermission {
   EXECUTE_PROPOSAL_PERMISSION = 'EXECUTE_PROPOSAL_PERMISSION',
   EXECUTE_PERMISSION = 'EXECUTE_PERMISSION',
@@ -5,4 +7,28 @@ export enum IPermission {
   CREATE_PROPOSAL_PERMISSION = 'CREATE_PROPOSAL_PERMISSION',
   PARENT_TO_SUB_DAO_ACKNOWLEDGEMENT_PERMISSION_ID = 'PARENT_TO_SUB_DAO_ACKNOWLEDGEMENT_PERMISSION_ID',
   SUB_DAO_TO_PARENT_ACKNOWLEDGEMENT_PERMISSION_ID = 'SUB_DAO_TO_PARENT_ACKNOWLEDGEMENT_PERMISSION_ID',
+}
+
+export type PermissionEntityLayer =
+  | 'dao'
+  | 'topLevelPlugin'
+  | 'processInternal'
+  | 'condition'
+  | 'externalActor'
+  | 'historicalPlugin'
+  | 'contract'
+  | 'unknown'
+
+export interface IPermissionEntityRef {
+  address: HexAddress
+  layer: PermissionEntityLayer
+  label?: string
+  interfaceType?: string
+  status?: 'installed' | 'uninstalled' | 'historical' | 'unknown'
+  parentPluginAddress?: HexAddress
+  parentPluginName?: string
+  parentInterfaceType?: string
+  stageIndex?: number
+  role?: 'who' | 'where' | 'condition'
+  avatarSrc?: string
 }

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -4,6 +4,8 @@ import { type IPluginInterfaceType, type IReportResultType } from '@src/types/pl
 import { type IActionMetadata, type IProposalAction, type IRawAction } from '@src/types/proposalAction'
 import { type ITokenType } from '@src/types/token'
 import { type ENS, type HexAddress, type NetworksEnum } from './networks'
+import type { IPermissionEntityRef } from './permission'
+export type { IPermissionEntityRef, PermissionEntityLayer } from './permission'
 
 export interface VersionedRouter {
   v1: Router
@@ -379,10 +381,13 @@ export interface IPermissionResponse {
   permissionId: string
   whoAddress: HexAddress
   whereAddress: HexAddress
-  conditionAddress?: HexAddress
+  conditionAddress: HexAddress
   blockNumber: number
   transactionHash: HexAddress
   condition?: IPermissionConditionData
+  who?: IPermissionEntityRef
+  where?: IPermissionEntityRef
+  conditionEntity?: IPermissionEntityRef
 }
 
 export interface ITransactionIndexingStatusResponse {

--- a/test/unit/models/schema/daoPermission.spec.ts
+++ b/test/unit/models/schema/daoPermission.spec.ts
@@ -1,6 +1,6 @@
 import { Models } from '@dbModels'
 import { FakeDaoPermissions } from '@test/mock/fakeDaoPermission'
-import { IPluginInterfaceType, IPluginStatus, ISettingStatus, NetworksEnum } from '@types'
+import { IPermissionResponse, IPluginInterfaceType, IPluginStatus, ISettingStatus, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
@@ -556,6 +556,335 @@ describe('Dao Permission', () => {
     it('omits condition and returns ALLOW_FLAG conditionAddress when the grant has no condition', () => {
       expect(byPermission['0xNONE']).to.not.have.property('condition')
       expect(byPermission['0xNONE'].conditionAddress).to.equal('0x0000000000000000000000000000000000000002')
+    })
+  })
+
+  describe('findWithPagination entity enrichment', () => {
+    const network = NetworksEnum.ethereumSepolia
+    const daoAddress = '0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd'
+    const linkedDaoAddress = '0xabababababababababababababababababababab'
+    const topLevelPlugin = '0x3333333333333333333333333333333333333333'
+    const processInternal = '0x4444444444444444444444444444444444444444'
+    const processBody = '0x5555555555555555555555555555555555555555'
+    const conditionAddress = '0x6666666666666666666666666666666666666666'
+    const externalActor = '0x7777777777777777777777777777777777777777'
+    const historicalPlugin = '0x8888888888888888888888888888888888888888'
+    const contractAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const unknownAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    let byPermission: Record<string, IPermissionResponse>
+
+    beforeEach(async () => {
+      await Models.Dao.collection.insertMany([
+        {
+          id: `${network}-${daoAddress}`,
+          address: daoAddress,
+          network,
+          name: 'Core Governance',
+          avatar: 'ipfs://dao-avatar',
+          isActive: true,
+          isHidden: false,
+          linkedAccounts: [linkedDaoAddress],
+        },
+        {
+          id: `${network}-${linkedDaoAddress}`,
+          address: linkedDaoAddress,
+          network,
+          name: 'Linked Treasury',
+          avatar: 'ipfs://linked-avatar',
+          isActive: true,
+          isHidden: false,
+          linkedAccounts: [],
+        },
+      ])
+
+      await Models.Plugin.collection.insertMany([
+        {
+          id: 'plugin-top-level',
+          address: topLevelPlugin,
+          daoAddress,
+          network,
+          status: IPluginStatus.installed,
+          interfaceType: IPluginInterfaceType.spp,
+          name: 'Polling',
+          isProcess: true,
+          blockNumber: 100,
+          subPlugins: [{ addresses: [processInternal], stageIndex: 1 }],
+          proposalCreationConditionAddress: conditionAddress,
+        },
+        {
+          id: 'plugin-process-body',
+          address: processBody,
+          daoAddress,
+          network,
+          status: IPluginStatus.installed,
+          interfaceType: IPluginInterfaceType.multisig,
+          name: 'Polling body',
+          isBody: true,
+          parentPlugin: topLevelPlugin,
+          stageIndex: 0,
+          blockNumber: 101,
+        },
+        {
+          id: 'plugin-historical',
+          address: historicalPlugin,
+          daoAddress,
+          network,
+          status: IPluginStatus.uninstalled,
+          interfaceType: IPluginInterfaceType.tokenVoting,
+          name: 'Token Voting',
+          blockNumber: 90,
+          conditionAddress: unknownAddress,
+          proposalCreationConditionAddress: unknownAddress,
+        },
+      ])
+
+      await Models.Setting.collection.insertOne({
+        id: 'setting-spp',
+        pluginAddress: topLevelPlugin,
+        daoAddress,
+        network,
+        status: ISettingStatus.active,
+        externalProposers: [{ address: externalActor, proposalCreationConditionAddress: conditionAddress }],
+      })
+
+      await Models.Contract.collection.insertOne({
+        id: `${contractAddress}-${network}`,
+        address: contractAddress,
+        network,
+        bytecode: '0x1234',
+        bytecodeHash: '0xhash',
+      })
+
+      const grants = [
+        {
+          permissionId: '0xTOP_LEVEL',
+          whoAddress: externalActor,
+          whereAddress: topLevelPlugin,
+          conditionAddress,
+        },
+        {
+          permissionId: '0xHISTORICAL',
+          whoAddress: historicalPlugin,
+          whereAddress: contractAddress,
+          conditionAddress: unknownAddress,
+        },
+        {
+          permissionId: '0xINTERNAL',
+          whoAddress: linkedDaoAddress,
+          whereAddress: processInternal,
+          conditionAddress: undefined,
+        },
+        {
+          permissionId: '0xBODY',
+          whoAddress: processBody,
+          whereAddress: daoAddress,
+          conditionAddress,
+        },
+      ]
+
+      for (let i = 0; i < grants.length; i++) {
+        await Models.DaoPermission.create({
+          network,
+          blockNumber: 200 + i,
+          transactionHash: `0x${i.toString().padStart(64, '0')}`,
+          transactionIndex: 0,
+          logIndex: i,
+          daoAddress,
+          permissionId: grants[i].permissionId,
+          whoAddress: grants[i].whoAddress,
+          whereAddress: grants[i].whereAddress,
+          conditionAddress: grants[i].conditionAddress,
+          event: 'Granted',
+        })
+      }
+
+      const result = await Models.DaoPermission.findWithPagination({
+        extraParams: { daoAddress, network },
+        paginationParams: { pageSize: 10, page: 1 },
+      })
+      byPermission = Object.fromEntries(result.data.map(row => [row.permissionId, row]))
+    })
+
+    it('classifies current plugins, external actors, and known conditions on permission rows', () => {
+      expect(byPermission['0xTOP_LEVEL'].where).to.deep.equal({
+        address: topLevelPlugin,
+        layer: 'topLevelPlugin',
+        label: 'Polling',
+        interfaceType: IPluginInterfaceType.spp,
+        status: 'installed',
+        role: 'where',
+      })
+      expect(byPermission['0xTOP_LEVEL'].who).to.deep.equal({
+        address: externalActor,
+        layer: 'externalActor',
+        label: 'External proposer',
+        status: 'unknown',
+        parentPluginAddress: topLevelPlugin,
+        parentPluginName: 'Polling',
+        parentInterfaceType: IPluginInterfaceType.spp,
+        role: 'who',
+      })
+      expect(byPermission['0xTOP_LEVEL'].conditionEntity).to.deep.equal({
+        address: conditionAddress,
+        layer: 'condition',
+        label: 'Condition contract',
+        status: 'installed',
+        parentPluginAddress: topLevelPlugin,
+        parentPluginName: 'Polling',
+        parentInterfaceType: IPluginInterfaceType.spp,
+        role: 'condition',
+      })
+    })
+
+    it('classifies historical plugins, known contracts, and unknown condition addresses', () => {
+      expect(byPermission['0xHISTORICAL'].who).to.deep.equal({
+        address: historicalPlugin,
+        layer: 'historicalPlugin',
+        label: 'Historical Token Voting',
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        status: 'uninstalled',
+        role: 'who',
+      })
+      expect(byPermission['0xHISTORICAL'].where).to.deep.equal({
+        address: contractAddress,
+        layer: 'contract',
+        label: 'Unresolved contract',
+        status: 'unknown',
+        role: 'where',
+      })
+      expect(byPermission['0xHISTORICAL'].conditionEntity).to.deep.equal({
+        address: unknownAddress,
+        layer: 'condition',
+        label: 'Condition contract',
+        status: 'uninstalled',
+        parentPluginAddress: historicalPlugin,
+        parentPluginName: 'Token Voting',
+        parentInterfaceType: IPluginInterfaceType.tokenVoting,
+        role: 'condition',
+      })
+    })
+
+    it('classifies linked DAOs, process internals, and the allow flag sentinel', () => {
+      expect(byPermission['0xINTERNAL'].who).to.deep.equal({
+        address: linkedDaoAddress,
+        layer: 'dao',
+        label: 'Linked Treasury',
+        avatarSrc: 'ipfs://linked-avatar',
+        role: 'who',
+      })
+      expect(byPermission['0xINTERNAL'].where).to.deep.equal({
+        address: processInternal,
+        layer: 'processInternal',
+        label: 'Process internal',
+        status: 'installed',
+        parentPluginAddress: topLevelPlugin,
+        parentPluginName: 'Polling',
+        parentInterfaceType: IPluginInterfaceType.spp,
+        stageIndex: 1,
+        role: 'where',
+      })
+      expect(byPermission['0xINTERNAL'].conditionEntity).to.deep.equal({
+        address: '0x0000000000000000000000000000000000000002',
+        layer: 'condition',
+        label: 'Allow flag',
+        status: 'unknown',
+        role: 'condition',
+      })
+    })
+
+    it('keeps legacy raw fields and conditionAddress on enriched rows', () => {
+      const requiredRawFields: Array<keyof IPermissionResponse> = [
+        'permissionId',
+        'whoAddress',
+        'whereAddress',
+        'conditionAddress',
+        'daoAddress',
+        'network',
+        'blockNumber',
+        'transactionHash',
+      ]
+      const requireConditionAddress = (_conditionAddress: string) => {}
+
+      for (const row of Object.values(byPermission)) {
+        expect(row).to.include.all.keys(requiredRawFields)
+        expect(row.whoAddress).to.be.a('string')
+        expect(row.whereAddress).to.be.a('string')
+        expect(row.daoAddress).to.equal(daoAddress)
+        expect(row.network).to.equal(network)
+        expect(row.blockNumber).to.be.a('number')
+        expect(row.transactionHash).to.be.a('string')
+      }
+
+      expect(byPermission['0xINTERNAL'].conditionAddress).to.equal('0x0000000000000000000000000000000000000002')
+      requireConditionAddress(byPermission['0xINTERNAL'].conditionAddress)
+      expect(byPermission['0xINTERNAL']).to.include.all.keys(['whoAddress', 'whereAddress', 'who', 'where'])
+    })
+
+    it('prefers the current installed plugin over stale historical plugin docs', async () => {
+      await Models.Plugin.collection.insertOne({
+        id: 'plugin-top-level-stale-history',
+        address: topLevelPlugin,
+        daoAddress,
+        network,
+        status: IPluginStatus.uninstalled,
+        interfaceType: IPluginInterfaceType.tokenVoting,
+        name: 'Stale Token Voting',
+        blockNumber: 300,
+      })
+
+      const result = await Models.DaoPermission.findWithPagination({
+        extraParams: { daoAddress, network },
+        paginationParams: { pageSize: 10, page: 1 },
+      })
+      const row = result.data.find(permission => permission.permissionId === '0xTOP_LEVEL')
+
+      expect(row?.where).to.deep.equal({
+        address: topLevelPlugin,
+        layer: 'topLevelPlugin',
+        label: 'Polling',
+        interfaceType: IPluginInterfaceType.spp,
+        status: 'installed',
+        role: 'where',
+      })
+    })
+
+    it('classifies linked DAOs even when the current page does not include the root DAO address', async () => {
+      const result = await Models.DaoPermission.findWithPagination({
+        extraParams: { daoAddress, network },
+        paginationParams: { pageSize: 1, page: 2, sort: 'blockNumber', order: 'desc' },
+      })
+
+      expect(result.data[0].permissionId).to.equal('0xINTERNAL')
+      expect(result.data[0].who).to.deep.equal({
+        address: linkedDaoAddress,
+        layer: 'dao',
+        label: 'Linked Treasury',
+        avatarSrc: 'ipfs://linked-avatar',
+        role: 'who',
+      })
+    })
+
+    it('classifies installed plugin body rows as process internals with parent context', () => {
+      expect(byPermission['0xBODY'].who).to.deep.equal({
+        address: processBody,
+        layer: 'processInternal',
+        label: 'Process internal',
+        interfaceType: IPluginInterfaceType.multisig,
+        status: 'installed',
+        parentPluginAddress: topLevelPlugin,
+        parentPluginName: 'Polling',
+        parentInterfaceType: IPluginInterfaceType.spp,
+        stageIndex: 0,
+        role: 'who',
+      })
+      expect(byPermission['0xBODY'].where).to.deep.equal({
+        address: daoAddress,
+        layer: 'dao',
+        label: 'Core Governance',
+        avatarSrc: 'ipfs://dao-avatar',
+        role: 'where',
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Adds additive permission entity enrichment to DAO permission responses so clients can label permission graph addresses without guessing.

Returned permission rows keep the legacy raw fields and add optional role-specific entity refs:

- `who`
- `where`
- `conditionEntity`

Each entity ref includes layer/status/context metadata when the backend can resolve it.

Compatibility safeguards:

- Keeps raw response fields present: `permissionId`, `whoAddress`, `whereAddress`, `conditionAddress`, `daoAddress`, `network`, `blockNumber`, `transactionHash`.
- Keeps enriched fields optional/additive, so legacy clients can continue using raw address fields.
- Backfills missing unconditional `conditionAddress` values with `ALLOW_FLAG`.
- Preserves `conditionAddress` on every returned permission row.
- Exposes SPP frontend-compatible Safe metadata:
  - stage/process body refs get `brandId` and `proposalCreationConditionAddress` from `Setting.stages[].plugins[]` when indexed.
  - external proposer refs get `brandId: safe` and `proposalCreationConditionAddress` from `Setting.externalProposers[]`; those rows are Safe proposer entries by backend construction.

## Verification

- `pnpm format:check` passed.
- `pnpm type-check` passed.
- `pnpm lint` passed; only the pre-existing Biome config deprecation info was reported.
- `pnpm test:unit test/unit/models/schema/daoPermission.spec.ts` passed: `5758 passing`, `5 pending`.
