### PR TITLE
feat(APP-1057): add V3 batch decode endpoint without DAO address in path

### DIFF
--- a/src/services/aragon-api/routers/schema/contract.ts
+++ b/src/services/aragon-api/routers/schema/contract.ts
@@ -3,6 +3,23 @@ import ValidationSchema from '@helpers/validationSchema'
 import { NetworksEnum } from '@types'
 import Joi from 'joi'
 
+/**
+ * `actions` payload shared by the batch decode endpoints: an array of raw
+ * `[to, data, value]` tuples, capped so a single request cannot fan out into an
+ * unbounded number of source-code lookups.
+ */
+const decodeBatchActions = Joi.array()
+  .items(
+    Joi.object({
+      to: ValidationSchema.joiAddress.required(),
+      data: Joi.string().required(),
+      value: Joi.alternatives().try(Joi.string(), Joi.number()).allow(null).default('0'),
+    }),
+  )
+  .min(1)
+  .max(config.SERVICES.ARAGON_API.DECODE_ACTION_BATCH_LIMIT)
+  .required()
+
 const ContractDetailsSchema = {
   getContractDetails: Joi.object({
     network: Joi.string()
@@ -38,19 +55,25 @@ const ContractDetailsSchema = {
       .required(),
   }),
 
+  /**
+   * @deprecated Superseded by `decodeActionBatchV3`, which makes `from` optional. Kept for the V2
+   * route until its clients have migrated.
+   */
   decodeActionBatchV2: Joi.object({
     from: ValidationSchema.joiAddress.required(),
-    actions: Joi.array()
-      .items(
-        Joi.object({
-          to: ValidationSchema.joiAddress.required(),
-          data: Joi.string().required(),
-          value: Joi.alternatives().try(Joi.string(), Joi.number()).allow(null).default('0'),
-        }),
-      )
-      .min(1)
-      .max(config.SERVICES.ARAGON_API.DECODE_ACTION_BATCH_LIMIT)
+    actions: decodeBatchActions,
+    network: Joi.string()
+      .valid(...Object.values(NetworksEnum))
       .required(),
+  }),
+
+  /**
+   * V3 drops `from` from the route path: the light decoder never reads it, it is only
+   * echoed back on each result, so callers that have no DAO context can omit it.
+   */
+  decodeActionBatchV3: Joi.object({
+    from: ValidationSchema.joiAddress.optional(),
+    actions: decodeBatchActions,
     network: Joi.string()
       .valid(...Object.values(NetworksEnum))
       .required(),

--- a/src/services/aragon-api/routers/v2/contract.ts
+++ b/src/services/aragon-api/routers/v2/contract.ts
@@ -35,6 +35,12 @@ const ContractRouter = {
     ctx.body = await ContractController.decodeContractData(result.params)
   },
 
+  /**
+   * @deprecated Use the V3 route instead: `POST /v3/contract/:network/decode-batch`.
+   *
+   * The light decoder never reads the sender address, so V2 requires a `:from` path segment that
+   * only gets echoed back on each result. V3 moves it to an optional `?from=` query param.
+   */
   async decodeActionBatch(ctx: RouterContext) {
     const result = await ValidationSchema.validateRoute(ctx, {
       params: {
@@ -64,9 +70,12 @@ const ContractRouter = {
 
     /**
      * /:network/:from/decode-batch
+     * @deprecated Use `POST /v3/contract/:network/decode-batch`, where `from` is an optional
+     * `?from=` query param. Kept for existing clients; remove once they have migrated.
      * @description Decode multiple actions in batch (lightweight, parallel).
      * @param {string} network - The network of the contracts.
-     * @param {string} from - The sender address (e.g. DAO address).
+     * @param {string} from - The sender address (e.g. DAO address). Echoed back on each result;
+     * not used to decode.
      * @body {array} - Array of actions [{ to, data, value }].
      * @returns {array} - The decoded actions.
      */

--- a/src/services/aragon-api/routers/v3/contract.ts
+++ b/src/services/aragon-api/routers/v3/contract.ts
@@ -1,0 +1,48 @@
+import ContractController from '@api/controllers/contract'
+import ContractDetailsSchema from '@api/routers/schema/contract'
+import ValidationSchema from '@helpers/validationSchema'
+import Router, { type RouterContext } from '@koa/router'
+
+/**
+ * V3 Contract Router - batch decoding without a DAO address in the path.
+ *
+ * The light decoder never uses the sender address to decode (it resolves proxies, ABIs and
+ * selectors from each action's `to`), it only echoes it back on every result. V3 therefore
+ * moves it out of the path and into an optional `?from=` query param, so callers with no DAO
+ * context (imports, previews, standalone tooling) do not have to invent an address.
+ */
+const ContractRouterV3 = {
+  async decodeActionBatch(ctx: RouterContext) {
+    const result = await ValidationSchema.validateRoute(ctx, {
+      params: {
+        actions: (ctx.request as any).body as any[],
+        network: ctx.params.network,
+        from: ctx.query.from as string | undefined,
+      },
+      schemas: {
+        params: ContractDetailsSchema.decodeActionBatchV3,
+      },
+    })
+
+    ctx.body = await ContractController.decodeContractDataBatch(result.params)
+  },
+
+  router(): Router {
+    const router = new Router()
+
+    /**
+     * /:network/decode-batch
+     * @description Decode multiple actions in batch (lightweight, parallel).
+     * @param {string} network - The network of the contracts.
+     * @query {string} [from] - Optional sender address (e.g. DAO address), echoed back on each
+     * result. Omit it when there is no sender context; results then carry an empty `from`.
+     * @body {array} - Array of actions [{ to, data, value }].
+     * @returns {array} - The decoded actions.
+     */
+    router.post('/:network/decode-batch', ContractRouterV3.decodeActionBatch)
+
+    return router
+  },
+}
+
+export default ContractRouterV3

--- a/src/services/aragon-api/routers/v3/index.ts
+++ b/src/services/aragon-api/routers/v3/index.ts
@@ -1,11 +1,16 @@
 import Router from '@koa/router'
+import ContractRouter from './contract'
 import DaoRouter from './dao'
 
 const V3Router = {
   router(): Router {
     const router = new Router()
     const daoRouter = DaoRouter.router()
+    const contractRouter = ContractRouter.router()
+
     router.use('/daos', daoRouter.routes(), daoRouter.allowedMethods())
+    router.use('/contract', contractRouter.routes(), contractRouter.allowedMethods())
+
     return router
   },
 }

--- a/src/types/queue.ts
+++ b/src/types/queue.ts
@@ -188,7 +188,14 @@ export interface IGetGovernanceRewardDistribution {
 }
 
 export interface IQueueContractDecoderLight {
-  from: HexAddress
+  /**
+   * Sender address (usually the DAO). The light decoder never reads it — it is only echoed back on
+   * each result — so callers may omit it.
+   *
+   * If an action ever needs it to decode, handle both cases explicitly: decode fully when it is
+   * provided, and fall back to `Unknown` when it is not.
+   */
+  from?: HexAddress
   actions: Array<{
     to: string
     data: string

--- a/test/unit/helpers/decoderLight.spec.ts
+++ b/test/unit/helpers/decoderLight.spec.ts
@@ -177,6 +177,24 @@ describe('Helpers: DecoderLight', () => {
       expect(result[2].type).to.equal(ProposalActionType.TransferNative)
     })
 
+    it('should decode actions without a from address, echoing back an empty from', async () => {
+      const actions = [
+        { to: '0xRecipient1', data: '0x', value: '1000' },
+        { to: '0xContract', data: '0x12345678', value: '0' },
+      ]
+
+      sandbox.stub(ProxyContract, 'getImplementationAddress').resolves(null)
+      sandbox.stub(ContractHelper, 'getSourceCode').resolves(null)
+
+      const result = await decoder.decodeBatch(actions, NetworksEnum.ethereumSepolia)
+
+      expect(result).to.have.length(2)
+      expect(result[0].type).to.equal(ProposalActionType.TransferNative)
+      expect(result[0].from).to.equal('')
+      expect(result[1].type).to.equal(ProposalActionType.Unknown)
+      expect(result[1].from).to.equal('')
+    })
+
     it('should reuse source code for same contract address', async () => {
       const actions = [
         { from: '0xDAO', to: '0xContract', data: '0x12345678', value: '0' },

--- a/test/unit/services/aragon-api/routers/v3/contract.spec.ts
+++ b/test/unit/services/aragon-api/routers/v3/contract.spec.ts
@@ -1,0 +1,211 @@
+import ContractController from '@api/controllers/contract'
+import MainRouter from '@api/routers'
+import ContractRouterV3 from '@api/routers/v3/contract'
+import config from '@config'
+import { ErrorKeyEnum, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { getAddress } from 'ethers'
+import Koa from 'koa'
+import bodyParser from 'koa-bodyparser'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+import supertest from 'supertest'
+
+const daoAddress = '0xf2d594f3c93c19d7b1a6f15b5489ffce4b01f7da'
+const targetAddress = '0x5fbdb2315678afecb367f032d93f642f64180aa3'
+
+const buildCtx = (query: Record<string, any> = {}, actions?: any[]) => ({
+  params: { network: NetworksEnum.ethereumMainnet },
+  query,
+  request: {
+    body: actions ?? [{ to: targetAddress, data: '0x12345678', value: '0' }],
+  },
+  body: null,
+})
+
+describe('RouterV3: Contract', () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  describe('decodeActionBatch', () => {
+    it('Should decode the batch without a `from` and return the results', async () => {
+      const mockResponse = [{ type: 'Unknown', from: '', to: targetAddress }] as any
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves(mockResponse)
+
+      const ctx: any = buildCtx()
+
+      await ContractRouterV3.decodeActionBatch(ctx)
+
+      expect(stubCtrl.calledOnce).to.be.true
+      const params = stubCtrl.firstCall.args[0]
+      expect(params.network).to.equal(NetworksEnum.ethereumMainnet)
+      expect(params.from).to.be.undefined
+      expect(params.actions).to.deep.equal([{ to: getAddress(targetAddress), data: '0x12345678', value: '0' }])
+      expect(ctx.body).to.deep.equal(mockResponse)
+    })
+
+    it('Should forward the optional `from` query param, checksummed', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx({ from: daoAddress })
+
+      await ContractRouterV3.decodeActionBatch(ctx)
+
+      expect(stubCtrl.firstCall.args[0].from).to.equal(getAddress(daoAddress))
+    })
+
+    it('Should accept a null action value', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx({}, [{ to: targetAddress, data: '0x', value: null }])
+
+      await ContractRouterV3.decodeActionBatch(ctx)
+
+      expect(stubCtrl.firstCall.args[0].actions[0].value).to.be.null
+    })
+
+    // `validateParams` runs Joi with `{ presence: 'required' }`, so every action key is mandatory
+    // unless explicitly optional — matching V2, where the schema's `.default('0')` never fires.
+    it('Should reject an action without a value', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx({}, [{ to: targetAddress, data: '0x' }])
+
+      await expect(ContractRouterV3.decodeActionBatch(ctx)).to.be.rejectedWith(Error, ErrorKeyEnum.badParams)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+
+    it('Should reject an invalid `from` query param', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx({ from: 'not-an-address' })
+
+      await expect(ContractRouterV3.decodeActionBatch(ctx)).to.be.rejectedWith(Error, ErrorKeyEnum.badParams)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+
+    it('Should reject an empty actions array', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx({}, [])
+
+      await expect(ContractRouterV3.decodeActionBatch(ctx)).to.be.rejectedWith(Error, ErrorKeyEnum.badParams)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+
+    it('Should reject a batch over the configured limit', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const actions = Array.from({ length: config.SERVICES.ARAGON_API.DECODE_ACTION_BATCH_LIMIT + 1 }, () => ({
+        to: targetAddress,
+        data: '0x12345678',
+        value: '0',
+      }))
+      const ctx: any = buildCtx({}, actions)
+
+      await expect(ContractRouterV3.decodeActionBatch(ctx)).to.be.rejectedWith(Error, ErrorKeyEnum.badParams)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+
+    it('Should reject an unknown network', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const ctx: any = buildCtx()
+      ctx.params.network = 'not-a-network'
+
+      await expect(ContractRouterV3.decodeActionBatch(ctx)).to.be.rejectedWith(Error, ErrorKeyEnum.badParams)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+  })
+
+  describe('router', () => {
+    it('Should register the decode-batch route without an address segment', () => {
+      const paths = ContractRouterV3.router().stack.map(layer => ({ path: layer.path, methods: layer.methods }))
+
+      expect(paths).to.have.lengthOf(1)
+      expect(paths[0].path).to.equal('/:network/decode-batch')
+      expect(paths[0].methods).to.include('POST')
+    })
+  })
+
+  describe('mounting', () => {
+    const network = NetworksEnum.ethereumMainnet
+    const actions = [{ to: targetAddress, data: '0x12345678', value: '0' }]
+
+    const buildRequest = () => {
+      const app = new Koa()
+      // The real service wraps the router in `errorMiddleware`; here we only need the thrown
+      // validation error to surface as a non-200, without Koa logging it.
+      app.on('error', () => {})
+      app.use(bodyParser())
+      app.use(MainRouter.router().routes())
+      return supertest(app.callback())
+    }
+
+    it('Should reach the V3 handler with no `from` on the versioned path', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest().post(`/v3/contract/${network}/decode-batch`).send(actions)
+
+      expect(response.status).to.equal(200)
+      expect(stubCtrl.firstCall.args[0].from).to.be.undefined
+      expect(stubCtrl.firstCall.args[0].network).to.equal(network)
+    })
+
+    it('Should reach the V3 handler with `from` from the query string', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest()
+        .post(`/v3/contract/${network}/decode-batch?from=${daoAddress}`)
+        .send(actions)
+
+      expect(response.status).to.equal(200)
+      expect(stubCtrl.firstCall.args[0].from).to.equal(getAddress(daoAddress))
+    })
+
+    it('Should resolve the unversioned path to V3', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest().post(`/contract/${network}/decode-batch`).send(actions)
+
+      expect(response.status).to.equal(200)
+      expect(stubCtrl.firstCall.args[0].from).to.be.undefined
+    })
+
+    it('Should leave the V2 path with an address segment untouched', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest().post(`/v2/contract/${network}/${daoAddress}/decode-batch`).send(actions)
+
+      expect(response.status).to.equal(200)
+      expect(stubCtrl.firstCall.args[0].from).to.equal(getAddress(daoAddress))
+    })
+
+    it('Should still fall back to V2 for the unversioned path with an address segment', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest().post(`/contract/${network}/${daoAddress}/decode-batch`).send(actions)
+
+      expect(response.status).to.equal(200)
+      expect(stubCtrl.firstCall.args[0].from).to.equal(getAddress(daoAddress))
+    })
+
+    it('Should reject an unknown query param on the V3 route', async () => {
+      const stubCtrl = sandbox.stub(ContractController, 'decodeContractDataBatch').resolves([] as any)
+
+      const response = await buildRequest()
+        .post(`/v3/contract/${network}/decode-batch?daoAddress=${daoAddress}`)
+        .send(actions)
+
+      expect(response.status).to.not.equal(200)
+      expect(stubCtrl.notCalled).to.be.true
+    })
+  })
+})

--- a/test/unit/services/aragon-gateway/actionDecoder.spec.ts
+++ b/test/unit/services/aragon-gateway/actionDecoder.spec.ts
@@ -167,5 +167,20 @@ describe('AragonDao: actionDecoder', () => {
       const calledActions = decodeBatchStub.firstCall.args[0]
       expect(calledActions[0].from).to.equal('0xDAO')
     })
+
+    it('should handle an omitted from address (V3 callers)', async () => {
+      const params = {
+        actions: [{ to: '0xRecipient', data: '0x', value: '1000' }],
+        network: NetworksEnum.ethereumSepolia,
+      }
+
+      const decodeBatchStub = sandbox.stub(DecoderLight.prototype, 'decodeBatch').resolves([])
+
+      await ActionDecoder.decodeLight(params)
+
+      const calledActions = decodeBatchStub.firstCall.args[0]
+      expect(calledActions[0].from).to.be.undefined
+      expect(calledActions[0].to).to.equal('0xRecipient')
+    })
   })
 })


### PR DESCRIPTION
## 📝 Summary
The goal of this PR is to enable action decoding outside of DAO context, so that frontend could provide DAO independent action composer.

The `ActionComposer` needs to decode actions when there is no DAO context (imports, previews, standalone tooling), but the V2 batch decode route forces a DAO address into the path: `POST /v2/contract/:network/:from/decode-batch`.

That address is not needed. Tracing it end to end, `from` is **write-only** in the light decode path — it is read exactly once, in `DecoderLight._buildBaseResult`, purely to echo it back on each result. It plays no part in proxy resolution, ABI/source lookup, selector matching, NatSpec parsing, type mapping, or native-transfer detection (all of which key off each action's `to`). For nested actions it is even discarded and replaced with the parent contract address.

This differs from the *heavy* decoder behind `/decode`, which genuinely uses `from` as `daoAddress` to resolve transfer direction and attribute metadata. The light decoder inherited the parameter but never the logic.

This PR adds a V3 route that drops the segment and accepts the address as an optional query param instead, so callers with no DAO context no longer have to invent one.

**Task:** [APP-1057](https://aragonassociation.atlassian.net/browse/APP-1057)

## 🔄 What Changed

**New V3 endpoint**

```
POST /v3/contract/:network/decode-batch?from=0x…   ← from is optional
POST /v2/contract/:network/:from/decode-batch      ← unchanged, now deprecated
```

- **`routers/v3/contract.ts`** (new) — reads `from` from `ctx.query` instead of the path. It is passed into `validateRoute` unconditionally (as `undefined` when absent) because `validateRoute` rejects any query key missing from `config.params` — the same pattern the V3 DAO router uses for `?address=`.
- **`routers/v3/index.ts`** — mounts `/contract`.
- **`routers/schema/contract.ts`** — adds `decodeActionBatchV3` with `from: joiAddress.optional()`. The `actions` array shape is extracted into a shared `decodeBatchActions` const so V2 and V3 cannot drift; V2's schema is otherwise unchanged in behaviour.
- **`types/queue.ts`** — `IQueueContractDecoderLight.from` is now optional. No change was needed in `actionDecoder.decodeLight` or `DecoderLight`: the existing `action.from || ''` in `_buildBaseResult` already yields `''` for an absent sender.
- **V2 marked `@deprecated`** in three places (handler, route JSDoc, schema) pointing at the V3 replacement. Behaviour is untouched — V2 keeps requiring the path segment for existing clients.

**Tests** — 17 new cases, all green alongside the existing suite (5775 passing).

- `test/unit/.../routers/v3/contract.spec.ts` — most cases run **real** Joi validation rather than stubbing it, since "is `from` genuinely optional" is the point. Includes a `supertest` block against the real `MainRouter` proving the versioned and unversioned V3 paths resolve, the 4-segment path still falls back to V2 (no shadowing either way), and unknown query params are rejected.
- `actionDecoder.spec.ts` / `decoderLight.spec.ts` — cover the newly reachable no-sender path (omitted `from` is not stamped onto actions; results echo `from: ''`).

### Notes for the reviewer

- **Frontend migration is one line** and can land separately: point `smartContractService.ts` at `/v3/contract/:network/decode-batch` and drop `address` from `IDecodeTransactionsLightUrlParams`. Nothing downstream changes, because `transferAssetAction.tsx` already falls back to `dao.address` when `action.from` is empty — and in the current import flow the echoed `from` is *always* equal to that fallback.
- **`value` remains required** on each action. `validateParams` runs Joi with `{ presence: 'required' }`, which makes every key mandatory unless explicitly `.optional()` — so the pre-existing `value: …default('0')` never fires, in V2 as much as V3. I kept this identical to V2 rather than quietly loosening V3, and pinned it with a test. Happy to make `value` properly optional in V3 if preferred.
- **Pre-existing, not addressed:** the queue message `id` in `decodeContractDataBatch` omits `from`. Harmless today because `waitResponse: true` skips the dedup branch in `rabbitMQ.process`, but it would become a real cross-DAO response-bleed bug if response caching were ever layered onto that `id`.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios — the `supertest` cases exercise the real `MainRouter` mount, but live in the unit suite; nothing was added under `test/integration`
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities — request fan-out stays bounded by the existing `DECODE_ACTION_BATCH_LIMIT` cap, and `from` is still address-validated when supplied
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
