### PR TITLE
ci(APP-1028): fall back to threading when the base slack-notify predates update-ts

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -204,6 +204,11 @@ jobs:
           slack-bot-token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
           slack-channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
           update-ts: ${{ needs.meta.outputs.thread-ts }}
+          # This action runs from the PR's base commit (see the checkout above), which
+          # may predate the update-ts contract. Such a version ignores the unknown input,
+          # and thread-ts makes it reply in the release thread instead of posting a
+          # second root message. A version that knows update-ts prefers it over thread-ts.
+          thread-ts: ${{ needs.meta.outputs.thread-ts }}
           message: |
             :rocket: *Backend Release v${{ needs.meta.outputs.version }} Started*
             *PR:* ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This keeps the Slack refresh inside the release thread when the composite action is older than the workflow calling it. \`refresh-summary\` deliberately runs actions and scripts from the PR's *base* commit (so pushes to \`release/*\` can't swap the code that reads the tokens) — which means a release cut right after a \`slack-notify\` contract change runs the old action against the new workflow inputs. v0.35.0 hit exactly that: the base action ignored the unknown \`update-ts\` input with only a warning, and every push to the release branch posted a fresh ":rocket: Started" root message instead of rewriting the existing one.

## Changes

- **\`thread-ts\` passed alongside \`update-ts\`** in the "Update Slack root message" step. A legacy action that only knows \`thread-ts\` now replies inside the release thread instead of posting a second root message; a current action prefers \`update-ts\` and rewrites the root message as before (\`slackNotify.js\` checks \`SLACK_UPDATE_TS\` first).

## Note

This is a seatbelt for the one-release lag that base-pinning bakes in, not a fix for the lag itself — any future change to the slack-notify/scripts contract still reaches \`main\` only with the next release. Interface changes there should stay backward-compatible for one release.