### PR TITLE
ci(APP-1028): warn about open tickets, refresh summary on push, parallelize staging deploy

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Thread timestamp to reply to (optional, enables threading)
     required: false
     default: ''
+  update-ts:
+    description: Timestamp of an existing message to rewrite in place via chat.update (optional, takes precedence over thread-ts)
+    required: false
+    default: ''
 
 outputs:
   ts:
@@ -31,6 +35,7 @@ runs:
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
         SLACK_CHANNEL_ID: ${{ inputs.slack-channel-id }}
         SLACK_THREAD_TS: ${{ inputs.thread-ts }}
+        SLACK_UPDATE_TS: ${{ inputs.update-ts }}
         SLACK_MESSAGE: ${{ inputs.message }}
       run: |
         set -euo pipefail

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -3,17 +3,16 @@ run-name: Release PR #${{ github.event.pull_request.number }} — test + staging
 
 # ──────────────────────────────────────────────────────────────────────────
 # Runs on release/* and hotfix/* PRs into `main`:
-#   1. fast checks (lint, format, unit + coverage) — pre-staging gate
-#   2. deploy to staging (Approve #1 = staging Environment protection)
+#   1. fast checks (lint, format, unit + coverage) and the staging deploy run in
+#      PARALLEL — merge is gated by the required checks (Approve #2), the deploy by
+#      the staging Environment's Required-reviewers rule (Approve #1)
+#   2. release/* PRs also regenerate the summary in the PR body + Slack root
+#      message on every push (refresh-summary)
 #   3. post "what to test" + non-blocking E2E into the Slack thread
 #
-# unit-dep + integration run via the existing unit-dep.yml / integration-test.yml
-# on the same PR and are required checks for MERGE (Approve #2). We keep only the
-# fast checks here to avoid duplicating the docker-compose-test infra before
-# staging.
-#
-# Deploys to `staging` — the staging Environment's Required-reviewers rule is
-# Approve #1 (pauses the deploy until a reviewer approves).
+# Only the fast checks live here: unit-dep + integration are required checks for
+# merge via their own workflows on the same PR, and duplicating the
+# docker-compose-test infra before staging would buy nothing.
 # ──────────────────────────────────────────────────────────────────────────
 
 on:
@@ -21,6 +20,8 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main]
 
+# Least privilege: only refresh-summary edits the PR body, so it carries the write
+# scope at job level and every other job here runs on a read-only token.
 permissions:
   contents: read
   pull-requests: read
@@ -38,6 +39,7 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
       thread-ts: ${{ steps.ts.outputs.ts }}
+      release-actor: ${{ steps.actor.outputs.actor }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -55,10 +57,43 @@ jobs:
           DELIM="EOF_$(date +%s%N)_$RANDOM"
           { echo "body<<$DELIM"; cat pr_body.txt; echo "$DELIM"; } >> "$GITHUB_OUTPUT"
       - name: Extract Slack thread ts
-        id: ts
+        id: ts-raw
         uses: ./.github/actions/extract-slack-ts
         with:
           text: ${{ steps.body.outputs.body }}
+      # A Slack ts is a unix timestamp and this release's root message is posted right after
+      # the PR opens, so a marker older than the PR belongs to another release — drop
+      # threading rather than let chat.update rewrite that release's message.
+      - name: Validate the Slack thread marker
+        id: ts
+        env:
+          TS: ${{ steps.ts-raw.outputs.ts }}
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TS" ]; then
+            echo "ts=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CREATED=$(node -p 'Math.floor(Date.parse(process.env.PR_CREATED_AT) / 1000)')
+          if [ "${TS%%.*}" -lt "$CREATED" ]; then
+            echo "::warning::Ignoring slack_ts $TS — it predates the PR, so it is not this release's root message."
+            echo "ts=" >> "$GITHUB_OUTPUT"
+          else
+            echo "ts=$TS" >> "$GITHUB_OUTPUT"
+          fi
+      # refresh-summary rewrites the whole root message, where `github.actor` is whoever
+      # pushed last — so release-start's attribution is carried in the body, not re-derived.
+      - name: Extract release actor
+        id: actor
+        env:
+          BODY: ${{ steps.body.outputs.body }}
+        run: |
+          set -euo pipefail
+          ACTOR=$(printf '%s\n' "$BODY" \
+            | sed -nE 's@^[[:space:]]*<!-- release_actor: ([A-Za-z0-9_.-]+) -->[[:space:]]*$@\1@p' \
+            | head -n 1)
+          echo "actor=$ACTOR" >> "$GITHUB_OUTPUT"
 
   test:
     needs: meta
@@ -73,12 +108,113 @@ jobs:
       - run: pnpm test:unit:coverage
       - run: pnpm test:coverage:check
 
-  # The "waiting Approve #1" gate ping is posted by deploy-reusable (notify-gate),
-  # so it fires for both release and manual deploys and isn't duplicated here.
+  # Keeps the PR body and the Slack root message reflecting the branch, not the snapshot
+  # release-start took — including the open-tickets warning.
+  # release/* only: hotfix PR bodies are authored by hotfix-start, not generated.
+  # synchronize only: on `opened` there is nothing to refresh yet, and the run would race
+  # release-start's body edit and rewrite it before the slack_ts marker lands, losing the
+  # Slack thread for the rest of the release.
+  refresh-summary:
+    if: github.event.action == 'synchronize' && startsWith(github.event.pull_request.head.ref, 'release/')
+    needs: meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Trusted code at the workspace root: scripts and composite actions are taken
+      # from the PR's BASE commit, never from the release branch. This job reads
+      # 1Password tokens below, and anyone able to push to release/* could otherwise
+      # swap the very code that handles them.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .github/actions
+            .github/workflows/scripts
+      # The release branch is checked out as git DATA only — the summary and the
+      # migration flag are derived from its history, no code from it is executed.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history: the summary range starts at the latest release tag.
+          fetch-depth: 0
+          path: pr
+      - name: Load secrets
+        id: secrets
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_BACKEND2_INFRA }}
+          LINEAR_API_TOKEN: op://kv_backend2_infra/LINEAR_API_TOKEN/credential
+          SLACK_BOT_TOKEN: op://kv_backend2_infra/SLACK_BOT_TOKEN/credential
+          SLACK_CHANNEL_ID: op://kv_backend2_infra/SLACK_CHANNEL_ID/credential
+      # Same flag release-start puts into the root message; re-detected here so the
+      # chat.update rewrite doesn't drop it.
+      - name: Detect DB migrations in this release (flag only)
+        id: migrations
+        working-directory: pr
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ] && git diff --name-only "$LAST_TAG"..HEAD | grep -qiE 'migration'; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has=false" >> "$GITHUB_OUTPUT"
+          fi
+      # Trusted script, release-branch history: the script derives everything from
+      # `git` in the working directory, so it reads the branch without running it.
+      - name: Regenerate release summary
+        id: summary
+        working-directory: pr
+        env:
+          LINEAR_API_TOKEN: ${{ steps.secrets.outputs.LINEAR_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          node "$GITHUB_WORKSPACE/.github/workflows/scripts/generateReleaseSummary.js" > "$GITHUB_WORKSPACE/summary.md"
+          DELIM="EOF_$(date +%s%N)_$RANDOM"
+          {
+            echo "summary<<$DELIM"
+            cat "$GITHUB_WORKSPACE/summary.md"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+      # Both markers are re-appended: they are this release's only cross-run state
+      # (Slack thread id and the actor release-start attributed the release to).
+      - name: Update PR body (preserving release markers)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          THREAD_TS: ${{ needs.meta.outputs.thread-ts }}
+          RELEASE_ACTOR: ${{ needs.meta.outputs.release-actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -n "$THREAD_TS" ]; then
+            printf '\n\n<!-- slack_ts: %s -->\n' "$THREAD_TS" >> summary.md
+          fi
+          if [ -n "$RELEASE_ACTOR" ]; then
+            printf '<!-- release_actor: %s -->\n' "$RELEASE_ACTOR" >> summary.md
+          fi
+          gh pr edit "$PR_NUMBER" --body-file summary.md
+      - name: Update Slack root message
+        if: needs.meta.outputs.thread-ts != '' && steps.secrets.outputs.SLACK_BOT_TOKEN != ''
+        uses: ./.github/actions/slack-notify
+        with:
+          slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+          update-ts: ${{ needs.meta.outputs.thread-ts }}
+          message: |
+            :rocket: *Backend Release v${{ needs.meta.outputs.version }} Started*
+            *PR:* ${{ github.event.pull_request.html_url }}
+            Branch: `${{ github.event.pull_request.head.ref }}`${{ needs.meta.outputs.release-actor != '' && format(' · by {0}', needs.meta.outputs.release-actor) || '' }}
+            ${{ steps.migrations.outputs.has == 'true' && ':warning: *Contains DB migrations* — roll-forward only' || '' }}
+
+            ${{ steps.summary.outputs.summary }}
+
+  # The "waiting Approve #1" gate ping comes from deploy-reusable (notify-gate), so it
+  # fires for manual deploys too and is not duplicated here.
   deploy-staging:
-    needs: [meta, test]
-    # Deploys to staging; Approve #1 = the staging Environment's Required-reviewers
-    # rule, which pauses this job until a reviewer approves.
+    needs: meta
     uses: ./.github/workflows/deploy-reusable.yml
     secrets: inherit
     with:
@@ -86,7 +222,6 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
       version: ${{ needs.meta.outputs.version }}
       slack-thread-ts: ${{ needs.meta.outputs.thread-ts }}
-
 
   e2e:
     needs: [meta, deploy-staging]

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -16,11 +16,9 @@ run-name: Start release (base ${{ inputs.base_commit || github.ref_name }})
 
 on:
   schedule:
-    # Auto release: every Monday at 14:37 UTC (~16:37 CEST in summer, 15:37 CET
-    # in winter — the cron is fixed in UTC, no DST handling). Off :00/:30
-    # because GitHub delays or drops schedules queued at popular minutes.
-    # Scheduled runs execute on the default branch, so the release bases off
-    # `development` — same as a manual run without inputs.
+    # Monday 14:37 UTC, fixed (no DST handling). Off :00/:30 — GitHub delays or drops
+    # schedules queued at popular minutes. A scheduled run executes on the default
+    # branch, so it bases off `development`, like a manual run without inputs.
     - cron: '37 14 * * 1'
   workflow_dispatch:
     inputs:
@@ -254,12 +252,19 @@ jobs:
 
             ${{ steps.summary.outputs.summary }}
 
-      - name: Embed slack_ts in PR body
+      # The PR body carries this release's cross-run state: the Slack thread id every
+      # later flow replies into, and the actor this release is attributed to (refresh-summary
+      # rewrites the root message, where `github.actor` would be the last pusher instead).
+      - name: Embed release markers in PR body
         if: steps.slack.outputs.ts != ''
         env:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_RELEASE_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          SLACK_TS: ${{ steps.slack.outputs.ts }}
+          RELEASE_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          gh pr view ${{ steps.pr.outputs.number }} --json body -q .body > body.md
-          printf '\n\n<!-- slack_ts: %s -->\n' "${{ steps.slack.outputs.ts }}" >> body.md
-          gh pr edit ${{ steps.pr.outputs.number }} --body-file body.md
+          gh pr view "$PR_NUMBER" --json body -q .body > body.md
+          printf '\n\n<!-- slack_ts: %s -->\n' "$SLACK_TS" >> body.md
+          printf '<!-- release_actor: %s -->\n' "$RELEASE_ACTOR" >> body.md
+          gh pr edit "$PR_NUMBER" --body-file body.md

--- a/.github/workflows/scripts/generateReleaseSummary.js
+++ b/.github/workflows/scripts/generateReleaseSummary.js
@@ -5,6 +5,9 @@ const REPO_URL = 'https://github.com/aragon/app-backend'
 const LINEAR_API_URL = 'https://api.linear.app/graphql'
 // Linear issue identifiers like "APP-1234" embedded in commit subjects.
 const LINEAR_ID_RE = /\b[A-Za-z]{2,}-\d+\b/g
+// Linear state types that mean a ticket is finished; anything else (triage, backlog,
+// unstarted, started) counts as open and is surfaced in the summary's warning section.
+const CLOSED_STATE_TYPES = new Set(['completed', 'canceled'])
 
 // Resolve a Linear issue to its title + url. Returns null on ANY failure (no
 // token, network error, unknown id) so the summary degrades gracefully — Linear
@@ -15,7 +18,7 @@ async function fetchLinearIssue(issueId, token) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: token },
       body: JSON.stringify({
-        query: 'query Issue($id: String!) { issue(id: $id) { title url } }',
+        query: 'query Issue($id: String!) { issue(id: $id) { title url state { name type } } }',
         variables: { id: issueId },
       }),
     })
@@ -145,7 +148,17 @@ async function categorize(commits) {
     }
   }
 
-  return { features, fixes, other }
+  // Tickets referenced by this range that are not completed/canceled yet. Unresolved
+  // ids (false positives like "UTF-8", missing issues) are cached as null, so the
+  // optional chaining below skips them and they never reach the warning.
+  const openIssues = []
+  for (const [id, issue] of issueCache) {
+    if (issue?.state && !CLOSED_STATE_TYPES.has(issue.state.type)) {
+      openIssues.push({ id, ...issue })
+    }
+  }
+
+  return { features, fixes, other, openIssues }
 }
 
 function formatSection(title, items) {
@@ -165,10 +178,16 @@ async function main() {
     return
   }
 
-  const { features, fixes, other } = await categorize(commits)
+  const { features, fixes, other, openIssues } = await categorize(commits)
   const total = features.length + fixes.length + other.length
 
   const sections = [
+    // Placed first so reviewers see un-QA'd tickets before approving/merging the
+    // release PR; the release is warned about, never blocked.
+    formatSection(
+      '*⚠️ Open tickets*',
+      openIssues.map(issue => `<${issue.url}|${issue.id}: ${issue.title}> — ${issue.state.name}`),
+    ),
     formatSection('*Features*', features),
     formatSection('*Fixes*', fixes),
     formatSection('*Other Changes*', other),

--- a/.github/workflows/scripts/slackNotify.js
+++ b/.github/workflows/scripts/slackNotify.js
@@ -4,6 +4,7 @@ const fs = require('node:fs')
 const token = process.env.SLACK_BOT_TOKEN
 const channel = process.env.SLACK_CHANNEL_ID
 const threadTs = process.env.SLACK_THREAD_TS || ''
+const updateTs = process.env.SLACK_UPDATE_TS || ''
 const message = process.env.SLACK_MESSAGE || ''
 
 if (!token || !channel) {
@@ -33,7 +34,11 @@ const payload = {
   unfurl_media: false,
 }
 
-if (threadTs) {
+// SLACK_UPDATE_TS rewrites an existing message in place (chat.update) instead of
+// posting a new one; SLACK_THREAD_TS still posts a new message into a thread.
+if (updateTs) {
+  payload.ts = updateTs
+} else if (threadTs) {
   payload.thread_ts = threadTs
 }
 
@@ -42,7 +47,7 @@ const body = JSON.stringify(payload)
 const req = https.request(
   {
     hostname: 'slack.com',
-    path: '/api/chat.postMessage',
+    path: updateTs ? '/api/chat.update' : '/api/chat.postMessage',
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,12 @@ deploys won't pause.
 ## Workflows & operator steps
 
 All release PRs target `main`. Slack threads are correlated via a
-`<!-- slack_ts: … -->` marker embedded in the PR/release body.
+`<!-- slack_ts: … -->` marker embedded in the PR/release body, alongside
+`<!-- release_actor: … -->` (who the release is attributed to, so a refresh does not
+re-attribute it to the last pusher). Leave both markers in place — deleting one loses
+the Slack thread or the attribution for the rest of the release. A `slack_ts` older
+than the PR is ignored, so a body copied from an earlier release cannot make the
+automation rewrite that release's Slack message.
 
 ### 1. Release — Start (`release-start.yml`) — scheduled or manual
 Runs automatically every Monday at **~5:30PM CET** (auto release); the
@@ -68,14 +73,23 @@ commits since the last tag. To start one manually, dispatch **on `development`**
 - cuts `release/x.y.z` from `development`, commits the version bump + CHANGELOG
   section (reviewable in the PR), force-pushes the branch;
 - opens the PR → `main` and starts the Slack thread (version, PR link, changelog,
-  DB-migration flag).
+  DB-migration flag, open-tickets warning).
 - **Guard:** only one open `release/*` PR at a time.
 
 ### 2. Release — PR (`release-pr.yml`) — on PR sync into `main`
 On `release/*` / `hotfix/*` PRs into `main`:
-- fast checks (lint, format, unit + coverage);
+- fast checks (lint, format, unit + coverage) and the staging deploy run in
+  **parallel** — the deploy is gated by Approve #1, not by the checks; merge is
+  where test results gate (Approve #2);
 - deploy to **staging** → **Approve #1** (the staging Environment pauses it;
   Slack thread + team ping);
+- on every **push** to a `release/*` PR (not on open — that would race release-start's
+  own body edit), the release summary in the PR body and the Slack root message are
+  regenerated — including the **⚠️ Open tickets** warning (Linear tickets referenced
+  by the release that are not completed/canceled, with their current status). The
+  warning never blocks; merging stays a human decision. This job runs the summary
+  script and Slack action from the PR's **base** commit and treats the release branch
+  as git data only, so a push cannot reach the tokens it loads;
 - after approval: non-blocking E2E (staging) + Slack note.
 - `unit-dep.yml` / `integration-test.yml` run on the same PR and are the required
   checks for **merge (Approve #2)**.


### PR DESCRIPTION
Implements the backend half of [APP-1028](https://linear.app/aragon/issue/APP-1028/automated-release-improvements-based-on-aug-31-retro) (Aug 31 retro).

## Changes

- **⚠️ Open tickets warning** — `generateReleaseSummary.js` now fetches each referenced Linear ticket's state and prepends an `*⚠️ Open tickets*` section listing every ticket that is not `completed`/`canceled`, with its current status. Warn only — merging stays a human decision. Unresolvable ids (false positives like `UTF-8`) stay out of the warning, matching the existing enrichment behavior.
- **Summary refresh on push** — new `refresh-summary` job in `release-pr.yml` (release/* PRs only): regenerates the summary on every push, rewrites the PR body (preserving the `slack_ts` marker) and updates the Slack root message via `chat.update` (new `update-ts` mode in `slack-notify`), mirroring the frontend release flow. Requires `pull-requests: write`.
- **Tests ∥ staging deploy** — `deploy-staging` no longer `needs: test`; fast checks and the staging deploy run in parallel. The deploy is still paused by the staging Environment gate (Approve #1), merge is still gated by required checks (Approve #2).
- `RELEASE.md` updated accordingly.

## ⚠️ Please verify branch protection

The `main` rulesets visible via API contain **no `required_status_checks` rule** (classic branch protection isn't readable with my token). With `deploy-staging` no longer depending on `test`, red fast checks won't block anything unless `test` / `unit-dep` / `integration` are required status checks for merge into `main` — worth double-checking in settings.

## Verification

- `node --check` on both scripts; `pnpm lint` clean.
- Standalone smoke-run of the summary script on real history (no token → no warning section) and in a fixture repo with a mocked Linear API → warning section renders with per-ticket status.
- Live check: next release PR should show the warning in body + Slack and refresh on push.