### PR TITLE
perf(vote): make parent proposal lookup indexable via sentinel let values

### DIFF
--- a/src/models/schema/vote.ts
+++ b/src/models/schema/vote.ts
@@ -330,9 +330,11 @@ export default class Vote extends Model {
         {
           $lookup: {
             from: 'Proposal',
+            // Coalesce missing parentProposal refs to a sentinel: $eq against a missing let value
+            // is not indexable and falls back to a full Proposal collection scan per vote.
             let: {
-              pluginAddress: '$proposal.parentProposal.pluginAddress',
-              proposalIndex: '$proposal.parentProposal.proposalIndex',
+              pluginAddress: { $ifNull: ['$proposal.parentProposal.pluginAddress', 'none'] },
+              proposalIndex: { $ifNull: ['$proposal.parentProposal.proposalIndex', 'none'] },
             },
             pipeline: [
               {

--- a/src/models/schema/vote.ts
+++ b/src/models/schema/vote.ts
@@ -330,8 +330,6 @@ export default class Vote extends Model {
         {
           $lookup: {
             from: 'Proposal',
-            // Coalesce missing parentProposal refs to a sentinel: $eq against a missing let value
-            // is not indexable and falls back to a full Proposal collection scan per vote.
             let: {
               pluginAddress: { $ifNull: ['$proposal.parentProposal.pluginAddress', 'none'] },
               proposalIndex: { $ifNull: ['$proposal.parentProposal.proposalIndex', 'none'] },


### PR DESCRIPTION
## 📝 Summary

> **Stacked PR — part 1/2 of APP-1061** (Mongo query optimization). Part 2/2: #1498 stacks on this branch.

The votes list endpoint could take over a minute: the `parentProposal` $lookup in `Vote.findWithPagination` did a full Proposal collection scan per vote. When a vote's proposal has no parent (the vast majority), the `let` values resolve to *missing*, and `$eq` against a missing value cannot use an index.

**Task:** [APP-1061](https://linear.app/aragon/issue/APP-1061)

## 🔄 What Changed

- Coalesce the missing parent refs to a `'none'` sentinel via `$ifNull`, so the comparison stays a plain string equality and uses the existing Proposal index. No-parent votes become an instant indexed miss; votes with a real parent resolve exactly as before.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [x] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
