### PR TITLE
chore(deps): bump CI actions (install-cli-action, docker/login-action, setup-python)

### DIFF
--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -140,7 +140,7 @@ jobs:
 
       # Step 2: Install required tools
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 #v4.0.0
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 #v4.1.0
 
       # Step 3: Load server connection secrets
       - name: Load server connection secrets

--- a/.github/workflows/build-container-and-sca.yaml
+++ b/.github/workflows/build-container-and-sca.yaml
@@ -140,7 +140,7 @@ jobs:
           output: trivy-results-repo-${{ needs.build.outputs.GIT_HASH_SHORT }}.json
 
       - name: Setup Python before transforming Trivy report to SonarQube
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -306,7 +306,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -147,7 +147,7 @@ jobs:
           echo "📋 environment=$ENVIRONMENT deploy_env=$DEPLOY_ENV ref=$REF repo=$REPO_NAME"
 
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 # v4.0.0
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 # v4.1.0
 
       - name: Load server connection secrets
         id: server-secrets

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 #v4.0.0
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 #v4.1.0
         #with:
         #  version: latest-beta
 

--- a/.github/workflows/unit-dep.yml
+++ b/.github/workflows/unit-dep.yml
@@ -39,7 +39,7 @@ jobs:
           SERVER_URL: ${{ env.OP_SERVER_URL }}
 
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@a5215d3a7f75c1629216c465ea9ab3ab399c4b71 #v4.0.0
+        uses: 1password/install-cli-action@1a3160d5e9de1ae0803eaa08a88746f5ae3daa50 #v4.1.0
 
       - name: Download certfile
         env:


### PR DESCRIPTION
## 📝 Summary

Bundles the open dependabot CI bumps into one PR so we dont merge them one by one.

## 🔄 What Changed

- 1password/install-cli-action 4.0.0 → 4.1.0 (#1504)
- docker/login-action 4.4.0 → 4.6.0 (#1504)
- actions/setup-python v6 → v7 (#1486)

Only workflow files, no app code or dependency changes.
