### PR TITLE
fix(cross-chain): join lane fee tokens on the token index instead of $in

### DIFF
--- a/src/models/utils/aggregation.ts
+++ b/src/models/utils/aggregation.ts
@@ -497,16 +497,13 @@ export const AggregationQueryHelper = {
       {
         $lookup: {
           from: ICollectionNames.Token,
-          let: {
-            addresses: { $ifNull: ['$crossChain.lanes.feeToken', []] },
-            network,
-          },
+          localField: 'crossChain.lanes.feeToken',
+          foreignField: 'address',
+          let: { network },
           pipeline: [
             {
               $match: {
-                $expr: {
-                  $and: [{ $in: ['$address', '$$addresses'] }, { $eq: ['$network', '$$network'] }],
-                },
+                $expr: { $eq: ['$network', '$$network'] },
               },
             },
             {


### PR DESCRIPTION
## 📝 Summary

This pull request updates the aggregation logic in the `AggregationQueryHelper` to simplify and optimize the `$lookup` stage when joining token information. The main change is to use `localField` and `foreignField` directly for the join, instead of using `$expr` with `$in`, which should improve performance and clarity.

### Aggregation query optimization:

* Updated the `$lookup` in `AggregationQueryHelper` to use `localField: 'crossChain.lanes.feeToken'` and `foreignField: 'address'` for joining tokens, removing the `$in` expression and simplifying the pipeline to only filter by `network`.

## ✅ Checklist

### 🔍 Code Review
- [ ] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [ ] Removed all debug code, console.logs, and dead code
- [ ] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [ ] Verified no secrets or credentials are exposed
- [ ] Reviewed for common security vulnerabilities
- [ ] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
