### PR TITLE
chore(deps): bump 1password/load-secrets-action and pnpm/action-setup

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       with:
         run_install: false
 

--- a/.github/workflows/app-deploy-docker.yml
+++ b/.github/workflows/app-deploy-docker.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Load Slack secrets
         id: slack-secrets
         if: needs.validate.outputs.environment == 'staging' || needs.validate.outputs.environment == 'production'
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 #v5.0.0
         with:
           export-env: false
         env:
@@ -145,7 +145,7 @@ jobs:
       # Step 3: Load server connection secrets
       - name: Load server connection secrets
         id: server-secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 #v5.0.0
         with:
           export-env: false
         env:
@@ -568,7 +568,7 @@ jobs:
       - name: Load Slack secrets
         id: slack-secrets
         if: needs.deploy.outputs.deploy-thread-ts != ''
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 #v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/app-production.yml
+++ b/.github/workflows/app-production.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Load Slack secrets
         id: secrets
         if: needs.meta.outputs.thread-ts != ''
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -68,7 +68,7 @@ jobs:
             .github/workflows/scripts
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:
@@ -151,7 +151,7 @@ jobs:
 
       - name: Load server connection secrets
         id: server-secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:
@@ -281,7 +281,7 @@ jobs:
             .github/workflows/scripts
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/hotfix-start.yml
+++ b/.github/workflows/hotfix-start.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-cancel.yml
+++ b/.github/workflows/release-cancel.yml
@@ -61,7 +61,7 @@ jobs:
             .github/workflows/scripts
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-hotfix-cherrypick.yml
+++ b/.github/workflows/release-hotfix-cherrypick.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -143,7 +143,7 @@ jobs:
           path: pr
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:
@@ -285,7 +285,7 @@ jobs:
       - name: Load secrets
         id: secrets
         if: steps.regen.outputs.changed == 'true'
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:
@@ -347,7 +347,7 @@ jobs:
       - name: Load Slack secrets
         id: secrets
         if: needs.meta.outputs.thread-ts != ''
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Load secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -75,7 +75,7 @@ jobs:
             .github/actions
       - name: Load Slack secrets
         id: secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
         with:
           export-env: false
         env:

--- a/.github/workflows/unit-dep.yml
+++ b/.github/workflows/unit-dep.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load secrets
         id: op-server-secrets
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 #v4.0.1
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 #v5.0.0
         with:
           export-env: false
         env:


### PR DESCRIPTION
## 📝 Summary

Bundles the open dependabot bumps for github actions into one PR, so we don't merge them one by one.

Typescript 6 -> 7 (#1468) is left out. TS7 removed `moduleResolution: node10` and `baseUrl`, and `tsc --noEmit` fails on our tsconfig with both. We use `baseUrl` with tsconfig-paths at runtime, so that one needs a proper tsconfig migration first.

## 🔄 What Changed

- `1password/load-secrets-action` 4.0.1 -> 5.0.0 (#1532). v5 only adds workload identity auth, service account auth we use is untouched.
- `pnpm/action-setup` 6.0.9 -> 6.0.10 in `.github/actions/setup-pnpm` (#1531).

Both are pinned to commit sha, same as before.

## ✅ Checklist

### 🔍 Code Review
- [x] Self-reviewed all code changes
- [ ] Ask AI/Copilot code review
- [x] Removed all debug code, console.logs, and dead code
- [x] Implemented error handling with try/catch blocks where needed

### 🧪 Testing
- [ ] All test suites pass locally
- [ ] Added comprehensive unit tests for new features
- [ ] Included integration tests for end-to-end scenarios
- [ ] Successfully tested on remote server

### 🔒 Security
- [x] Verified no secrets or credentials are exposed
- [x] Reviewed for common security vulnerabilities
- [x] **Verified commit authorship** - Reviewed all commits to ensure they're from team members (check for compromised accounts)
