### PR TITLE
fix(migration): backfill missing token documents for gauge plugins

### DIFF
--- a/src/migrations/20260804180138-backfillGaugePluginTokens.ts
+++ b/src/migrations/20260804180138-backfillGaugePluginTokens.ts
@@ -1,0 +1,65 @@
+import { Models } from '@dbModels'
+import logger from '@logger'
+import type Plugin from '@models/schema/plugin'
+import { ProxyToken } from '@modules/proxyToken'
+import { type IMigration, IPluginInterfaceType } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: backfillGaugePluginTokens' })
+
+export const backfillGaugePluginTokensMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: '20260804180138-backfillGaugePluginTokens' }))
+
+    try {
+      const plugins = await Models.Plugin.find({
+        interfaceType: IPluginInterfaceType.gauge,
+        tokenAddress: { $ne: null },
+      })
+
+      const seen = new Set<string>()
+      let created = 0
+      let failed = 0
+
+      for (const plugin of plugins as Plugin[]) {
+        const key = `${plugin.network}-${plugin.tokenAddress}`
+        if (seen.has(key)) continue
+        seen.add(key)
+
+        const existingToken = await Models.Token.findExistingLog({
+          address: plugin.tokenAddress,
+          network: plugin.network,
+        })
+        if (existingToken) continue
+
+        const token = await ProxyToken.saveAndGetToken(plugin.tokenAddress, plugin.network)
+        if (token) {
+          created++
+          logger.verbose(
+            'Backfilled missing gauge plugin token',
+            llo({ pluginAddress: plugin.address, tokenAddress: plugin.tokenAddress, network: plugin.network }),
+          )
+        } else {
+          failed++
+          logger.warn(
+            'Could not backfill gauge plugin token',
+            llo({ pluginAddress: plugin.address, tokenAddress: plugin.tokenAddress, network: plugin.network }),
+          )
+        }
+      }
+
+      logger.info(
+        'Migration completed successfully',
+        llo({ migration: '20260804180138-backfillGaugePluginTokens', created, failed }),
+      )
+    } catch (error) {
+      logger.error('Migration failed', llo({ migration: '20260804180138-backfillGaugePluginTokens', error }))
+      throw error
+    }
+  },
+
+  stop: async () => {
+    // Usually empty for migrations
+  },
+}
+
+export default backfillGaugePluginTokensMigration

--- a/test/unit/migrations/20260804180138-backfillGaugePluginTokens.spec.ts
+++ b/test/unit/migrations/20260804180138-backfillGaugePluginTokens.spec.ts
@@ -1,0 +1,125 @@
+import { Models } from '@dbModels'
+import logger from '@logger'
+import { ProxyToken } from '@modules/proxyToken'
+import backfillGaugePluginTokensMigration from '@src/migrations/20260804180138-backfillGaugePluginTokens'
+import { IPluginInterfaceType, IPluginStatus, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { SinonSandbox, SinonStub } from 'sinon'
+
+describe('migration: backfillGaugePluginTokens', () => {
+  const network = NetworksEnum.ethereumMainnet
+
+  let sandbox: SinonSandbox
+  let saveAndGetTokenStub: SinonStub
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    saveAndGetTokenStub = sandbox.stub(ProxyToken, 'saveAndGetToken').callsFake(async (tokenAddress, net) => {
+      await Models.Token.collection.insertOne({
+        id: `${tokenAddress}-${net}`,
+        address: tokenAddress,
+        network: net,
+        name: 'Backfilled',
+        symbol: 'BF',
+      })
+      return (await Models.Token.collection.findOne({ address: tokenAddress, network: net })) as any
+    })
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
+  })
+
+  const seedPlugin = async (address: string, tokenAddress: string | null, interfaceType = IPluginInterfaceType.gauge) =>
+    Models.Plugin.create({
+      address,
+      daoAddress: '0xabCDef1234567890abCdEF1234567890ABcDeF12',
+      network,
+      interfaceType,
+      status: IPluginStatus.installed,
+      tokenAddress,
+      blockNumber: 1000,
+      transactionHash: '0xabc123',
+    })
+
+  describe('start', () => {
+    it('creates the missing token for a gauge plugin with a tokenAddress', async () => {
+      const tokenAddress = '0xB000000000000000000000000000000000000001'
+      await seedPlugin('0xA000000000000000000000000000000000000001', tokenAddress)
+
+      await backfillGaugePluginTokensMigration.start()
+
+      const token = await Models.Token.collection.findOne({ address: tokenAddress, network })
+      expect(token).to.exist
+      expect(saveAndGetTokenStub.calledOnceWith(tokenAddress, network)).to.be.true
+    })
+
+    it('skips gauge plugins whose token already exists', async () => {
+      const tokenAddress = '0xB000000000000000000000000000000000000002'
+      await seedPlugin('0xA000000000000000000000000000000000000002', tokenAddress)
+      await Models.Token.collection.insertOne({
+        id: `${tokenAddress}-${network}`,
+        address: tokenAddress,
+        network,
+        name: 'Existing',
+        symbol: 'EX',
+      })
+
+      await backfillGaugePluginTokensMigration.start()
+
+      expect(saveAndGetTokenStub.called).to.be.false
+      const tokens = await Models.Token.collection.find({ address: tokenAddress, network }).toArray()
+      expect(tokens).to.have.lengthOf(1)
+      expect(tokens[0].name).to.eq('Existing')
+    })
+
+    it('ignores non-gauge plugins and gauge plugins without a tokenAddress', async () => {
+      await seedPlugin(
+        '0xA000000000000000000000000000000000000003',
+        '0xB000000000000000000000000000000000000003',
+        IPluginInterfaceType.tokenVoting,
+      )
+      await seedPlugin('0xA000000000000000000000000000000000000004', null)
+
+      await backfillGaugePluginTokensMigration.start()
+
+      expect(saveAndGetTokenStub.called).to.be.false
+      expect(await Models.Token.collection.countDocuments({})).to.eq(0)
+    })
+
+    it('deduplicates plugins sharing the same tokenAddress and network', async () => {
+      const tokenAddress = '0xB000000000000000000000000000000000000005'
+      await seedPlugin('0xA000000000000000000000000000000000000005', tokenAddress)
+      await seedPlugin('0xA000000000000000000000000000000000000006', tokenAddress)
+
+      await backfillGaugePluginTokensMigration.start()
+
+      expect(saveAndGetTokenStub.calledOnce).to.be.true
+      const tokens = await Models.Token.collection.find({ address: tokenAddress, network }).toArray()
+      expect(tokens).to.have.lengthOf(1)
+    })
+
+    it('completes cleanly when there is nothing to migrate', async () => {
+      await backfillGaugePluginTokensMigration.start()
+
+      expect(saveAndGetTokenStub.called).to.be.false
+    })
+
+    it('logs error and rethrows when the plugin query fails', async () => {
+      const loggerErrorStub = sandbox.stub(logger, 'error')
+      sandbox.stub(Models.Plugin, 'find').rejects(new Error('Database error'))
+
+      await expect(backfillGaugePluginTokensMigration.start()).to.be.rejectedWith('Database error')
+      const failedErrorCall = loggerErrorStub.getCalls().find(call => String(call.args[0]) === 'Migration failed')
+      expect(failedErrorCall).to.exist
+    })
+  })
+
+  describe('stop', () => {
+    it('should do nothing', async () => {
+      await backfillGaugePluginTokensMigration.stop()
+      expect(true).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
## 📝 Summary

19 gauge plugins have a `tokenAddress` with no matching `Token` document, so the API returns `settings.token` as empty and the gauges page crashes (e.g. `benqi-governance` on avax-mainnet). Cause: the `resetGauges` migration stamped `tokenAddress` on plugins without calling `ProxyToken.saveAndGetToken`, and nothing backfills tokens after install time.

## 🔄 What Changed

- New migration `20260804180138-backfillGaugePluginTokens`: for gauge plugins with a `tokenAddress` but no Token row, calls `ProxyToken.saveAndGetToken` (deduped by network+token, skips existing, logs created/failed)
- Unit test covering create-missing, skip-existing, non-gauge/null-token, dedupe, no-op, and error paths

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)