### PR TITLE
chore: sync main (v0.34.0) back to development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.34.0](https://github.com/aragon/app-backend/compare/v0.33.0...v0.34.0) (2026-08-03)
+## [0.34.0](https://github.com/aragon/app-backend/compare/v0.33.0...v0.34.0) (2026-08-07)
 
 ### Features
 
@@ -15,8 +15,12 @@
 
 * **api:** reject empty segments in pagination field path validation ([5896867](https://github.com/aragon/app-backend/commit/58968672e4446d3fdec7a190eccab6469f35d3b0))
 * **api:** reject non-field sort values in pagination validation ([2b0ef84](https://github.com/aragon/app-backend/commit/2b0ef84942ac67c63982aec1b1d199ffa2632b9f))
+* **governance:** order same-block DelegateVotesChanged events by log index ([475f36e](https://github.com/aragon/app-backend/commit/475f36e1c35f3fb66306b4e95076a0b976651542))
+* land APP-1019 objection tally content stranded by stacked merge ([#1489](https://github.com/aragon/app-backend/issues/1489)) ([c4d0ce3](https://github.com/aragon/app-backend/commit/c4d0ce3f566269bf2e5d9053a7fbf2e075d923ba))
+* **logTokenVoting:** ensure highest log index for duplicate logs in the same block ([63955b9](https://github.com/aragon/app-backend/commit/63955b9f862abdcc0e574c22a204fde271e64a0b))
 * **plugin:** address objection review notes and add detection backfill tool ([86b10c1](https://github.com/aragon/app-backend/commit/86b10c161e8b09b18ce48eff1f165fe15ec210bc))
 * **plugin:** handle objection settings safely ([84c7cda](https://github.com/aragon/app-backend/commit/84c7cda54b99c1a4f4f4144f6856917e0d124ae6))
+* **replay:** attach tick context so replayed events can resolve block timestamps ([3c5a7ad](https://github.com/aragon/app-backend/commit/3c5a7ad5c9dbeb82b3f2fa3dbc6bbf5a97c61cf5))
 ## [0.33.0](https://github.com/aragon/app-backend/compare/v0.32.0...v0.33.0) (2026-07-27)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [0.34.0](https://github.com/aragon/app-backend/compare/v0.33.0...v0.34.0) (2026-08-03)
+
+### Features
+
+* enrich permission entities ([#1490](https://github.com/aragon/app-backend/issues/1490)) ([f2d7af8](https://github.com/aragon/app-backend/commit/f2d7af8ea57ad582ae73f59716e8ec111a5a26cc))
+* expose SPP Safe metadata on permission entity refs ([#1491](https://github.com/aragon/app-backend/issues/1491)) ([8736add](https://github.com/aragon/app-backend/commit/8736addadae4cbf521c6d5434e483c8348227c56))
+* **plugin:** add isObjection flag to support objection plugins and enhance settings synchronization ([d6360c6](https://github.com/aragon/app-backend/commit/d6360c6555050341c59047abb9fac5bfff6d4f0b))
+* **plugin:** update getVotingSettings to accept block number and adjust related settings handling ([eb2f1ad](https://github.com/aragon/app-backend/commit/eb2f1add99f154d65469666040441048ae7eeeb8))
+* **proxy:** enhance proxy implementation detection for multiple proxy types ([baa640b](https://github.com/aragon/app-backend/commit/baa640b459ee97ae8c659b9f3d197442dd05fc6f))
+* **proxy:** improve proxy implementation detection logic and update test cases ([168b295](https://github.com/aragon/app-backend/commit/168b295511ae1d3f9615c62ba18eb4ed04a77db9))
+* **votes:** handle OverrideVoteCast to update delegate votes on override ([d62ad17](https://github.com/aragon/app-backend/commit/d62ad17d867ebb769ba3b31ce8af387b24c4a94f))
+* **votes:** update delegatee vote handling for overrides and add metadata ([e1e6422](https://github.com/aragon/app-backend/commit/e1e642247a5b398abce91b9f1386feaec678d464))
+
+### Bug Fixes
+
+* **api:** reject empty segments in pagination field path validation ([5896867](https://github.com/aragon/app-backend/commit/58968672e4446d3fdec7a190eccab6469f35d3b0))
+* **api:** reject non-field sort values in pagination validation ([2b0ef84](https://github.com/aragon/app-backend/commit/2b0ef84942ac67c63982aec1b1d199ffa2632b9f))
+* **plugin:** address objection review notes and add detection backfill tool ([86b10c1](https://github.com/aragon/app-backend/commit/86b10c161e8b09b18ce48eff1f165fe15ec210bc))
+* **plugin:** handle objection settings safely ([84c7cda](https://github.com/aragon/app-backend/commit/84c7cda54b99c1a4f4f4144f6856917e0d124ae6))
 ## [0.33.0](https://github.com/aragon/app-backend/compare/v0.32.0...v0.33.0) (2026-07-27)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aragon-backend",
   "description": "OpenSource backend services",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "author": "Aragon Development Team",

--- a/src/governance/erc20Governance.ts
+++ b/src/governance/erc20Governance.ts
@@ -77,6 +77,7 @@ export class Erc20Governance extends BaseGovernance {
           network: this.network,
           delegateReceivedCount: 0,
           lastVPBlockNumber: params?.lastActivity || 0,
+          lastVPLogIndex: params?.logIndex || 0,
         },
         { session },
       )
@@ -119,13 +120,20 @@ export class Erc20Governance extends BaseGovernance {
           return null
         }
 
-        // Only update if block number is newer
-        if (params.lastActivity && tokenMember.lastVPBlockNumber >= params.lastActivity) {
+        // Only update if (block number, log index) is newer; same-block events are ordered by log index
+        const isStale =
+          params.lastActivity &&
+          (tokenMember.lastVPBlockNumber > params.lastActivity ||
+            (tokenMember.lastVPBlockNumber === params.lastActivity &&
+              (params.logIndex === undefined || (tokenMember.lastVPLogIndex || 0) >= params.logIndex)))
+        if (isStale) {
           logger.verbose(
             'Skipping update - older block',
             this.llo({
               current: tokenMember.lastVPBlockNumber,
+              currentLogIndex: tokenMember.lastVPLogIndex,
               new: params.lastActivity,
+              newLogIndex: params.logIndex,
             }),
           )
           await session.commitTransaction()
@@ -146,6 +154,9 @@ export class Erc20Governance extends BaseGovernance {
         }
         if (params.lastActivity !== undefined) {
           updateData.lastVPBlockNumber = params.lastActivity
+        }
+        if (params.logIndex !== undefined) {
+          updateData.lastVPLogIndex = params.logIndex
         }
         if (params.delegateReceivedCount !== undefined) {
           updateData.delegateReceivedCount = params.delegateReceivedCount
@@ -301,6 +312,7 @@ export class Erc20Governance extends BaseGovernance {
       votingPower?: string
       tokenIds?: string[]
       lastVPBlockNumber: number
+      lastVPLogIndex?: number
     }>,
   ): Promise<boolean> {
     try {
@@ -318,9 +330,9 @@ export class Erc20Governance extends BaseGovernance {
         })
         .filter(update => update !== null)
 
-      // Sort by block number descending and reduce to get only latest per id
+      // Sort by (block number, log index) descending and reduce to get only latest per id
       const latestUpdates = updatesWithParsedAddress
-        .sort((a, b) => b.lastVPBlockNumber - a.lastVPBlockNumber)
+        .sort((a, b) => b.lastVPBlockNumber - a.lastVPBlockNumber || (b.lastVPLogIndex || 0) - (a.lastVPLogIndex || 0))
         .reduce<typeof updatesWithParsedAddress>((acc, update) => {
           if (!acc.some(u => u.id === update.id)) {
             acc.push(update)
@@ -332,6 +344,10 @@ export class Erc20Governance extends BaseGovernance {
         const setFields: any = {
           votingPower: update.votingPower?.toString() || '0',
           lastVPBlockNumber: update.lastVPBlockNumber,
+        }
+
+        if (update.lastVPLogIndex !== undefined) {
+          setFields.lastVPLogIndex = update.lastVPLogIndex
         }
 
         if (update.tokenIds !== undefined) {

--- a/src/handlers/governanceErc20Handler.ts
+++ b/src/handlers/governanceErc20Handler.ts
@@ -37,6 +37,7 @@ export const GovernanceErc20Handler = {
       await governance.update(memberAddress, {
         votingPower: newBalance.toString(),
         lastActivity,
+        logIndex: info.logIndex,
       })
 
       // Update plugin metrics for all plugins using this token
@@ -85,10 +86,14 @@ export const GovernanceErc20Handler = {
 
       // Use for...of with Map entries for better performance
       for (const [, memberEvents] of eventsByMember) {
-        // Find the event with the highest block number without sorting the entire array
+        // Find the event with the highest (block number, log index) without sorting the entire array
         let latestEvent = memberEvents[0]
         for (let i = 1; i < memberEvents.length; i++) {
-          if (memberEvents[i].info.blockNumber > latestEvent.info.blockNumber) {
+          const current = memberEvents[i].info
+          if (
+            current.blockNumber > latestEvent.info.blockNumber ||
+            (current.blockNumber === latestEvent.info.blockNumber && current.logIndex > latestEvent.info.logIndex)
+          ) {
             latestEvent = memberEvents[i]
           }
         }
@@ -114,6 +119,7 @@ export const GovernanceErc20Handler = {
             memberAddress: string
             votingPower: string
             lastVPBlockNumber: number
+            lastVPLogIndex?: number
           }>
         >()
 
@@ -123,6 +129,7 @@ export const GovernanceErc20Handler = {
             memberAddress: parsedEvent.args.delegate,
             votingPower: BigInt(parsedEvent?.args?.newBalance || 0).toString(),
             lastVPBlockNumber: info.blockNumber,
+            lastVPLogIndex: info.logIndex,
           }
           const existing = updatesByTokenNetwork.get(key)
           if (existing) {
@@ -244,6 +251,7 @@ export const GovernanceErc20Handler = {
             await governance.update(memberAddress, {
               votingPower: BigInt(parsedEvent?.args?.newBalance || 0).toString(),
               lastActivity: info.blockNumber,
+              logIndex: info.logIndex,
             })
 
             // Update plugin metrics for this member

--- a/src/helpers/eventReplay.ts
+++ b/src/helpers/eventReplay.ts
@@ -1,6 +1,7 @@
 import Web3Helper from '@helpers/web3'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
+import { TickContext } from '@modules/crawlers/tickContext'
 import IndexerEventConfig from '@services/aragon-indexer/configIndexer'
 import { type IIndexerConfig, type ILogInfo, type NetworksEnum } from '@types'
 import { Interface, type Log, type LogDescription } from 'ethers'
@@ -52,10 +53,14 @@ const EventReplayHelper = {
     const sortedLogs = [...receipt.logs].sort((a: any, b: any) => a.index - b.index)
     const parsed = EventReplayHelper.parseLogsByConfig(sortedLogs as any, network)
 
+    const tickCtx = new TickContext(network, sortedLogs as any)
+    await tickCtx.init()
+
     let handled = 0
     let failed = 0
     for (const { event, handler, info } of parsed) {
       try {
+        info.context = tickCtx
         await handler(event, info)
         handled++
       } catch (error) {

--- a/src/models/schema/tokenMember.ts
+++ b/src/models/schema/tokenMember.ts
@@ -58,6 +58,9 @@ export default class TokenMember extends Model {
   @prop({ type: () => Number, default: 0 })
   public lastVPBlockNumber!: number
 
+  @prop({ type: () => Number, default: 0 })
+  public lastVPLogIndex!: number
+
   static async create(rawData: Partial<TokenMember> = {} as Partial<TokenMember>, tOpts?: SaveOptions) {
     if (!rawData.id) {
       assert(!!rawData.network, 'network is required')

--- a/src/services/aragon-plugins/logTokenVoting.ts
+++ b/src/services/aragon-plugins/logTokenVoting.ts
@@ -168,7 +168,7 @@ export const LogTokenVoting = {
       stopOnError: true,
       filterLogs: async (logs: any[]) => {
         // Since tokenCrawler only fetches DelegateVotesChanged events, all logs are DelegateVotesChanged
-        // Filter out duplicate events keeping only the highest block number per delegate
+        // Filter out duplicate events keeping only the latest event per delegate
 
         if (logs.length === 0) {
           return logs
@@ -176,7 +176,11 @@ export const LogTokenVoting = {
 
         // Always use the most optimized approach: Sort + Set
         // O(n log n) for sort + O(n) for filtering = most efficient
-        logs.sort((a, b) => Number(b.blockNumber) - Number(a.blockNumber))
+        logs.sort(
+          (a, b) =>
+            Number(b.blockNumber) - Number(a.blockNumber) ||
+            Number(b.index ?? b.logIndex ?? 0) - Number(a.index ?? a.logIndex ?? 0),
+        )
 
         const seen = new Set<string>()
         const filtered: any = []

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -5,6 +5,7 @@ export interface IGovernanceParamsOpts {
   tokenIds?: string[]
   tokenId?: string
   lastActivity?: number
+  logIndex?: number
   votingPower?: string
   delegateReceivedCount?: number
   delegateReceiverAddress?: string | null

--- a/test/unit/governance/erc20Governance.spec.ts
+++ b/test/unit/governance/erc20Governance.spec.ts
@@ -352,6 +352,61 @@ describe('Governance:Erc20Governance', () => {
       expect(loggerVerboseStub.calledWith('Skipping update - older block')).to.be.true
     })
 
+    it('should apply same-block update with higher log index', async () => {
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      // First event in the block already applied
+      await Models.TokenMember.create({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+        network: testNetwork,
+        votingPower: '1000000000000000000',
+        lastVPBlockNumber: 12345,
+        lastVPLogIndex: 10,
+      })
+
+      // Second event in the same block (e.g. received then transferred away in one tx)
+      const result = await erc20Governance.update(memberAddress, {
+        votingPower: '1',
+        lastActivity: 12345,
+        logIndex: 15,
+      })
+
+      expect(result).to.exist
+      expect(result?.votingPower).to.equal('1')
+      expect(result?.lastVPBlockNumber).to.equal(12345)
+      expect(result?.lastVPLogIndex).to.equal(15)
+
+      const updatedMember = await Models.TokenMember.findOne({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+      })
+      expect(updatedMember?.votingPower).to.equal('1')
+    })
+
+    it('should skip same-block update with lower log index', async () => {
+      const parsedAddress = Web3Utils.parseAddress(memberAddress)
+      await Models.TokenMember.create({
+        memberAddress: parsedAddress,
+        tokenAddress: testTokenAddress,
+        network: testNetwork,
+        votingPower: '1',
+        lastVPBlockNumber: 12345,
+        lastVPLogIndex: 15,
+      })
+
+      const result = await erc20Governance.update(memberAddress, {
+        votingPower: '1000000000000000000',
+        lastActivity: 12345,
+        logIndex: 10, // Earlier event replayed out of order
+      })
+
+      expect(result).to.exist
+      expect(result?.votingPower).to.equal('1') // Should not change
+      expect(result?.lastVPLogIndex).to.equal(15)
+
+      expect(loggerVerboseStub.calledWith('Skipping update - older block')).to.be.true
+    })
+
     it('should clear tokenIds when voting power is set to 0', async () => {
       const parsedAddress = Web3Utils.parseAddress(memberAddress)
       // Create existing member with tokenIds
@@ -862,6 +917,37 @@ describe('Governance:Erc20Governance', () => {
         expect(member).to.exist
         expect(member?.votingPower).to.equal('2000')
         expect(member?.lastVPBlockNumber).to.equal(200)
+      })
+
+      it('should keep latest by log index for same-block duplicates', async () => {
+        const updates = [
+          {
+            memberAddress: '0x1111111111111111111111111111111111111111' as HexAddress,
+            votingPower: '1000000000000000000',
+            lastVPBlockNumber: 100,
+            lastVPLogIndex: 5,
+          },
+          {
+            memberAddress: '0x1111111111111111111111111111111111111111' as HexAddress,
+            votingPower: '1',
+            lastVPBlockNumber: 100, // Same block, later event
+            lastVPLogIndex: 8,
+          },
+        ]
+
+        const result = await erc20Governance.updateTokenMemberVPBatchNoTx(updates)
+
+        expect(result).to.be.true
+
+        // Should use the update with higher log index
+        const member = await Models.TokenMember.findOne({
+          memberAddress: Web3Utils.parseAddress(updates[0].memberAddress),
+          tokenAddress: testTokenAddress,
+        })
+
+        expect(member).to.exist
+        expect(member?.votingPower).to.equal('1')
+        expect(member?.lastVPLogIndex).to.equal(8)
       })
 
       it('should clear tokenIds when voting power is 0', async () => {

--- a/test/unit/helpers/eventReplay.spec.ts
+++ b/test/unit/helpers/eventReplay.spec.ts
@@ -1,6 +1,7 @@
 import '@test/environment'
 import EventReplayHelper from '@helpers/eventReplay'
 import Web3Helper from '@helpers/web3'
+import Web3BatchHelper from '@helpers/web3BatchHelper'
 import Web3Utils from '@helpers/web3Utils'
 import logger from '@logger'
 import IndexerEventConfig from '@services/aragon-indexer/configIndexer'
@@ -24,6 +25,7 @@ describe('Helper: EventReplay', () => {
     sandbox = sinon.createSandbox()
     sandbox.stub(logger, 'warn')
     sandbox.stub(logger, 'error')
+    sandbox.stub(Web3BatchHelper, 'getBlocksTimestamps').resolves(new Map())
   })
 
   afterEach(() => {
@@ -103,6 +105,23 @@ describe('Helper: EventReplay', () => {
         handled: 2,
         failed: 0,
       })
+    })
+
+    it('attaches a tick context so handlers can resolve block timestamps', async () => {
+      sandbox
+        .stub(Web3Helper, 'getTransactionReceipt')
+        .resolves({ logs: [{ index: 0, topics: ['0x0'], blockNumber: 100, transactionHash: txHash }] } as any)
+      sandbox.stub(Web3Helper, 'getBlockTimestamp').resolves(1750000000)
+
+      const handler = sandbox.stub().resolves()
+      const info = { eventName: 'Deposit', network, blockNumber: 100 } as any
+      sandbox.stub(EventReplayHelper, 'parseLogsByConfig').returns([{ event: {} as any, handler, info }])
+
+      await EventReplayHelper.handleEventsFromTxHash(txHash, network)
+
+      const passedInfo = handler.firstCall.args[1]
+      expect(passedInfo.context).to.not.be.undefined
+      expect(await passedInfo.context.getBlockTimestamp(100)).to.equal(1750000000)
     })
 
     it('isolates a failing handler and keeps processing the rest', async () => {

--- a/test/unit/services/aragon-plugins/logTokenVoting.spec.ts
+++ b/test/unit/services/aragon-plugins/logTokenVoting.spec.ts
@@ -342,6 +342,46 @@ describe('AragonPlugins: LogTokenVoting', () => {
       expect(result[2].topics[1]).to.equal('0xdelegate2')
     })
 
+    it('should keep the highest log index for duplicate DelegateVotesChanged logs in the same block', async () => {
+      const pluginStub = {
+        address: '0x123',
+        tokenAddress: '0x456',
+        network: NetworksEnum.ethereumSepolia,
+        blockNumber: 100,
+        interfaceType: 'tokenVoting',
+      } as any
+
+      const tokenStub = {
+        address: '0x456',
+        blockNumber: 200,
+        network: NetworksEnum.ethereumSepolia,
+        type: ITokenType.ERC20,
+      } as any
+
+      sandbox.stub(logger, 'verbose')
+
+      let result: any
+      const crawlStub = sandbox.stub(BlockchainLogCrawler.prototype, 'crawl')
+
+      crawlStub.onFirstCall().resolves()
+      crawlStub.onSecondCall().callsFake(async function (this: any) {
+        if (this.crawlParams?.filterLogs) {
+          const logs = [
+            { topics: ['0xevent', '0xdelegate1'], blockNumber: 100n, index: 5, newBalance: '100' },
+            { topics: ['0xevent', '0xdelegate1'], blockNumber: 100n, index: 8, newBalance: '0' },
+          ]
+          result = await this.crawlParams.filterLogs(logs)
+        }
+        return undefined
+      })
+
+      await LogTokenVoting.erc20Governance(pluginStub, tokenStub)
+
+      expect(result).to.have.length(1)
+      expect(result[0].index).to.equal(8)
+      expect(result[0].newBalance).to.equal('0')
+    })
+
     it('should log filtered results with correct counts', async () => {
       const pluginStub = {
         address: '0x123',


### PR DESCRIPTION
Auto-opened when `release/0.34.0` merged into `main`. Carries the merged changes (incl. CHANGELOG.md / version) back into `development`.