### PR TITLE
fix(governance): order same-block DelegateVotesChanged events by log index

### DIFF
--- a/src/governance/erc20Governance.ts
+++ b/src/governance/erc20Governance.ts
@@ -77,6 +77,7 @@ export class Erc20Governance extends BaseGovernance {
           network: this.network,
           delegateReceivedCount: 0,
           lastVPBlockNumber: params?.lastActivity || 0,
+          lastVPLogIndex: params?.logIndex || 0,
         },
         { session },
       )
@@ -119,13 +120,20 @@ export class Erc20Governance extends BaseGovernance {
           return null
         }
 
-        // Only update if block number is newer
-        if (params.lastActivity && tokenMember.lastVPBlockNumber >= params.lastActivity) {
+        // Only update if (block number, log index) is newer; same-block events are ordered by log index
+        const isStale =
+          params.lastActivity &&
+          (tokenMember.lastVPBlockNumber > params.lastActivity ||
+            (tokenMember.lastVPBlockNumber === params.lastActivity &&
+              (params.logIndex === undefined || (tokenMember.lastVPLogIndex || 0) >= params.logIndex)))
+        if (isStale) {
           logger.verbose(
             'Skipping update - older block',
             this.llo({
               current: tokenMember.lastVPBlockNumber,
+              currentLogIndex: tokenMember.lastVPLogIndex,
               new: params.lastActivity,
+              newLogIndex: params.logIndex,
             }),
           )
           await session.commitTransaction()
@@ -146,6 +154,9 @@ export class Erc20Governance extends BaseGovernance {
         }
         if (params.lastActivity !== undefined) {
           updateData.lastVPBlockNumber = params.lastActivity
+        }
+        if (params.logIndex !== undefined) {
+          updateData.lastVPLogIndex = params.logIndex
         }
         if (params.delegateReceivedCount !== undefined) {
           updateData.delegateReceivedCount = params.delegateReceivedCount
@@ -301,6 +312,7 @@ export class Erc20Governance extends BaseGovernance {
       votingPower?: string
       tokenIds?: string[]
       lastVPBlockNumber: number
+      lastVPLogIndex?: number
     }>,
   ): Promise<boolean> {
     try {
@@ -318,9 +330,9 @@ export class Erc20Governance extends BaseGovernance {
         })
         .filter(update => update !== null)
 
-      // Sort by block number descending and reduce to get only latest per id
+      // Sort by (block number, log index) descending and reduce to get only latest per id
       const latestUpdates = updatesWithParsedAddress
-        .sort((a, b) => b.lastVPBlockNumber - a.lastVPBlockNumber)
+        .sort((a, b) => b.lastVPBlockNumber - a.lastVPBlockNumber || (b.lastVPLogIndex || 0) - (a.lastVPLogIndex || 0))
         .reduce<typeof updatesWithParsedAddress>((acc, update) => {
           if (!acc.some(u => u.id === update.id)) {
             acc.push(update)
@@ -332,6 +344,10 @@ export class Erc20Governance extends BaseGovernance {
         const setFields: any = {
           votingPower: update.votingPower?.toString() || '0',
           lastVPBlockNumber: update.lastVPBlockNumber,
+        }
+
+        if (update.lastVPLogIndex !== undefined) {
+          setFields.lastVPLogIndex = update.lastVPLogIndex
         }
 
         if (update.tokenIds !== undefined) {

--- a/src/handlers/governanceErc20Handler.ts
+++ b/src/handlers/governanceErc20Handler.ts
@@ -37,6 +37,7 @@ export const GovernanceErc20Handler = {
       await governance.update(memberAddress, {
         votingPower: newBalance.toString(),
         lastActivity,
+        logIndex: info.logIndex,
       })
 
       // Update plugin metrics for all plugins using this token
@@ -85,10 +86,14 @@ export const GovernanceErc20Handler = {
 
       // Use for...of with Map entries for better performance
       for (const [, memberEvents] of eventsByMember) {
-        // Find the event with the highest block number without sorting the entire array
+        // Find the event with the highest (block number, log index) without sorting the entire array
         let latestEvent = memberEvents[0]
         for (let i = 1; i < memberEvents.length; i++) {
-          if (memberEvents[i].info.blockNumber > latestEvent.info.blockNumber) {
+          const current = memberEvents[i].info
+          if (
+            current.blockNumber > latestEvent.info.blockNumber ||
+            (current.blockNumber === latestEvent.info.blockNumber && current.logIndex > latestEvent.info.logIndex)
+          ) {
             latestEvent = memberEvents[i]
           }
         }
@@ -114,6 +119,7 @@ export const GovernanceErc20Handler = {
             memberAddress: string
             votingPower: string
             lastVPBlockNumber: number
+            lastVPLogIndex?: number
           }>
         >()
 
@@ -123,6 +129,7 @@ export const GovernanceErc20Handler = {
             memberAddress: parsedEvent.args.delegate,
             votingPower: BigInt(parsedEvent?.args?.newBalance || 0).toString(),
             lastVPBlockNumber: info.blockNumber,
+            lastVPLogIndex: info.logIndex,
           }
           const existing = updatesByTokenNetwork.get(key)
           if (existing) {
@@ -244,6 +251,7 @@ export const GovernanceErc20Handler = {
             await governance.update(memberAddress, {
               votingPower: BigInt(parsedEvent?.args?.newBalance || 0).toString(),
               lastActivity: info.blockNumber,
+              logIndex: info.logIndex,
             })
 
             // Update plugin metrics for this member

--- a/src/models/schema/tokenMember.ts
+++ b/src/models/schema/tokenMember.ts
@@ -58,6 +58,9 @@ export default class TokenMember extends Model {
   @prop({ type: () => Number, default: 0 })
   public lastVPBlockNumber!: number
 
+  @prop({ type: () => Number, default: 0 })
+  public lastVPLogIndex!: number
+
   static async create(rawData: Partial<TokenMember> = {} as Partial<TokenMember>, tOpts?: SaveOptions) {
     if (!rawData.id) {
       assert(!!rawData.network, 'network is required')

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -5,6 +5,7 @@ export interface IGovernanceParamsOpts {
   tokenIds?: string[]
   tokenId?: string
   lastActivity?: number
+  logIndex?: number
   votingPower?: string
   delegateReceivedCount?: number
   delegateReceiverAddress?: string | null

--- a/test/unit/governance/erc20Governance.spec.ts
+++ b/test/unit/governance/erc20Governance.spec.ts
@@ -352,6 +352,61 @@ describe('Governance:Erc20Governance', () => {
       expect(loggerVerboseStub.calledWith('Skipping update - older block')).to.be.true
     })
 
+    it('should apply same-block update with higher log index', async () => {
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      // First event in the block already applied
+      await Models.TokenMember.create({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+        network: testNetwork,
+        votingPower: '1000000000000000000',
+        lastVPBlockNumber: 12345,
+        lastVPLogIndex: 10,
+      })
+
+      // Second event in the same block (e.g. received then transferred away in one tx)
+      const result = await erc20Governance.update(memberAddress, {
+        votingPower: '1',
+        lastActivity: 12345,
+        logIndex: 15,
+      })
+
+      expect(result).to.exist
+      expect(result?.votingPower).to.equal('1')
+      expect(result?.lastVPBlockNumber).to.equal(12345)
+      expect(result?.lastVPLogIndex).to.equal(15)
+
+      const updatedMember = await Models.TokenMember.findOne({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+      })
+      expect(updatedMember?.votingPower).to.equal('1')
+    })
+
+    it('should skip same-block update with lower log index', async () => {
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      await Models.TokenMember.create({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+        network: testNetwork,
+        votingPower: '1',
+        lastVPBlockNumber: 12345,
+        lastVPLogIndex: 15,
+      })
+
+      const result = await erc20Governance.update(memberAddress, {
+        votingPower: '1000000000000000000',
+        lastActivity: 12345,
+        logIndex: 10, // Earlier event replayed out of order
+      })
+
+      expect(result).to.exist
+      expect(result?.votingPower).to.equal('1') // Should not change
+      expect(result?.lastVPLogIndex).to.equal(15)
+
+      expect(loggerVerboseStub.calledWith('Skipping update - older block')).to.be.true
+    })
+
     it('should clear tokenIds when voting power is set to 0', async () => {
       const parsedAddress = Web3Utils.parseAddress(memberAddress)
       // Create existing member with tokenIds
@@ -862,6 +917,37 @@ describe('Governance:Erc20Governance', () => {
         expect(member).to.exist
         expect(member?.votingPower).to.equal('2000')
         expect(member?.lastVPBlockNumber).to.equal(200)
+      })
+
+      it('should keep latest by log index for same-block duplicates', async () => {
+        const updates = [
+          {
+            memberAddress: '0x1111111111111111111111111111111111111111' as HexAddress,
+            votingPower: '1000000000000000000',
+            lastVPBlockNumber: 100,
+            lastVPLogIndex: 5,
+          },
+          {
+            memberAddress: '0x1111111111111111111111111111111111111111' as HexAddress,
+            votingPower: '1',
+            lastVPBlockNumber: 100, // Same block, later event
+            lastVPLogIndex: 8,
+          },
+        ]
+
+        const result = await erc20Governance.updateTokenMemberVPBatchNoTx(updates)
+
+        expect(result).to.be.true
+
+        // Should use the update with higher log index
+        const member = await Models.TokenMember.findOne({
+          memberAddress: Web3Utils.parseAddress(updates[0].memberAddress),
+          tokenAddress: testTokenAddress,
+        })
+
+        expect(member).to.exist
+        expect(member?.votingPower).to.equal('1')
+        expect(member?.lastVPLogIndex).to.equal(8)
       })
 
       it('should clear tokenIds when voting power is 0', async () => {


### PR DESCRIPTION
## 📝 Summary

Voting power in TokenMember goes wrong when a member receives and sends away tokens in the same transaction. Token emits two DelegateVotesChanged in the same block and we keep the first value, since we only compare block numbers. Example on polygon, token 0x8A68ad904551AD8148fd72b69Ac87E0950E85BfB member 0x8F10B468b06c6FD214B65F87778827F7D113f996, db has 1e18 but on chain it is 1 wei.

## 🔄 What Changed

Pass logIndex through the delegate votes handlers and compare (blockNumber, logIndex) when deciding if an update is stale. Added lastVPLogIndex to TokenMember for the same block tiebreak. Batch dedupe also tiebreaks on log index now. Callers that dont pass logIndex behave same as before.

Backfill for the already wrong rows comes separate.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [x] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)