### PR TITLE
fix(replay): attach tick context so replayed events can resolve block timestamps

### DIFF
--- a/src/helpers/eventReplay.ts
+++ b/src/helpers/eventReplay.ts
@@ -1,6 +1,7 @@
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
+import { TickContext } from '@modules/crawlers/tickContext'
 import IndexerEventConfig from '@services/aragon-indexer/configIndexer'
 import { type IIndexerConfig, type ILogInfo, type NetworksEnum } from '@types'
 import { Interface, type Log, type LogDescription } from 'ethers'
@@ -52,10 +53,14 @@ const EventReplayHelper = {
     const sortedLogs = [...receipt.logs].sort((a: any, b: any) => a.index - b.index)
     const parsed = EventReplayHelper.parseLogsByConfig(sortedLogs as any, network)
 
+    const tickCtx = new TickContext(network, sortedLogs as any)
+    await tickCtx.init()
+
     let handled = 0
     let failed = 0
     for (const { event, handler, info } of parsed) {
       try {
+        info.context = tickCtx
         await handler(event, info)
         handled++
       } catch (error) {

--- a/test/unit/helpers/eventReplay.spec.ts
+++ b/test/unit/helpers/eventReplay.spec.ts
@@ -1,6 +1,7 @@
 import '@test/environment'
 import EventReplayHelper from '@helpers/eventReplay'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import IndexerEventConfig from '@services/aragon-indexer/configIndexer'
@@ -24,6 +25,7 @@ describe('Helper: EventReplay', () => {
     sandbox = sinon.createSandbox()
     sandbox.stub(logger, 'warn')
     sandbox.stub(logger, 'error')
+    sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map())
   })
 
   afterEach(() => {
@@ -103,6 +105,23 @@ describe('Helper: EventReplay', () => {
         handled: 2,
         failed: 0,
       })
+    })
+
+    it('attaches a tick context so handlers can resolve block timestamps', async () => {
+      sandbox
+        .stub(Web3Helper, 'getTransactionReceipt')
+        .resolves({ logs: [{ index: 0, topics: ['0x0'], blockNumber: 100, transactionHash: txHash }] } as any)
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(1750000000)
+
+      const handler = sandbox.stub().resolves()
+      const info = { eventName: 'Deposit', network, blockNumber: 100 } as any
+      sandbox.stub(EventReplayHelper, 'parseLogsByConfig').returns([{ event: {} as any, handler, info }])
+
+      await EventReplayHelper.handleEventsFromTxHash(txHash, network)
+
+      const passedInfo = handler.firstCall.args[1]
+      expect(passedInfo.context).to.not.be.undefined
+      expect(await passedInfo.context.getBlockTimestamp(100)).to.equal(1750000000)
     })
 
     it('isolates a failing handler and keeps processing the rest', async () => {


### PR DESCRIPTION
## 📝 Summary

This pull request enhances the event replay functionality by introducing a tick context, which allows event handlers to resolve block timestamps during processing. It also updates the unit tests to cover this new behavior and ensures that block timestamp fetching is properly stubbed in tests.

**Enhancements to event replay context:**

* [`src/helpers/eventReplay.ts`](diffhunk://#diff-3741c3caeac7a110f3c1d9beb775fe26ed659026177e888a157c19a4996e0661R4): Introduced the `TickContext` class to provide context (including block timestamp resolution) to event handlers during event replay. The tick context is initialized and attached to the `info` object passed to each handler. [[1]](diffhunk://#diff-3741c3caeac7a110f3c1d9beb775fe26ed659026177e888a157c19a4996e0661R4) [[2]](diffhunk://#diff-3741c3caeac7a110f3c1d9beb775fe26ed659026177e888a157c19a4996e0661R56-R63)

**Testing improvements:**

* [`test/unit/helpers/eventReplay.spec.ts`](diffhunk://#diff-c24f4991c0f4178e4751814c789501d76ddc806f69133545ff5b8a8120b295b2R110-R126): Added a unit test to verify that a tick context is attached and that handlers can resolve block timestamps through it.
* [`test/unit/helpers/eventReplay.spec.ts`](diffhunk://#diff-c24f4991c0f4178e4751814c789501d76ddc806f69133545ff5b8a8120b295b2R28): Stubbed `Web3BatchHelper.getBlocksTimestamps` in the test setup to prevent actual network calls during tests.
* [`test/unit/helpers/eventReplay.spec.ts`](diffhunk://#diff-c24f4991c0f4178e4751814c789501d76ddc806f69133545ff5b8a8120b295b2R4): Imported `Web3BatchHelper` to support the new test stubbing.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
