### PR TITLE
feat(APP-1077): recognize verified empty execute selector conditions

### DIFF
--- a/src/handlers/pluginHandler.ts
+++ b/src/handlers/pluginHandler.ts
@@ -3,6 +3,7 @@ import { PluginSetupProcessor } from '@artifacts/pluginSetupProcessor'
 import { Models } from '@dbModels'
 import { DaoRegistryHandler } from '@handlers/daoRegistryHandler'
 import { MetadataHandler } from '@handlers/metadataHandler'
+import ConditionDetector from '@helpers/conditionDetector'
 import PluginDetector from '@helpers/pluginDetector'
 import { PluginSlug } from '@helpers/pluginSlug'
 import Web3Helper from '@helpers/web3'
@@ -807,10 +808,12 @@ export const PluginHandler = {
       return
     }
 
+    const conditionInterfaceType = conditionAddress ? await ConditionDetector.detect(conditionAddress, network) : null
+
     await DbOperations.updateDocument(
       plugin,
-      { conditionAddress },
-      { logId: plugin.id, conditionAddress },
+      { conditionAddress, conditionInterfaceType },
+      { logId: plugin.id, conditionAddress, conditionInterfaceType },
       'Update Plugin Condition Address',
       llo,
     )

--- a/src/helpers/conditionDetector.ts
+++ b/src/helpers/conditionDetector.ts
@@ -3,17 +3,23 @@ import { ExecuteSelectorCondition } from '@artifacts/ExecuteSelectorCondition'
 import logger from '@logger'
 import ProviderModule from '@modules/provider'
 import { type HexAddress, IConditionInterfaceType, type NetworksEnum } from '@types'
-import { Interface } from 'ethers'
+import { Interface, id } from 'ethers'
+import type { Provider } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'helper:ConditionDetector' })
 
 // Event topic hashes are embedded in runtime bytecode as PUSH32 constants, so their presence
 // identifies the condition implementation even though the DAO-address immutable makes raw
-// codehashes differ between deployments of the same contract.
-const EXECUTE_SELECTOR_TOPICS = [
-  new Interface(ExecuteSelectorCondition.abi).getEvent('SelectorAllowed')?.topicHash,
-  new Interface(CrossChainExecuteSelectorCondition.abi).getEvent('SelectorAllowed')?.topicHash,
-].map(topic => topic!.replace('0x', ''))
+const EXECUTE_SELECTOR_TOPIC_SETS = [ExecuteSelectorCondition.abi, CrossChainExecuteSelectorCondition.abi].map(abi => {
+  const contractInterface = new Interface(abi)
+  return ['SelectorAllowed', 'SelectorDisallowed'].map(event =>
+    contractInterface.getEvent(event)!.topicHash.replace('0x', ''),
+  )
+})
+
+const supportsInterfaceInterface = new Interface(['function supportsInterface(bytes4 interfaceId) view returns (bool)'])
+
+const PERMISSION_CONDITION_INTERFACE_ID = id('isGranted(address,address,bytes32,bytes)').slice(0, 10)
 
 const ConditionDetector = {
   /**
@@ -30,7 +36,11 @@ const ConditionDetector = {
         return null
       }
 
-      if (EXECUTE_SELECTOR_TOPICS.some(topic => bytecode.includes(topic))) {
+      const matchesExecuteSelector = EXECUTE_SELECTOR_TOPIC_SETS.some(topics =>
+        topics.every(topic => bytecode.includes(topic)),
+      )
+
+      if (matchesExecuteSelector && (await ConditionDetector.isPermissionCondition(provider, address))) {
         return IConditionInterfaceType.executeSelector
       }
 
@@ -38,6 +48,27 @@ const ConditionDetector = {
     } catch (error) {
       logger.warn('Failed to detect condition interface type', llo({ address, network, error }))
       return null
+    }
+  },
+
+  /**
+   * ERC-165 check. Any failure (no such function, revert, empty return, rpc error) means the
+   * contract does not answer as a permission condition, so it is treated as not supported.
+   */
+
+  isPermissionCondition: async (provider: Provider, address: HexAddress): Promise<boolean> => {
+    try {
+      const result = await provider.call({
+        to: address,
+        data: supportsInterfaceInterface.encodeFunctionData('supportsInterface', [PERMISSION_CONDITION_INTERFACE_ID]),
+      })
+
+      const [supported] = supportsInterfaceInterface.decodeFunctionResult('supportsInterface', result)
+
+      return supported === true
+    } catch (error) {
+      logger.verbose('Condition does not answer the ERC-165 permission condition check', llo({ address, error }))
+      return false
     }
   },
 }

--- a/src/helpers/conditionDetector.ts
+++ b/src/helpers/conditionDetector.ts
@@ -1,0 +1,45 @@
+import { CrossChainExecuteSelectorCondition } from '@artifacts/CrossChainExecuteSelectorCondition'
+import { ExecuteSelectorCondition } from '@artifacts/ExecuteSelectorCondition'
+import logger from '@logger'
+import ProviderModule from '@modules/provider'
+import { type HexAddress, IConditionInterfaceType, type NetworksEnum } from '@types'
+import { Interface } from 'ethers'
+
+const llo = logger.logMeta.bind(null, { service: 'helper:ConditionDetector' })
+
+// Event topic hashes are embedded in runtime bytecode as PUSH32 constants, so their presence
+// identifies the condition implementation even though the DAO-address immutable makes raw
+// codehashes differ between deployments of the same contract.
+const EXECUTE_SELECTOR_TOPICS = [
+  new Interface(ExecuteSelectorCondition.abi).getEvent('SelectorAllowed')?.topicHash,
+  new Interface(CrossChainExecuteSelectorCondition.abi).getEvent('SelectorAllowed')?.topicHash,
+].map(topic => topic!.replace('0x', ''))
+
+const ConditionDetector = {
+  /**
+   * Verify on-chain what a condition contract actually is. Returns null when the bytecode is
+   * absent or does not match any known condition implementation — callers must treat null as
+   * "unverified", never as an error.
+   */
+  detect: async (address: HexAddress, network: NetworksEnum): Promise<IConditionInterfaceType | null> => {
+    try {
+      const provider = ProviderModule.getAnyRpcProvider(network)
+      const bytecode = await provider.getCode(address)
+
+      if (!bytecode || bytecode === '0x') {
+        return null
+      }
+
+      if (EXECUTE_SELECTOR_TOPICS.some(topic => bytecode.includes(topic))) {
+        return IConditionInterfaceType.executeSelector
+      }
+
+      return null
+    } catch (error) {
+      logger.warn('Failed to detect condition interface type', llo({ address, network, error }))
+      return null
+    }
+  },
+}
+
+export default ConditionDetector

--- a/src/models/schema/daoPermission.ts
+++ b/src/models/schema/daoPermission.ts
@@ -10,6 +10,7 @@ import {
   type IPaginatedResult,
   type IPaginationParams,
   type IPermissionResponse,
+  IConditionInterfaceType,
   IPluginInterfaceType,
   IPluginStatus,
   ISettingStatus,
@@ -243,6 +244,7 @@ export default class DaoPermission extends Model {
                 address: 1,
                 interfaceType: 1,
                 tokenAddress: 1,
+                conditionInterfaceType: 1,
                 matchedProposal: { $eq: [{ $toLower: '$proposalCreationConditionAddress' }, '$$cond'] },
               },
             },
@@ -330,6 +332,17 @@ export default class DaoPermission extends Model {
                         selectors: '$selectorRows.selector',
                         targets: '$selectorRows.target',
                         chainIds: '$selectorRows.chainId',
+                      },
+                    },
+                    // Bytecode-verified execute condition whose allowlist is still empty:
+                    // recognized type, no allowed actions yet.
+                    {
+                      case: { $eq: ['$$pp.conditionInterfaceType', IConditionInterfaceType.executeSelector] },
+                      then: {
+                        conditionType: 'execute-selector',
+                        selectors: [],
+                        targets: [],
+                        chainIds: [],
                       },
                     },
                   ],

--- a/src/models/schema/daoPermission.ts
+++ b/src/models/schema/daoPermission.ts
@@ -246,6 +246,7 @@ export default class DaoPermission extends Model {
                 tokenAddress: 1,
                 conditionInterfaceType: 1,
                 matchedProposal: { $eq: [{ $toLower: '$proposalCreationConditionAddress' }, '$$cond'] },
+                matchedExecute: { $eq: [{ $toLower: '$conditionAddress' }, '$$cond'] },
               },
             },
           ],
@@ -335,9 +336,15 @@ export default class DaoPermission extends Model {
                       },
                     },
                     // Bytecode-verified execute condition whose allowlist is still empty:
-                    // recognized type, no allowed actions yet.
+                    // recognized type, no allowed actions yet. matchedExecute keeps the plugin's
+                    // proposal-creation condition from borrowing this verdict.
                     {
-                      case: { $eq: ['$$pp.conditionInterfaceType', IConditionInterfaceType.executeSelector] },
+                      case: {
+                        $and: [
+                          { $eq: ['$$pp.matchedExecute', true] },
+                          { $eq: ['$$pp.conditionInterfaceType', IConditionInterfaceType.executeSelector] },
+                        ],
+                      },
                       then: {
                         conditionType: 'execute-selector',
                         selectors: [],

--- a/src/models/schema/plugin.ts
+++ b/src/models/schema/plugin.ts
@@ -4,6 +4,7 @@ import { index, modelOptions, prop } from '@typegoose/typegoose'
 import {
   HexAddress,
   ICollectionNames,
+  type IConditionInterfaceType,
   type IGetPoliciesByDaoParams,
   type IPluginIdParams,
   IPluginInterfaceType,
@@ -215,6 +216,9 @@ export default class Plugin extends Model {
 
   @prop({ type: () => String, default: null })
   public conditionAddress?: HexAddress
+
+  @prop({ type: () => String, default: null })
+  public conditionInterfaceType?: IConditionInterfaceType
 
   @prop({ type: () => String, default: null })
   public lockManagerAddress?: HexAddress

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -71,6 +71,10 @@ export enum IPluginInterfaceType {
   crossChainController = 'crossChainController',
 }
 
+export enum IConditionInterfaceType {
+  executeSelector = 'execute-selector',
+}
+
 export enum IEventLogCrossChainSettings {
   ConfigUpdated = 'ConfigUpdated',
   ExecutorUpdated = 'ExecutorUpdated',

--- a/test/unit-dep/executeSelector.spec.ts
+++ b/test/unit-dep/executeSelector.spec.ts
@@ -1,13 +1,14 @@
 import { Models } from '@dbModels'
+import ConditionDetector from '@helpers/conditionDetector'
 import RabbitMQHelper from '@helpers/rabbitMQ'
 import Web3Helper from '@helpers/web3'
 import { LogSelectorPermission } from '@plugins/logSelectorPermission'
 import { LibUtils } from '@test/lib/unit-dep/lib'
-import { NetworksEnum } from '@types'
+import { IConditionInterfaceType, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import sinon from 'sinon'
 
-describe('Integ: ExecuteSelector', function () {
+describe.only('Integ: ExecuteSelector', function () {
   this.timeout(100000000)
   let sandbox: sinon.SinonSandbox
   let network = NetworksEnum.ethereumSepolia
@@ -167,6 +168,17 @@ describe('Integ: ExecuteSelector', function () {
       expect(selectors[0].selector).to.be.eq(null)
       expect(selectors[0].isAllowed).to.be.false
       expect(selectors[0].disallowed.status).to.be.true
+    })
+  })
+
+  describe('condition detection', () => {
+    it('should detect a deployed ExecuteSelectorCondition on ethereum mainnet', async () => {
+      const result = await ConditionDetector.detect(
+        '0x404d9B84191E55506dEb74C6E3d634c4C8784a7F',
+        NetworksEnum.ethereumMainnet,
+      )
+
+      expect(result).to.be.eq(IConditionInterfaceType.executeSelector)
     })
   })
 })

--- a/test/unit-dep/executeSelector.spec.ts
+++ b/test/unit-dep/executeSelector.spec.ts
@@ -8,7 +8,7 @@ import { IConditionInterfaceType, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import sinon from 'sinon'
 
-describe.only('Integ: ExecuteSelector', function () {
+describe('Integ: ExecuteSelector', function () {
   this.timeout(100000000)
   let sandbox: sinon.SinonSandbox
   let network = NetworksEnum.ethereumSepolia

--- a/test/unit/handlers/pluginHandler.spec.ts
+++ b/test/unit/handlers/pluginHandler.spec.ts
@@ -3,6 +3,7 @@ import { Models } from '@dbModels'
 import { GovernanceVeHandler } from '@handlers/governanceVeHandler'
 import { MetadataHandler } from '@handlers/metadataHandler'
 import { PluginHandler } from '@handlers/pluginHandler'
+import ConditionDetector from '@helpers/conditionDetector'
 import PluginDetector from '@helpers/pluginDetector'
 import { PluginSlug } from '@helpers/pluginSlug'
 import ProxyContractHelper from '@helpers/proxyContract'
@@ -20,6 +21,7 @@ import { ListLogPluginRepo } from '@test/mock/fakeLogPluginRepo'
 import { ListLogPluginSetupProcessor } from '@test/mock/fakeLogPluginSetupProcessor'
 import { PluginList } from '@test/mock/fakePlugins'
 import {
+  IConditionInterfaceType,
   IDaoLogs,
   IEventLogPluginType,
   IMetadataTargetField,
@@ -2037,6 +2039,12 @@ describe('Indexer:Plugin', () => {
   })
 
   describe('updateConditionAddress', () => {
+    let detectStub: sinon.SinonStub
+
+    beforeEach(() => {
+      detectStub = sandbox.stub(ConditionDetector, 'detect').resolves(null)
+    })
+
     it('should update plugin condition address successfully', async () => {
       // Create a mock plugin in the database
       const mockPlugin = await Models.Plugin.create({
@@ -2055,6 +2063,7 @@ describe('Indexer:Plugin', () => {
       const newConditionAddress = '0x2222222222222222222222222222222222222222'
       const sendMessageStub = sandbox.stub(RabbitMQHelper, 'sendMessage')
       const loggerStub = sandbox.stub(logger, 'verbose')
+      detectStub.resolves(IConditionInterfaceType.executeSelector)
 
       await PluginHandler.updateConditionAddress(
         mockPlugin.address,
@@ -2071,6 +2080,8 @@ describe('Indexer:Plugin', () => {
 
       expect(updatedPlugin).to.exist
       expect(updatedPlugin.conditionAddress).to.equal(newConditionAddress)
+      expect(updatedPlugin.conditionInterfaceType).to.equal(IConditionInterfaceType.executeSelector)
+      expect(detectStub.calledOnceWith(newConditionAddress, NetworksEnum.ethereumMainnet)).to.be.true
       expect(sendMessageStub.calledOnce).to.be.true
       expect(loggerStub.calledWith('Updated document - Update Plugin Condition Address' as any)).to.be.true
       expect(sendMessageStub.args[0][1]).to.deep.include({
@@ -2081,6 +2092,38 @@ describe('Indexer:Plugin', () => {
           conditionAddress: newConditionAddress,
         },
       })
+    })
+
+    it('should store no interface type when the condition contract is not recognized', async () => {
+      const mockPlugin = await Models.Plugin.create({
+        status: IPluginStatus.installed,
+        network: NetworksEnum.ethereumMainnet,
+        blockNumber: 12345,
+        blockTimestamp: 1620000000,
+        transactionHash: '0x123abc',
+        address: '0x1234567890123456789012345678901234567890',
+        daoAddress: '0x9876543210987654321098765432109876543210',
+        pluginSetupRepoAddress: '0x1111111111111111111111111111111111111111',
+        interfaceType: IPluginInterfaceType.spp,
+        conditionAddress: null,
+      })
+
+      sandbox.stub(RabbitMQHelper, 'sendMessage')
+
+      await PluginHandler.updateConditionAddress(
+        mockPlugin.address,
+        mockPlugin.daoAddress,
+        NetworksEnum.ethereumMainnet,
+        '0x4444444444444444444444444444444444444444',
+      )
+
+      const updatedPlugin = await Models.Plugin.findOne({
+        address: mockPlugin.address,
+        network: NetworksEnum.ethereumMainnet,
+      })
+
+      expect(updatedPlugin.conditionAddress).to.equal('0x4444444444444444444444444444444444444444')
+      expect(updatedPlugin.conditionInterfaceType).to.equal(null)
     })
 
     it('should not update if plugin is not found', async () => {
@@ -2140,6 +2183,10 @@ describe('Indexer:Plugin', () => {
   })
 
   describe('recoverConditionAddress', () => {
+    beforeEach(() => {
+      sandbox.stub(ConditionDetector, 'detect').resolves(null)
+    })
+
     const network = NetworksEnum.ethereumMainnet
     const daoAddress = '0x9876543210987654321098765432109876543210'
     const pluginAddress = '0x1234567890123456789012345678901234567890'

--- a/test/unit/helpers/conditionDetector.spec.ts
+++ b/test/unit/helpers/conditionDetector.spec.ts
@@ -5,7 +5,7 @@ import logger from '@logger'
 import ProviderModule from '@modules/provider'
 import { IConditionInterfaceType, NetworksEnum } from '@types'
 import { expect } from 'chai'
-import { Interface } from 'ethers'
+import { AbiCoder, Interface } from 'ethers'
 import * as sinon from 'sinon'
 import { SinonSandbox } from 'sinon'
 
@@ -14,19 +14,29 @@ describe('Helper: ConditionDetector', () => {
   const testAddress = '0x3BCE21a6EFeF775960D121D3A1947b9CCc030B0F'
   const testNetwork = NetworksEnum.ethereumMainnet
 
-  const plainTopic = new Interface(ExecuteSelectorCondition.abi).getEvent('SelectorAllowed')!.topicHash.slice(2)
-  const crossChainTopic = new Interface(CrossChainExecuteSelectorCondition.abi)
-    .getEvent('SelectorAllowed')!
-    .topicHash.slice(2)
+  const topicsOf = (abi: any) => {
+    const contractInterface = new Interface(abi)
+    return {
+      allowed: contractInterface.getEvent('SelectorAllowed')!.topicHash.slice(2),
+      disallowed: contractInterface.getEvent('SelectorDisallowed')!.topicHash.slice(2),
+    }
+  }
 
-  const stubGetCode = (result: Promise<string>) => {
-    const getCodeStub = sandbox.stub().returns(result)
-    sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({ getCode: getCodeStub } as any)
-    return getCodeStub
+  const plain = topicsOf(ExecuteSelectorCondition.abi)
+  const crossChain = topicsOf(CrossChainExecuteSelectorCondition.abi)
+
+  const supportsInterfaceResult = (supported: boolean) => AbiCoder.defaultAbiCoder().encode(['bool'], [supported])
+
+  const stubProvider = (getCode: Promise<string>, call?: Promise<string>) => {
+    const getCodeStub = sandbox.stub().returns(getCode)
+    const callStub = sandbox.stub().returns(call ?? Promise.resolve(supportsInterfaceResult(true)))
+    sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({ getCode: getCodeStub, call: callStub } as any)
+    return { getCodeStub, callStub }
   }
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
+    sandbox.stub(logger, 'verbose')
   })
 
   afterEach(() => {
@@ -34,25 +44,67 @@ describe('Helper: ConditionDetector', () => {
   })
 
   describe('detect', () => {
-    it('should detect an ExecuteSelectorCondition by its SelectorAllowed topic', async () => {
-      const getCodeStub = stubGetCode(Promise.resolve(`0x6080604052${plainTopic}60805260`))
+    it('should detect an ExecuteSelectorCondition that carries both topics and answers ERC-165', async () => {
+      const { getCodeStub, callStub } = stubProvider(
+        Promise.resolve(`0x6080604052${plain.allowed}608052${plain.disallowed}60`),
+      )
 
       const result = await ConditionDetector.detect(testAddress, testNetwork)
 
       expect(result).to.equal(IConditionInterfaceType.executeSelector)
       expect(getCodeStub.calledOnceWith(testAddress)).to.be.true
+      expect(callStub.calledOnce).to.be.true
     })
 
-    it('should detect a CrossChainExecuteSelectorCondition by its SelectorAllowed topic', async () => {
-      stubGetCode(Promise.resolve(`0x6080604052${crossChainTopic}60805260`))
+    it('should detect a CrossChainExecuteSelectorCondition that carries both topics and answers ERC-165', async () => {
+      stubProvider(Promise.resolve(`0x6080604052${crossChain.allowed}608052${crossChain.disallowed}60`))
 
       const result = await ConditionDetector.detect(testAddress, testNetwork)
 
       expect(result).to.equal(IConditionInterfaceType.executeSelector)
     })
 
+    it('should return null for a contract that carries the topics but is not a permission condition', async () => {
+      stubProvider(
+        Promise.resolve(`0x6080604052${plain.allowed}608052${plain.disallowed}60`),
+        Promise.resolve(supportsInterfaceResult(false)),
+      )
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+    })
+
+    it('should return null when the ERC-165 call reverts', async () => {
+      stubProvider(
+        Promise.resolve(`0x6080604052${plain.allowed}608052${plain.disallowed}60`),
+        Promise.reject(new Error('execution reverted')),
+      )
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+    })
+
+    it('should return null when only one of the two topics is present', async () => {
+      const { callStub } = stubProvider(Promise.resolve(`0x6080604052${plain.allowed}60805260`))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+      expect(callStub.called).to.be.false
+    })
+
+    it('should return null when the topics come from two different implementations', async () => {
+      stubProvider(Promise.resolve(`0x6080604052${plain.allowed}608052${crossChain.disallowed}60`))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+    })
+
     it('should return null for bytecode of an unrelated contract', async () => {
-      stubGetCode(Promise.resolve('0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe'))
+      stubProvider(Promise.resolve('0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe'))
 
       const result = await ConditionDetector.detect(testAddress, testNetwork)
 
@@ -60,7 +112,7 @@ describe('Helper: ConditionDetector', () => {
     })
 
     it('should return null when the address has no code', async () => {
-      stubGetCode(Promise.resolve('0x'))
+      stubProvider(Promise.resolve('0x'))
 
       const result = await ConditionDetector.detect(testAddress, testNetwork)
 
@@ -69,7 +121,7 @@ describe('Helper: ConditionDetector', () => {
 
     it('should return null and warn when the provider fails', async () => {
       const loggerWarnStub = sandbox.stub(logger, 'warn')
-      stubGetCode(Promise.reject(new Error('rpc down')))
+      stubProvider(Promise.reject(new Error('rpc down')))
 
       const result = await ConditionDetector.detect(testAddress, testNetwork)
 

--- a/test/unit/helpers/conditionDetector.spec.ts
+++ b/test/unit/helpers/conditionDetector.spec.ts
@@ -1,0 +1,81 @@
+import { CrossChainExecuteSelectorCondition } from '@artifacts/CrossChainExecuteSelectorCondition'
+import { ExecuteSelectorCondition } from '@artifacts/ExecuteSelectorCondition'
+import ConditionDetector from '@helpers/conditionDetector'
+import logger from '@logger'
+import ProviderModule from '@modules/provider'
+import { IConditionInterfaceType, NetworksEnum } from '@types'
+import { expect } from 'chai'
+import { Interface } from 'ethers'
+import * as sinon from 'sinon'
+import { SinonSandbox } from 'sinon'
+
+describe('Helper: ConditionDetector', () => {
+  let sandbox: SinonSandbox
+  const testAddress = '0x3BCE21a6EFeF775960D121D3A1947b9CCc030B0F'
+  const testNetwork = NetworksEnum.ethereumMainnet
+
+  const plainTopic = new Interface(ExecuteSelectorCondition.abi).getEvent('SelectorAllowed')!.topicHash.slice(2)
+  const crossChainTopic = new Interface(CrossChainExecuteSelectorCondition.abi)
+    .getEvent('SelectorAllowed')!
+    .topicHash.slice(2)
+
+  const stubGetCode = (result: Promise<string>) => {
+    const getCodeStub = sandbox.stub().returns(result)
+    sandbox.stub(ProviderModule, 'getAnyRpcProvider').returns({ getCode: getCodeStub } as any)
+    return getCodeStub
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('detect', () => {
+    it('should detect an ExecuteSelectorCondition by its SelectorAllowed topic', async () => {
+      const getCodeStub = stubGetCode(Promise.resolve(`0x6080604052${plainTopic}60805260`))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.equal(IConditionInterfaceType.executeSelector)
+      expect(getCodeStub.calledOnceWith(testAddress)).to.be.true
+    })
+
+    it('should detect a CrossChainExecuteSelectorCondition by its SelectorAllowed topic', async () => {
+      stubGetCode(Promise.resolve(`0x6080604052${crossChainTopic}60805260`))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.equal(IConditionInterfaceType.executeSelector)
+    })
+
+    it('should return null for bytecode of an unrelated contract', async () => {
+      stubGetCode(Promise.resolve('0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe'))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+    })
+
+    it('should return null when the address has no code', async () => {
+      stubGetCode(Promise.resolve('0x'))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+    })
+
+    it('should return null and warn when the provider fails', async () => {
+      const loggerWarnStub = sandbox.stub(logger, 'warn')
+      stubGetCode(Promise.reject(new Error('rpc down')))
+
+      const result = await ConditionDetector.detect(testAddress, testNetwork)
+
+      expect(result).to.be.null
+      expect(loggerWarnStub.calledOnce).to.be.true
+      expect(loggerWarnStub.calledWith('Failed to detect condition interface type' as any)).to.be.true
+    })
+  })
+})

--- a/test/unit/models/schema/daoPermission.spec.ts
+++ b/test/unit/models/schema/daoPermission.spec.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import { FakeDaoPermissions } from '@test/mock/fakeDaoPermission'
 import {
+  IConditionInterfaceType,
   IPermissionResponse,
   IPluginInterfaceType,
   IPluginStatus,
@@ -402,12 +403,14 @@ describe('Dao Permission', () => {
     const multisigCondition = '0x902D99e5291ba7628AeD2b03dc533E4BBcAAA5aE'
     const selectorCondition = '0x23c4aDb7CE681a785ACbf75841b0312A7014BB98'
     const emptySelectorCondition = '0x9A6EbE7E2a7722F8200d0ffB63a1F6406A0d7dce'
+    const verifiedEmptyCondition = '0x3BCE21a6EFeF775960D121D3A1947b9CCc030B0F'
     const unknownCondition = '0x1111111111111111111111111111111111111111'
 
     const tokenVotingPlugin = '0xC0Ffee254729296a45a3885639AC7E10F9d54979'
     const multisigPlugin = '0xDe0B295669a9FD93d5F28D9Ec85E40f4cb697BAe'
     const sppPlugin = '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049'
     const emptySelectorPlugin = '0x14dC79964da2C08b23698B3D3cc7Ca32193d9955'
+    const verifiedEmptyPlugin = '0x26A65F77d4805eDab92a29ec964A0ac9891F9626'
     const tokenAddress = '0x0bA45A8b5d5575935B8158a88C631E9F9C95a2e5'
     const target = '0x902D99e5291ba7628AeD2b03dc533E4BBcAAA5aE'
     const minVotingPower = '1000000000000000000'
@@ -454,6 +457,16 @@ describe('Dao Permission', () => {
           status: IPluginStatus.installed,
           interfaceType: IPluginInterfaceType.spp,
           conditionAddress: emptySelectorCondition,
+        },
+        {
+          id: 'plugin-verified-empty',
+          address: verifiedEmptyPlugin,
+          daoAddress,
+          network,
+          status: IPluginStatus.installed,
+          interfaceType: IPluginInterfaceType.spp,
+          conditionAddress: verifiedEmptyCondition,
+          conditionInterfaceType: IConditionInterfaceType.executeSelector,
         },
       ] as any)
 
@@ -505,6 +518,7 @@ describe('Dao Permission', () => {
         { permissionId: '0xMEMBER', whoAddress: '0xWHO_M', conditionAddress: multisigCondition },
         { permissionId: '0xSELECTOR', whoAddress: '0xWHO_S', conditionAddress: selectorCondition },
         { permissionId: '0xEMPTY_SELECTOR', whoAddress: '0xWHO_E', conditionAddress: emptySelectorCondition },
+        { permissionId: '0xVERIFIED_EMPTY', whoAddress: '0xWHO_VE', conditionAddress: verifiedEmptyCondition },
         { permissionId: '0xUNKNOWN', whoAddress: '0xWHO_U', conditionAddress: unknownCondition },
         { permissionId: '0xNONE', whoAddress: '0xWHO_N', conditionAddress: undefined },
       ]
@@ -559,8 +573,17 @@ describe('Dao Permission', () => {
       expect(byPermission['0xUNKNOWN'].condition).to.deep.equal({ conditionType: 'unknown' })
     })
 
-    it('resolves unknown (not execute-selector) when the matched condition has no allowed selector rows', () => {
+    it('resolves unknown when the matched condition has no selector rows and is not bytecode-verified', () => {
       expect(byPermission['0xEMPTY_SELECTOR'].condition).to.deep.equal({ conditionType: 'unknown' })
+    })
+
+    it('resolves execute-selector with empty arrays for a bytecode-verified condition with no selector rows', () => {
+      expect(byPermission['0xVERIFIED_EMPTY'].condition).to.deep.equal({
+        conditionType: 'execute-selector',
+        selectors: [],
+        targets: [],
+        chainIds: [],
+      })
     })
 
     it('omits condition and returns ALLOW_FLAG conditionAddress when the grant has no condition', () => {

--- a/test/unit/models/schema/daoPermission.spec.ts
+++ b/test/unit/models/schema/daoPermission.spec.ts
@@ -404,6 +404,7 @@ describe('Dao Permission', () => {
     const selectorCondition = '0x23c4aDb7CE681a785ACbf75841b0312A7014BB98'
     const emptySelectorCondition = '0x9A6EbE7E2a7722F8200d0ffB63a1F6406A0d7dce'
     const verifiedEmptyCondition = '0x3BCE21a6EFeF775960D121D3A1947b9CCc030B0F'
+    const verifiedEmptyProposalCondition = '0x861Ef6b2F86B9343fB4A88bB8e11C1e8295F8d1e'
     const unknownCondition = '0x1111111111111111111111111111111111111111'
 
     const tokenVotingPlugin = '0xC0Ffee254729296a45a3885639AC7E10F9d54979'
@@ -467,6 +468,7 @@ describe('Dao Permission', () => {
           interfaceType: IPluginInterfaceType.spp,
           conditionAddress: verifiedEmptyCondition,
           conditionInterfaceType: IConditionInterfaceType.executeSelector,
+          proposalCreationConditionAddress: verifiedEmptyProposalCondition,
         },
       ] as any)
 
@@ -519,6 +521,11 @@ describe('Dao Permission', () => {
         { permissionId: '0xSELECTOR', whoAddress: '0xWHO_S', conditionAddress: selectorCondition },
         { permissionId: '0xEMPTY_SELECTOR', whoAddress: '0xWHO_E', conditionAddress: emptySelectorCondition },
         { permissionId: '0xVERIFIED_EMPTY', whoAddress: '0xWHO_VE', conditionAddress: verifiedEmptyCondition },
+        {
+          permissionId: '0xVE_PROPOSAL',
+          whoAddress: '0xWHO_VP',
+          conditionAddress: verifiedEmptyProposalCondition,
+        },
         { permissionId: '0xUNKNOWN', whoAddress: '0xWHO_U', conditionAddress: unknownCondition },
         { permissionId: '0xNONE', whoAddress: '0xWHO_N', conditionAddress: undefined },
       ]
@@ -584,6 +591,10 @@ describe('Dao Permission', () => {
         targets: [],
         chainIds: [],
       })
+    })
+
+    it('does not borrow the execute verdict for the same plugin proposal-creation condition', () => {
+      expect(byPermission['0xVE_PROPOSAL'].condition).to.deep.equal({ conditionType: 'unknown' })
     })
 
     it('omits condition and returns ALLOW_FLAG conditionAddress when the grant has no condition', () => {


### PR DESCRIPTION
## 📝 Summary

Permissions gated by an execute selector condition that has no allowed actions yet were showing as "Unrecognized condition" in the app. The condition contract is real, just empty, so it should show as a recognized execute selector with an empty action list.

**Task:** [APP-1077](https://linear.app/aragon/issue/APP-1077)

## 🔄 What Changed

- Added a condition detector that verifies the condition contract bytecode on chain and stores the result as `conditionInterfaceType` on the plugin
- Permissions api now returns `execute-selector` with empty selectors/targets for verified conditions that have no selector rows, instead of `unknown`
- Unverified conditions still return `unknown` as before
- Existing plugins were backfilled with a one-off tool, new installs get the field set on indexing

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [x] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
