### PR TITLE
ci(APP-1028): guard release-start against squash-merged back-merges

### DIFF
--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -52,7 +52,9 @@ jobs:
           VERSION="${MERGED_HEAD##*/}" # release/0.27.0 | hotfix/0.27.1 -> 0.27.x
           echo "Back-merge: $HEAD → $BASE (from $MERGED_HEAD)"
           TITLE="chore: sync $HEAD (v$VERSION) back to $BASE"
-          BODY="Auto-opened when \`$MERGED_HEAD\` merged into \`$HEAD\`. Carries the merged changes (incl. CHANGELOG.md / version) back into \`$BASE\`."
+          BODY=$(printf '%s\n\n%s' \
+            "Auto-opened when \`$MERGED_HEAD\` merged into \`$HEAD\`. Carries the merged changes (incl. CHANGELOG.md / version) back into \`$BASE\`." \
+            "⚠️ Merge with a **merge commit** — never squash or rebase. Squashing copies the content but not the history: the release tag stays unreachable from \`$BASE\` and the next release-start recomputes the version that was just released.")
           EXISTING_PR=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json number -q '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -124,6 +124,19 @@ jobs:
             exit 1
           fi
 
+      # A squash-merged back-merge copies main's content but not its history: the
+      # release tag stays unreachable from the base, semantic-release baselines on
+      # the previous tag and recomputes the version that was just released.
+      - name: Guard — latest tag reachable from base
+        run: |
+          set -euo pipefail
+          LATEST_TAG=$(git tag --list --sort=-v:refname | head -1)
+          if [ -n "$LATEST_TAG" ] && ! git merge-base --is-ancestor "$LATEST_TAG" HEAD; then
+            echo "❌ Latest tag $LATEST_TAG is not an ancestor of the base — the back-merge from main is missing or was squash/rebase-merged." >&2
+            echo "   Merge main into the base with a merge commit (re-open the back-merge PR if needed), then retry." >&2
+            exit 1
+          fi
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
@@ -157,10 +170,11 @@ jobs:
           fi
           # Guard against stale tag lineage: if BASE diverged from the production
           # tag line (e.g. a history rewrite, or main never back-merged into it),
-          # semantic-release baselines on an old tag and computes a version BELOW
-          # what's already released. Fail loudly instead of opening a bogus PR.
+          # semantic-release baselines on an old tag and computes a version AT OR
+          # BELOW what's already released — recomputing the just-released version
+          # is the same symptom. Fail loudly instead of opening a bogus PR.
           LATEST=$(git tag --list --sort=-v:refname | head -1 | sed 's/^v//')
-          if [ -n "$LATEST" ] && [ "$VERSION" != "$LATEST" ] && \
+          if [ -n "$LATEST" ] && \
              [ "$(printf '%s\n%s\n' "$LATEST" "$VERSION" | sort -V | tail -1)" = "$LATEST" ]; then
             echo "❌ Computed v$VERSION ≤ latest tag v$LATEST — base '$BASE' tag lineage is stale." >&2
             echo "   Back-merge main into '$BASE' (so it descends from v$LATEST), then retry." >&2


### PR DESCRIPTION
This makes \`release-start\` fail fast when the tag lineage is broken instead of opening a release PR for an already-released version. Today the v0.35.0 back-merge PR (#1521) was squash-merged: \`development\` received main's content but not its history, the \`v0.35.0\` tag stayed unreachable, and a manual release-start baselined semantic-release on \`v0.34.0\` — opening a second "Release v0.35.0" PR (#1522). The existing stale-lineage guard only rejected versions strictly *below* the latest tag, so the duplicate sailed through.

## Changes

- **Ancestry guard in \`release-start\`:** a new step fails when the latest tag is not an ancestor of the base, with a message naming the likely cause (back-merge missing or squash/rebase-merged) and the fix. Unlike the schedule gate, it also covers \`workflow_dispatch\` runs — exactly how the duplicate was started.
- **Stale-lineage guard rejects equality:** the semantic-release check now fails on a computed version *equal to* the latest tag, not only below it. Recomputing the just-released version is the same symptom.
- **Back-merge PR body warns against squash:** the auto-opened \`main → development\` PR now states it must be merged with a merge commit and why.

## Note

The ancestry guard only protects the next release-start run — nothing stops a squash-merge of the back-merge PR itself. If we want a hard stop, that would need a branch-protection/merge-method rule, which felt heavier than this incident warrants.