### PR TITLE
fix: remove unused discord webhook from api-monitor workflow

### DIFF
--- a/.github/workflows/api-monitor.yml
+++ b/.github/workflows/api-monitor.yml
@@ -6,9 +6,6 @@ on:
     - cron: '*/15 * * * *' # Runs every 15 mins
   workflow_dispatch:
 
-env:
-  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-
 permissions:
   contents: read
 
@@ -162,63 +159,3 @@ jobs:
           EOF
 
           bash curl_test
-
-  #     - name: Notify Discord on Failure
-  #       if: failure()
-  #       env:
-  #         FAILURES: ${{ env.FAILURES }}
-  #       run: |
-  #         echo "Sending Discord failure notification..."
-
-  #         # Create JSON payload
-  #         cat <<EOF > payload.json
-  #         {
-  #           "embeds": [{
-  #             "title": "❌ Backend API Monitoring Test Failed",
-  #             "color": 15158332,
-  #             "fields": [
-  #               { "name": "Repository", "value": "aragon/app-backend", "inline": false },
-  #               { "name": "Workflow", "value": "AppBackend API Monitoring", "inline": false },
-  #               { "name": "Branch", "value": "${{ github.ref }}", "inline": false },
-  #               { "name": "Environment", "value": "${{ matrix.host }} (${{ matrix.env_name }})", "inline": false },
-  #               { "name": "Details", "value": "[View Failure Details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": false }
-  #             ],
-  #             "timestamp": "$(date --utc +%FT%TZ)"
-  #           }]
-  #         }
-  #         EOF
-
-  #         # Send notification to Discord
-  #         curl -X POST -H "Content-Type: application/json" -d @payload.json https://discord.com/api/webhooks/1309183202719699084/7iigCapTmyIHtgkqcLfXY9j557T_YChm7bv9h-BBU37ZhPDIIZYt34Z0KkqQGCBGic1M
-  #         echo "Discord notification sent."
-
-  #     - name: Cleanup Temporary Files
-  #       run: rm -rf ./node_modules ./build ./tmp
-
-  # weekly_success:
-  #   if: github.event.schedule == '0 0 * * 1'
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Notify Discord Weekly Success Message
-  #       run: |
-  #         echo "Sending Discord weekly success notification..."
-  #         cat <<EOF > payload.json
-  #         {
-  #           "embeds": [{
-  #             "title": "✅ Weekly Report: Backend API Monitoring Tests Succeeded!",
-  #             "color": 3066993,
-  #             "fields": [
-  #               { "name": "Repository", "value": "aragon/app-backend", "inline": false },
-  #               { "name": "Workflow", "value": "AppBackend API Monitoring", "inline": false },
-  #               { "name": "Branch", "value": "${{ github.ref }}", "inline": false },
-  #               { "name": "Environment", "value": "${{ matrix.host }} (${{ matrix.env_name }})", "inline": false },
-  #               { "name": "Details", "value": "[View Failure Details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": false }
-  #             ],
-  #             "timestamp": "$(date --utc +%FT%TZ)"
-  #           }]
-  #         }
-  #         EOF
-
-  #         curl -X POST -H "Content-Type: application/json" -d @payload.json https://discord.com/api/webhooks/1309183202719699084/7iigCapTmyIHtgkqcLfXY9j557T_YChm7bv9h-BBU37ZhPDIIZYt34Z0KkqQGCBGic1M
-  #         echo "Discord weekly success notification sent."


### PR DESCRIPTION
## 📝 Summary

A hardcoded discord webhook url was sitting in commented code in the api-monitor workflow, flagged by https://github.com/aragon/app-backend/issues/1506. We no longer use the discord notification, so removed the whole section along with the unused webhook env.

## 🔄 What Changed

- Removed commented discord notification steps from `.github/workflows/api-monitor.yml`
- Removed unused `DISCORD_WEBHOOK_URL` env

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)