### PR TITLE
feat: expose SPP Safe metadata on permission entity refs

### DIFF
--- a/src/modules/permissionEntities.ts
+++ b/src/modules/permissionEntities.ts
@@ -133,7 +133,7 @@ export const PermissionEntityEnrichment = {
     metadata?: PermissionEntityMetadataContext,
   ) {
     const entity: IPermissionEntityRef = { address, layer, role }
-    if (layer === 'processInternal') entity.label = 'Process internal'
+    if (layer === 'processInternal') entity.label = plugin?.name ?? 'Process internal'
     if (layer === 'condition') entity.label = address === ALLOW_FLAG ? 'Allow flag' : 'Condition contract'
     if (layer === 'externalActor') entity.label = 'External proposer'
     entity.status = status || (layer === 'condition' && address === ALLOW_FLAG ? 'unknown' : 'installed')
@@ -350,7 +350,7 @@ export const PermissionEntityEnrichment = {
           role,
           'processInternal',
           internal.parent,
-          internal.plugin,
+          internal.plugin ?? directPlugin,
           undefined,
           {
             brandId: internal.brandId,

--- a/src/modules/permissionEntities.ts
+++ b/src/modules/permissionEntities.ts
@@ -6,6 +6,7 @@ import {
   type IPluginInterfaceType,
   IPluginStatus,
   ISettingStatus,
+  VotingBodyBrandIdentity,
   type NetworksEnum,
 } from '@types'
 import type { Connection } from 'mongoose'
@@ -46,11 +47,13 @@ interface PermissionEntityPluginDoc {
 interface PermissionEntityExternalProposerDoc {
   address?: HexAddress
   proposalCreationConditionAddress?: HexAddress
+  brandId?: VotingBodyBrandIdentity
 }
 
 interface PermissionEntityStagePluginDoc {
   address?: HexAddress
   proposalCreationConditionAddress?: HexAddress
+  brandId?: VotingBodyBrandIdentity
 }
 
 interface PermissionEntityStageDoc {
@@ -79,6 +82,11 @@ interface PermissionEntityParentContext {
 interface PermissionEntityConditionContext {
   parent?: PermissionEntityParentContext
   status?: IPermissionEntityRef['status']
+}
+
+interface PermissionEntityMetadataContext {
+  brandId?: VotingBodyBrandIdentity
+  proposalCreationConditionAddress?: HexAddress
 }
 
 export const PermissionEntityEnrichment = {
@@ -122,6 +130,7 @@ export const PermissionEntityEnrichment = {
     parent?: PermissionEntityParentContext,
     plugin?: PermissionEntityPluginDoc,
     status?: IPermissionEntityRef['status'],
+    metadata?: PermissionEntityMetadataContext,
   ) {
     const entity: IPermissionEntityRef = { address, layer, role }
     if (layer === 'processInternal') entity.label = 'Process internal'
@@ -133,6 +142,10 @@ export const PermissionEntityEnrichment = {
     if (parent?.name) entity.parentPluginName = parent.name
     if (parent?.interfaceType) entity.parentInterfaceType = parent.interfaceType
     if (parent?.stageIndex !== undefined) entity.stageIndex = parent.stageIndex
+    if (metadata?.brandId) entity.brandId = metadata.brandId
+    if (metadata?.proposalCreationConditionAddress) {
+      entity.proposalCreationConditionAddress = metadata.proposalCreationConditionAddress
+    }
     return entity
   },
 
@@ -233,10 +246,13 @@ export const PermissionEntityEnrichment = {
 
     const processInternalByAddress = new Map<
       string,
-      { parent?: PermissionEntityParentContext; plugin?: PermissionEntityPluginDoc }
+      { parent?: PermissionEntityParentContext; plugin?: PermissionEntityPluginDoc } & PermissionEntityMetadataContext
     >()
     const conditionByAddress = new Map<string, PermissionEntityConditionContext>()
-    const externalActorByAddress = new Map<string, PermissionEntityParentContext | undefined>()
+    const externalActorByAddress = new Map<
+      string,
+      (PermissionEntityMetadataContext & { parent?: PermissionEntityParentContext }) | undefined
+    >()
 
     for (const plugin of sortedPlugins) {
       const parentPlugin = plugin.parentPlugin ? pluginByAddress.get(plugin.parentPlugin) : undefined
@@ -278,7 +294,13 @@ export const PermissionEntityEnrichment = {
     for (const setting of settings) {
       const parentPlugin = setting.pluginAddress ? pluginByAddress.get(setting.pluginAddress) : undefined
       for (const proposer of setting.externalProposers || []) {
-        if (proposer.address) externalActorByAddress.set(proposer.address, parentContext(parentPlugin))
+        if (proposer.address) {
+          externalActorByAddress.set(proposer.address, {
+            parent: parentContext(parentPlugin),
+            brandId: VotingBodyBrandIdentity.SAFE,
+            proposalCreationConditionAddress: proposer.proposalCreationConditionAddress,
+          })
+        }
 
         const conditionAddress = proposer.proposalCreationConditionAddress
         if (conditionAddress && !conditionByAddress.has(conditionAddress)) {
@@ -289,9 +311,14 @@ export const PermissionEntityEnrichment = {
       for (const stage of setting.stages || []) {
         for (const stagePlugin of stage.plugins || []) {
           const address = stagePlugin.address
-          if (address && !processInternalByAddress.has(address)) {
+          if (address) {
+            const existing = processInternalByAddress.get(address)
             processInternalByAddress.set(address, {
-              parent: parentContext(parentPlugin, stage.stageIndex),
+              parent: existing?.parent || parentContext(parentPlugin, stage.stageIndex),
+              plugin: existing?.plugin,
+              brandId: stagePlugin.brandId || existing?.brandId,
+              proposalCreationConditionAddress:
+                stagePlugin.proposalCreationConditionAddress || existing?.proposalCreationConditionAddress,
             })
           }
 
@@ -318,7 +345,18 @@ export const PermissionEntityEnrichment = {
       const directPlugin = pluginByAddress.get(address)
       const internal = processInternalByAddress.get(address)
       if (internal) {
-        return this.createParentedEntity(address, role, 'processInternal', internal.parent, internal.plugin)
+        return this.createParentedEntity(
+          address,
+          role,
+          'processInternal',
+          internal.parent,
+          internal.plugin,
+          undefined,
+          {
+            brandId: internal.brandId,
+            proposalCreationConditionAddress: internal.proposalCreationConditionAddress,
+          },
+        )
       }
 
       const isTopLevelInstalledPlugin = Boolean(
@@ -339,7 +377,10 @@ export const PermissionEntityEnrichment = {
 
       const externalActor = externalActorByAddress.get(address)
       if (externalActorByAddress.has(address)) {
-        return this.createParentedEntity(address, role, 'externalActor', externalActor, undefined, 'unknown')
+        return this.createParentedEntity(address, role, 'externalActor', externalActor?.parent, undefined, 'unknown', {
+          brandId: externalActor?.brandId,
+          proposalCreationConditionAddress: externalActor?.proposalCreationConditionAddress,
+        })
       }
 
       if (directPlugin && directPlugin.status !== IPluginStatus.preInstall) {

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,4 +1,5 @@
 import type { HexAddress } from './networks'
+import type { VotingBodyBrandIdentity } from './plugin'
 
 export enum IPermission {
   EXECUTE_PROPOSAL_PERMISSION = 'EXECUTE_PROPOSAL_PERMISSION',
@@ -31,4 +32,6 @@ export interface IPermissionEntityRef {
   stageIndex?: number
   role?: 'who' | 'where' | 'condition'
   avatarSrc?: string
+  brandId?: VotingBodyBrandIdentity
+  proposalCreationConditionAddress?: HexAddress
 }

--- a/test/unit/models/schema/daoPermission.spec.ts
+++ b/test/unit/models/schema/daoPermission.spec.ts
@@ -1,6 +1,13 @@
 import { Models } from '@dbModels'
 import { FakeDaoPermissions } from '@test/mock/fakeDaoPermission'
-import { IPermissionResponse, IPluginInterfaceType, IPluginStatus, ISettingStatus, NetworksEnum } from '@types'
+import {
+  IPermissionResponse,
+  IPluginInterfaceType,
+  IPluginStatus,
+  ISettingStatus,
+  NetworksEnum,
+  VotingBodyBrandIdentity,
+} from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
@@ -646,6 +653,18 @@ describe('Dao Permission', () => {
         network,
         status: ISettingStatus.active,
         externalProposers: [{ address: externalActor, proposalCreationConditionAddress: conditionAddress }],
+        stages: [
+          {
+            stageIndex: 1,
+            plugins: [
+              {
+                address: processInternal,
+                brandId: VotingBodyBrandIdentity.SAFE,
+                proposalCreationConditionAddress: conditionAddress,
+              },
+            ],
+          },
+        ],
       })
 
       await Models.Contract.collection.insertOne({
@@ -723,6 +742,8 @@ describe('Dao Permission', () => {
         parentPluginAddress: topLevelPlugin,
         parentPluginName: 'Polling',
         parentInterfaceType: IPluginInterfaceType.spp,
+        brandId: VotingBodyBrandIdentity.SAFE,
+        proposalCreationConditionAddress: conditionAddress,
         role: 'who',
       })
       expect(byPermission['0xTOP_LEVEL'].conditionEntity).to.deep.equal({
@@ -782,6 +803,8 @@ describe('Dao Permission', () => {
         parentPluginName: 'Polling',
         parentInterfaceType: IPluginInterfaceType.spp,
         stageIndex: 1,
+        brandId: VotingBodyBrandIdentity.SAFE,
+        proposalCreationConditionAddress: conditionAddress,
         role: 'where',
       })
       expect(byPermission['0xINTERNAL'].conditionEntity).to.deep.equal({

--- a/test/unit/models/schema/daoPermission.spec.ts
+++ b/test/unit/models/schema/daoPermission.spec.ts
@@ -644,6 +644,16 @@ describe('Dao Permission', () => {
           conditionAddress: unknownAddress,
           proposalCreationConditionAddress: unknownAddress,
         },
+        {
+          id: 'plugin-process-internal',
+          address: processInternal,
+          daoAddress,
+          network,
+          status: IPluginStatus.installed,
+          interfaceType: IPluginInterfaceType.tokenVoting,
+          name: 'Token Voting',
+          blockNumber: 102,
+        },
       ])
 
       await Models.Setting.collection.insertOne({
@@ -797,7 +807,8 @@ describe('Dao Permission', () => {
       expect(byPermission['0xINTERNAL'].where).to.deep.equal({
         address: processInternal,
         layer: 'processInternal',
-        label: 'Process internal',
+        label: 'Token Voting',
+        interfaceType: IPluginInterfaceType.tokenVoting,
         status: 'installed',
         parentPluginAddress: topLevelPlugin,
         parentPluginName: 'Polling',
@@ -892,7 +903,7 @@ describe('Dao Permission', () => {
       expect(byPermission['0xBODY'].who).to.deep.equal({
         address: processBody,
         layer: 'processInternal',
-        label: 'Process internal',
+        label: 'Polling body',
         interfaceType: IPluginInterfaceType.multisig,
         status: 'installed',
         parentPluginAddress: topLevelPlugin,


### PR DESCRIPTION
## Summary

Follow-up to #1490 (merged). Adds two additive enrichments for permission entity refs:

1. Exposes SPP Safe metadata so clients can label stage/process bodies and external Safe proposers without frontend guessing.
2. Names process-internal body refs from their resolved plugin docs instead of always returning the generic `Process internal` label.

## Safe metadata

Adds two optional fields to `IPermissionEntityRef`:

- `brandId` (`eoa | safe | other`)
- `proposalCreationConditionAddress`

Population:

- **Stage / process body refs** carry `brandId` + `proposalCreationConditionAddress` from `Setting.stages[].plugins[]` when indexed.
- **External proposer refs** carry `brandId: safe` (Safe by backend construction — see `ExternalProposer` / `attachExternalBodyConditions`) plus `proposalCreationConditionAddress` from `Setting.externalProposers[]`; `status` stays `unknown` since these are not installed-plugin lifecycle entities.

This matches the frontend's existing determination keys:

- indexed SPP body data: `brandId === SAFE`
- external Safe proposal-creation eligibility: `brandId === SAFE && proposalCreationConditionAddress != null`

## Process-internal naming

- `processInternal` entity refs now use `plugin.name` for `label` when the backend has a resolved plugin doc.
- The resolver falls back from `internal.plugin` to the indexed `directPlugin`, so bodies registered through `subPlugins` / `stages[].plugins[]` can still use their plugin doc name and `interfaceType`.
- Bodies with no plugin doc still return `label: 'Process internal'`.

No new field is added for this naming change; clients continue using `label` + `interfaceType`.

## Compatibility

- All fields are optional/additive except the improved existing `label` value.
- Raw permission row fields are unchanged.

## Verification

- GitHub checks pass on PR #1491: Analyze, CodeQL, integration, unit-dep shards, unit-test.
- Local `pnpm type-check` passed.
- Local `pnpm lint` passed (only pre-existing Biome config deprecation info).
- Local `pnpm test:unit test/unit/models/schema/daoPermission.spec.ts` passed: `5758 passing`, `5 pending`.
