### PR TITLE
Feat/index crosschain fee token

### DIFF
--- a/src/handlers/crossChainHandler.ts
+++ b/src/handlers/crossChainHandler.ts
@@ -8,6 +8,7 @@ import BottleneckModule from '@modules/bottleneck'
 import ProviderModule from '@modules/provider'
 import { type HexAddress, type ILogInfo, IPluginInterfaceType, ISettingStatus, type NetworksEnum } from '@types'
 import { Contract, type LogDescription } from 'ethers'
+import { ProxyToken } from '@modules/proxyToken'
 
 const llo = logger.logMeta.bind(null, { service: 'handler:CrossChainHandler' })
 
@@ -89,6 +90,9 @@ export const CrossChainHandler = {
 
     if (!cleared) {
       const feeToken = await CrossChainHandler._readFeeToken(localAdapter, info.network)
+      if (feeToken) {
+        await ProxyToken.saveAndGetToken(feeToken, info.network)
+      }
       lanes.push({ chainId, localAdapter, remoteAdapter, feeToken })
     }
 

--- a/src/models/schema/setting.ts
+++ b/src/models/schema/setting.ts
@@ -475,6 +475,8 @@ export default class Setting extends Model {
         },
       },
 
+      ...AggregationQueryHelper.crossChainLaneTokens(),
+
       {
         $project: {
           _id: 0,
@@ -491,6 +493,7 @@ export default class Setting extends Model {
           externalProposers: 1,
           votingEscrow: 1,
           policy: 1,
+          crossChain: 1,
         },
       },
     ]
@@ -547,6 +550,8 @@ export default class Setting extends Model {
         },
       },
 
+      ...AggregationQueryHelper.crossChainLaneTokens(),
+
       {
         $project: {
           _id: 0,
@@ -561,6 +566,7 @@ export default class Setting extends Model {
           token: 1,
           votingEscrow: 1,
           policy: 1,
+          crossChain: 1,
         },
       },
     ]

--- a/src/models/utils/aggregation.ts
+++ b/src/models/utils/aggregation.ts
@@ -425,6 +425,11 @@ export const AggregationQueryHelper = {
       },
     )
 
+    // Only worth the extra join when the caller actually asks for the cross chain config.
+    if (project?.crossChain) {
+      pipeline.push(...AggregationQueryHelper.crossChainLaneTokens())
+    }
+
     if (project) {
       pipeline.push({
         $project: project,
@@ -481,6 +486,92 @@ export const AggregationQueryHelper = {
         as,
       },
     }
+  },
+
+  // A lane only stores the fee token address, so join the indexed token and put it on each lane.
+  // Stages run on a setting shaped document, they add nothing when the setting has no crossChain.
+  crossChainLaneTokens: (network: string = '$network', as: string = 'crossChainLaneTokens') => {
+    const hasCrossChain = { $eq: [{ $type: '$crossChain' }, 'object'] }
+
+    return [
+      {
+        $lookup: {
+          from: ICollectionNames.Token,
+          let: {
+            addresses: { $ifNull: ['$crossChain.lanes.feeToken', []] },
+            network,
+          },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [{ $in: ['$address', '$$addresses'] }, { $eq: ['$network', '$$network'] }],
+                },
+              },
+            },
+            {
+              $project: {
+                _id: 0,
+                network: 1,
+                address: 1,
+                symbol: 1,
+                name: 1,
+                decimals: 1,
+                logo: 1,
+                type: 1,
+                priceUsd: 1,
+              },
+            },
+          ],
+          as,
+        },
+      },
+      {
+        $addFields: {
+          crossChain: {
+            $cond: {
+              if: hasCrossChain,
+              then: {
+                $mergeObjects: [
+                  '$crossChain',
+                  {
+                    lanes: {
+                      $map: {
+                        input: { $ifNull: ['$crossChain.lanes', []] },
+                        as: 'lane',
+                        in: {
+                          $mergeObjects: [
+                            '$$lane',
+                            {
+                              token: {
+                                $arrayElemAt: [
+                                  {
+                                    $filter: {
+                                      input: `$${as}`,
+                                      as: 'laneToken',
+                                      cond: { $eq: ['$$laneToken.address', '$$lane.feeToken'] },
+                                    },
+                                  },
+                                  0,
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+              else: '$$REMOVE',
+            },
+          },
+        },
+      },
+      {
+        $unset: as,
+      },
+    ]
   },
 
   logPluginSetupProcessor: (pluginAddress: HexAddress, network: string, as: string = 'plugin') => {

--- a/test/unit/handlers/crossChainHandler.spec.ts
+++ b/test/unit/handlers/crossChainHandler.spec.ts
@@ -1,5 +1,6 @@
 import { Models } from '@dbModels'
 import { CrossChainHandler } from '@handlers/crossChainHandler'
+import { ProxyToken } from '@modules/proxyToken'
 import { IPluginInterfaceType, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
@@ -23,6 +24,7 @@ const info = {
 
 describe('Indexer: CrossChain Handler', () => {
   let sandbox: SinonSandbox
+  let saveToken: sinon.SinonStub
 
   const stubSetting = (sb: SinonSandbox, crossChain: any = {}) => {
     const setting = {
@@ -53,6 +55,7 @@ describe('Indexer: CrossChain Handler', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     sandbox.stub(CrossChainHandler, '_readFeeToken').resolves(null)
+    saveToken = sandbox.stub(ProxyToken, 'saveAndGetToken').resolves()
   })
 
   afterEach(() => {
@@ -90,6 +93,31 @@ describe('Indexer: CrossChain Handler', () => {
       )
     })
 
+    it('should index the fee token so it gets a name, symbol and decimals', async () => {
+      const feeToken = '0x6666666666666666666666666666666666666666'
+      stubSetting(sandbox)
+      ;(CrossChainHandler._readFeeToken as sinon.SinonStub).resolves(feeToken)
+
+      await CrossChainHandler.configUpdated(
+        { args: { chainId: BigInt(8453), localAdapter: ADAPTER_LOCAL, remoteAdapter: ADAPTER_REMOTE } } as any,
+        info,
+      )
+
+      expect(saveToken.calledOnceWith(feeToken, info.network)).to.equal(true)
+    })
+
+    it('should index the native currency when the adapter pays fees in gas', async () => {
+      stubSetting(sandbox)
+      ;(CrossChainHandler._readFeeToken as sinon.SinonStub).resolves(ZERO)
+
+      await CrossChainHandler.configUpdated(
+        { args: { chainId: BigInt(8453), localAdapter: ADAPTER_LOCAL, remoteAdapter: ADAPTER_REMOTE } } as any,
+        info,
+      )
+
+      expect(saveToken.calledOnceWith(ZERO, info.network)).to.equal(true)
+    })
+
     it('should keep the lane when the fee token cannot be read', async () => {
       const setting = stubSetting(sandbox)
       ;(CrossChainHandler._readFeeToken as sinon.SinonStub).resolves(null)
@@ -101,6 +129,7 @@ describe('Indexer: CrossChain Handler', () => {
 
       expect(setting.crossChain.lanes).to.have.lengthOf(1)
       expect(setting.crossChain.lanes[0].feeToken).to.equal(null)
+      expect(saveToken.called).to.equal(false)
     })
 
     it('should not read a fee token when the lane is cleared', async () => {

--- a/test/unit/models/schema/setting.spec.ts
+++ b/test/unit/models/schema/setting.spec.ts
@@ -1,6 +1,7 @@
 import { Models } from '@dbModels'
 import Setting from '@models/schema/setting'
 import { fakeSettings } from '@test/mock/fakeSettings'
+import { FakeToken } from '@test/mock/fakeToken'
 import { IPluginInterfaceType, IPluginStatus, ISettingStatus, NetworksEnum } from '@types'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
@@ -346,6 +347,122 @@ describe('Model: Setting', () => {
       expect(settings.votingMode).to.eq(rawSetting.votingMode)
       expect(settings.supportThreshold).to.eq(rawSetting.supportThreshold)
       expect(settings.minParticipation).to.eq(rawSetting.minParticipation)
+    })
+  })
+
+  describe('crossChain lane fee tokens', () => {
+    const NATIVE = '0x0000000000000000000000000000000000000000'
+
+    const crossChainSetting = (lanes: any[]) => ({
+      ...rawSetting,
+      crossChain: {
+        executor: null,
+        executorIsDao: false,
+        minFailedMessageGas: '120000',
+        lanes,
+      },
+    })
+
+    const findLanes = async () => {
+      const setting = await Models.Setting.findSetting({
+        daoAddress: rawSetting.daoAddress,
+        pluginAddress: rawSetting.pluginAddress,
+        network: rawSetting.network,
+        status: rawSetting.status,
+      })
+      return setting.crossChain.lanes
+    }
+
+    beforeEach(async () => {
+      await Models.Token.create({
+        ...FakeToken,
+        network: rawSetting.network,
+      })
+    })
+
+    it('should put the indexed token details on the lane', async () => {
+      await Models.Setting.create(
+        crossChainSetting([
+          {
+            chainId: 8453,
+            localAdapter: '0x4444444444444444444444444444444444444444',
+            remoteAdapter: '0x5555555555555555555555555555555555555555',
+            feeToken: FakeToken.address,
+          },
+        ]),
+      )
+
+      const lanes = await findLanes()
+
+      expect(lanes[0].feeToken).to.eq(FakeToken.address)
+      expect(lanes[0].token.symbol).to.eq(FakeToken.symbol)
+      expect(lanes[0].token.name).to.eq(FakeToken.name)
+      expect(lanes[0].token.decimals).to.eq(FakeToken.decimals)
+    })
+
+    it('should enrich every lane with its own token', async () => {
+      await Models.Token.create({
+        ...FakeToken,
+        id: `${NATIVE}-${rawSetting.network}`,
+        address: NATIVE,
+        symbol: 'MATIC',
+        name: 'Polygon',
+        decimals: 18,
+        type: 'native',
+        network: rawSetting.network,
+      })
+
+      await Models.Setting.create(
+        crossChainSetting([
+          {
+            chainId: 1,
+            localAdapter: '0x4444444444444444444444444444444444444444',
+            remoteAdapter: '0x5555555555555555555555555555555555555555',
+            feeToken: NATIVE,
+          },
+          {
+            chainId: 8453,
+            localAdapter: '0x6666666666666666666666666666666666666666',
+            remoteAdapter: '0x7777777777777777777777777777777777777777',
+            feeToken: FakeToken.address,
+          },
+        ]),
+      )
+
+      const lanes = await findLanes()
+
+      expect(lanes.map((lane: any) => lane.token.symbol)).to.deep.eq(['MATIC', FakeToken.symbol])
+    })
+
+    it('should leave the token out when the fee token is not indexed yet', async () => {
+      await Models.Setting.create(
+        crossChainSetting([
+          {
+            chainId: 8453,
+            localAdapter: '0x4444444444444444444444444444444444444444',
+            remoteAdapter: '0x5555555555555555555555555555555555555555',
+            feeToken: '0x8888888888888888888888888888888888888888',
+          },
+        ]),
+      )
+
+      const lanes = await findLanes()
+
+      expect(lanes[0].feeToken).to.eq('0x8888888888888888888888888888888888888888')
+      expect(lanes[0].token).to.eq(undefined)
+    })
+
+    it('should not add a crossChain object to settings that have none', async () => {
+      await Models.Setting.create(rawSetting)
+
+      const setting = await Models.Setting.findSetting({
+        daoAddress: rawSetting.daoAddress,
+        pluginAddress: rawSetting.pluginAddress,
+        network: rawSetting.network,
+        status: rawSetting.status,
+      })
+
+      expect(setting.crossChain).to.eq(undefined)
     })
   })
 })


### PR DESCRIPTION
## 📝 Summary

This pull request enhances the handling and enrichment of cross-chain lane fee tokens within the settings model. It ensures that fee tokens used in cross-chain lanes are properly indexed, so their metadata (such as symbol, name, and decimals) is available on each lane. The changes also add comprehensive tests to verify this behavior.

**Cross-chain lane fee token enrichment and indexing:**

* Added a new aggregation pipeline (`crossChainLaneTokens`) in `AggregationQueryHelper` that joins token metadata to each cross-chain lane based on the `feeToken` address, enriching the lane with token details if available.
* Integrated the new aggregation pipeline into the main settings queries and projections, so cross-chain lanes automatically include enriched token data when requested. [[1]](diffhunk://#diff-91cb0620be211d600e6029061dec013f6d1282fca10d1dca75610531cd395236R478-R479) [[2]](diffhunk://#diff-91cb0620be211d600e6029061dec013f6d1282fca10d1dca75610531cd395236R496) [[3]](diffhunk://#diff-91cb0620be211d600e6029061dec013f6d1282fca10d1dca75610531cd395236R553-R554) [[4]](diffhunk://#diff-91cb0620be211d600e6029061dec013f6d1282fca10d1dca75610531cd395236R569) [[5]](diffhunk://#diff-55f0803de94d1fa0f90db2dacbc75c5a13d7da3c33c829be8275a21a615c9878R428-R432)
* Updated the cross-chain handler to index any fee token (including native tokens) by calling `ProxyToken.saveAndGetToken` whenever a new lane is configured, ensuring token metadata is available for enrichment. [[1]](diffhunk://#diff-3ed22545be69f0559cdcee2f0595bbed7fa125f19d0d193458d8829b2cc2229fR11) [[2]](diffhunk://#diff-3ed22545be69f0559cdcee2f0595bbed7fa125f19d0d193458d8829b2cc2229fR93-R95)

**Testing improvements:**

* Added unit tests for the cross-chain handler to verify that fee tokens are indexed as expected, including handling of native tokens and cases where the fee token is not available. [[1]](diffhunk://#diff-7c0cbd940b46937e8fa78b754a7ed54e52263f887f5a881830f03875a0892d14R3) [[2]](diffhunk://#diff-7c0cbd940b46937e8fa78b754a7ed54e52263f887f5a881830f03875a0892d14R27) [[3]](diffhunk://#diff-7c0cbd940b46937e8fa78b754a7ed54e52263f887f5a881830f03875a0892d14R58) [[4]](diffhunk://#diff-7c0cbd940b46937e8fa78b754a7ed54e52263f887f5a881830f03875a0892d14R96-R120) [[5]](diffhunk://#diff-7c0cbd940b46937e8fa78b754a7ed54e52263f887f5a881830f03875a0892d14R132)
* Added comprehensive tests for the settings model to ensure that cross-chain lanes are enriched with token metadata when available, and behave correctly when tokens are not indexed or when the cross-chain config is absent. [[1]](diffhunk://#diff-2c1e0157b537b1cf52d53c41b0fbcd905d9a94aefcb5580e152017ad509a88e3R4) [[2]](diffhunk://#diff-2c1e0157b537b1cf52d53c41b0fbcd905d9a94aefcb5580e152017ad509a88e3R352-R467)

These changes improve the reliability and usability of cross-chain configuration by ensuring that all relevant token information is present and up-to-date in the settings data.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
