### PR TITLE
Hotfix v0.36.1

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -65,8 +65,12 @@ jobs:
         run: |
           set -euo pipefail
           VER="$VERSION"
+          # Three hashes too: the conventionalcommits preset drops a patch section to
+          # `### [x.y.z]`, which is the level every hotfix release lands on. The type
+          # sub-headings inside a section ("### Bug Fixes") carry no `[`, so widening
+          # the level cannot end the block early.
           awk -v ver="$VER" '
-            /^#{1,2} \[/ { if (inblock) exit; if (index($0, "[" ver "]")) { inblock=1; print; next } }
+            /^#{1,3} \[/ { if (inblock) exit; if (index($0, "[" ver "]")) { inblock=1; print; next } }
             inblock { print }
           ' CHANGELOG.md > notes.md || true
           if [ ! -s notes.md ]; then echo "Release v$VER" > notes.md; fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -6,7 +6,7 @@ run-name: Release PR #${{ github.event.pull_request.number }} — test + staging
 #   1. fast checks (lint, format, unit + coverage) and the staging deploy run in
 #      PARALLEL — merge is gated by the required checks (Approve #2), the deploy by
 #      the staging Environment's Required-reviewers rule (Approve #1)
-#   2. release/* PRs also regenerate the summary in the PR body + Slack root
+#   2. both branch kinds also regenerate the summary in the PR body + Slack root
 #      message (refresh-summary) and rebuild the CHANGELOG.md section
 #      (regen-changelog) on every push
 #   3. post "what to test" + non-blocking E2E into the Slack thread
@@ -116,7 +116,10 @@ jobs:
   # release-start's body edit and rewrite it before the slack_ts marker lands, losing the
   # Slack thread for the rest of the release.
   refresh-summary:
-    if: github.event.action == 'synchronize' && startsWith(github.event.pull_request.head.ref, 'release/')
+    if: >
+      github.event.action == 'synchronize' &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     needs: meta
     runs-on: ubuntu-latest
     permissions:
@@ -218,8 +221,8 @@ jobs:
             ${{ steps.summary.outputs.summary }}
 
   # Keeps CHANGELOG.md — and the GitHub Release notes finalize extracts from it —
-  # matching what actually ships: commits landing on the release branch after
-  # release-start are otherwise never reflected in the changelog.
+  # matching what actually ships: commits landing on the release or hotfix branch
+  # after start are otherwise never reflected in the changelog.
   # The in-flight section is rebuilt from scratch (latest tag → HEAD), so manual
   # edits to it do NOT survive the next push; commits with non-conventional
   # subjects are dropped by the generator — fix the subject, or hand-edit only
@@ -227,7 +230,10 @@ jobs:
   # synchronize only, mirroring refresh-summary: the `opened` head is
   # release-start's own commit, which already carries a fresh changelog.
   regen-changelog:
-    if: github.event.action == 'synchronize' && startsWith(github.event.pull_request.head.ref, 'release/')
+    if: >
+      github.event.action == 'synchronize' &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     runs-on: ubuntu-latest
     steps:
       # The release branch is git DATA here, like in refresh-summary: nothing
@@ -253,7 +259,9 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$RELEASE_REF" | grep -qE '^release/[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # hotfix-start appends a slug from its description input, so a hotfix ref
+          # carries an optional `-<slug>` the release refs never have.
+          if ! printf '%s' "$RELEASE_REF" | grep -qE '^(release/[0-9]+\.[0-9]+\.[0-9]+|hotfix/[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9-]+)?)$'; then
             echo "❌ Unexpected release ref shape: $RELEASE_REF" >&2
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+* **execute-handler:** improve error handling and simplify selector permission creation ([afca718](https://github.com/aragon/app-backend/commit/afca7182bc15862c227ee5a66993bc6e82617660))
 * **release:** update release and hotfix branch handling in workflows ([0d4fe69](https://github.com/aragon/app-backend/commit/0d4fe6924bf389e59f6a31158800d530495e6dd6))
 * **selector-permission:** enhance deduplication migration to handle duplicate writes ([7130f62](https://github.com/aragon/app-backend/commit/7130f620844266ae2204ef5beacea12bd5c473f7))
 * **selector-permission:** keep one row per allowed selector log ([dd33ce8](https://github.com/aragon/app-backend/commit/dd33ce859fd2c4ee346677ba6caa1ce6a63c9d16))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.36.1](https://github.com/aragon/app-backend/compare/v0.36.0...v0.36.1) (2026-08-20)
+
+### Bug Fixes
+
+* **selector-permission:** keep one row per allowed selector log ([dd33ce8](https://github.com/aragon/app-backend/commit/dd33ce859fd2c4ee346677ba6caa1ce6a63c9d16))
 ## [0.36.0](https://github.com/aragon/app-backend/compare/v0.35.0...v0.36.0) (2026-08-14)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+* **release:** update release and hotfix branch handling in workflows ([0d4fe69](https://github.com/aragon/app-backend/commit/0d4fe6924bf389e59f6a31158800d530495e6dd6))
+* **selector-permission:** enhance deduplication migration to handle duplicate writes ([7130f62](https://github.com/aragon/app-backend/commit/7130f620844266ae2204ef5beacea12bd5c473f7))
 * **selector-permission:** keep one row per allowed selector log ([dd33ce8](https://github.com/aragon/app-backend/commit/dd33ce859fd2c4ee346677ba6caa1ce6a63c9d16))
 ## [0.36.0](https://github.com/aragon/app-backend/compare/v0.35.0...v0.36.0) (2026-08-14)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aragon-backend",
   "description": "OpenSource backend services",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "main": "index.ts",
   "license": "AGPL-3.0",
   "author": "Aragon Development Team",

--- a/src/handlers/executeHandler.ts
+++ b/src/handlers/executeHandler.ts
@@ -1,6 +1,8 @@
 import { Models } from '@dbModels'
 import Web3Helper from '@helpers/web3'
 import logger from '@logger'
+import type SelectorPermission from '@models/schema/selectorPermission'
+import type { ActionDecoded } from '@models/schema/selectorPermission'
 import DbTx from '@modules/dbTx'
 import ProviderModule from '@modules/provider'
 import { ContractInfo } from '@services/aragon-gateway/contractInfo'
@@ -8,6 +10,17 @@ import { type ILogInfo, IPluginStatus, type ISelectorPermissionIdParams, type Ne
 import { type LogDescription } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'handlers:ExecuteHandler' })
+
+// What the sub schema fills in on its own, spelled out so a partially decoded signature still
+// types as an `ActionDecoded`.
+const EMPTY_DECODED: ActionDecoded = {
+  functionName: null,
+  contractName: null,
+  proxyName: null,
+  implementationAddress: null,
+  inputs: null,
+  notice: null,
+}
 
 export const ExecuteHandler = {
   /**
@@ -32,7 +45,7 @@ export const ExecuteHandler = {
    * index on the entity id settles it; the one that loses reads back the row instead of failing
    * the message.
    */
-  async _createSelectorPermission(payload: Record<string, any>, selectorParams: ISelectorPermissionIdParams) {
+  async _createSelectorPermission(payload: Partial<SelectorPermission>, selectorParams: ISelectorPermissionIdParams) {
     try {
       return await Models.SelectorPermission.create(payload)
     } catch (error) {
@@ -80,16 +93,17 @@ export const ExecuteHandler = {
         )
       }
 
-      const decoded = selectorInfo
+      const decoded: ActionDecoded = selectorInfo
         ? {
+            ...EMPTY_DECODED,
             functionName: selectorInfo.functionName,
             contractName: selectorInfo.contractName,
-            proxyName: selectorInfo.proxyName,
-            implementationAddress: selectorInfo.implementationAddress,
+            proxyName: selectorInfo.proxyName ?? null,
+            implementationAddress: selectorInfo.implementationAddress ?? null,
             inputs: selectorInfo.inputs,
-            notice: selectorInfo.notice,
+            notice: selectorInfo.notice ?? null,
           }
-        : {}
+        : { ...EMPTY_DECODED }
 
       const selectorRecord = await ExecuteHandler._createSelectorPermission(
         {
@@ -246,6 +260,7 @@ export const ExecuteHandler = {
           chainId,
           isAllowed: true,
           decoded: {
+            ...EMPTY_DECODED,
             functionName: decoded.functionName,
             contractName: decoded.contractName,
           },

--- a/src/handlers/executeHandler.ts
+++ b/src/handlers/executeHandler.ts
@@ -6,8 +6,9 @@ import type { ActionDecoded } from '@models/schema/selectorPermission'
 import DbTx from '@modules/dbTx'
 import ProviderModule from '@modules/provider'
 import { ContractInfo } from '@services/aragon-gateway/contractInfo'
-import { type ILogInfo, IPluginStatus, type ISelectorPermissionIdParams, type NetworksEnum } from '@types'
+import { type ILogInfo, IPluginStatus, type NetworksEnum } from '@types'
 import { type LogDescription } from 'ethers'
+import { type ClientSession } from 'mongoose'
 
 const llo = logger.logMeta.bind(null, { service: 'handlers:ExecuteHandler' })
 
@@ -42,16 +43,15 @@ export const ExecuteHandler = {
   /**
    * The existence check and the write are far apart — the block timestamp and the signature both
    * come from RPC in between — so two workers on the same log can both decide to write. The unique
-   * index on the entity id settles it; the one that loses reads back the row instead of failing
-   * the message.
+   * index on the entity id settles it, and `executeTxFn` hands the loser the row the winner wrote
+   * instead of failing the message.
    */
-  async _createSelectorPermission(payload: Partial<SelectorPermission>, selectorParams: ISelectorPermissionIdParams) {
-    try {
-      return await Models.SelectorPermission.create(payload)
-    } catch (error) {
-      if (!DbTx.isErrorDuplicateKey(error)) throw error
-      return await Models.SelectorPermission.findExistingLog(selectorParams)
-    }
+  async _createSelectorPermission(payload: Partial<SelectorPermission>) {
+    return await DbTx.executeTxFn(async ({ session }: { session: ClientSession }) => {
+      const logDb = await Models.SelectorPermission.create(payload, { session })
+      await DbTx.safeCommit(session)
+      return logDb
+    })
   },
 
   async selectorAllowed(parsedEvent: LogDescription, info: ILogInfo) {
@@ -105,21 +105,18 @@ export const ExecuteHandler = {
           }
         : { ...EMPTY_DECODED }
 
-      const selectorRecord = await ExecuteHandler._createSelectorPermission(
-        {
-          blockNumber,
-          blockTimestamp,
-          pluginAddress: plugin.address,
-          daoAddress: plugin.daoAddress,
-          selector,
-          target: where,
-          chainId,
-          isAllowed: true,
-          ...selectorParams,
-          decoded,
-        },
-        selectorParams,
-      )
+      const selectorRecord = await ExecuteHandler._createSelectorPermission({
+        blockNumber,
+        blockTimestamp,
+        pluginAddress: plugin.address,
+        daoAddress: plugin.daoAddress,
+        selector,
+        target: where,
+        chainId,
+        isAllowed: true,
+        ...selectorParams,
+        decoded,
+      })
 
       logger.info(
         'Selector allowed',
@@ -244,29 +241,26 @@ export const ExecuteHandler = {
 
       const decoded = await ContractInfo.parseSignature(null, where, network)
 
-      const selectorRecord = await ExecuteHandler._createSelectorPermission(
-        {
-          network,
-          transactionHash,
-          transactionIndex,
-          logIndex,
-          blockNumber,
-          blockTimestamp,
-          pluginAddress: plugin.address,
-          daoAddress: plugin.daoAddress,
-          conditionAddress: info.address,
-          selector: null,
-          target: where,
-          chainId,
-          isAllowed: true,
-          decoded: {
-            ...EMPTY_DECODED,
-            functionName: decoded.functionName,
-            contractName: decoded.contractName,
-          },
+      const selectorRecord = await ExecuteHandler._createSelectorPermission({
+        network,
+        transactionHash,
+        transactionIndex,
+        logIndex,
+        blockNumber,
+        blockTimestamp,
+        pluginAddress: plugin.address,
+        daoAddress: plugin.daoAddress,
+        conditionAddress: info.address,
+        selector: null,
+        target: where,
+        chainId,
+        isAllowed: true,
+        decoded: {
+          ...EMPTY_DECODED,
+          functionName: decoded.functionName,
+          contractName: decoded.contractName,
         },
-        selectorParams,
-      )
+      })
 
       logger.info(
         'Native transfers allowed',

--- a/src/handlers/executeHandler.ts
+++ b/src/handlers/executeHandler.ts
@@ -1,9 +1,10 @@
 import { Models } from '@dbModels'
 import Web3Helper from '@helpers/web3'
 import logger from '@logger'
+import DbTx from '@modules/dbTx'
 import ProviderModule from '@modules/provider'
 import { ContractInfo } from '@services/aragon-gateway/contractInfo'
-import { type ILogInfo, IPluginStatus, type NetworksEnum } from '@types'
+import { type ILogInfo, IPluginStatus, type ISelectorPermissionIdParams, type NetworksEnum } from '@types'
 import { type LogDescription } from 'ethers'
 
 const llo = logger.logMeta.bind(null, { service: 'handlers:ExecuteHandler' })
@@ -23,6 +24,21 @@ export const ExecuteHandler = {
     return parsedEvent.args?.chainId === undefined || parsedEvent.args?.chainId === null
       ? { $or: [{ chainId }, { chainId: null }] }
       : { chainId }
+  },
+
+  /**
+   * The existence check and the write are far apart — the block timestamp and the signature both
+   * come from RPC in between — so two workers on the same log can both decide to write. The unique
+   * index on the entity id settles it; the one that loses reads back the row instead of failing
+   * the message.
+   */
+  async _createSelectorPermission(payload: Record<string, any>, selectorParams: ISelectorPermissionIdParams) {
+    try {
+      return await Models.SelectorPermission.create(payload)
+    } catch (error) {
+      if (!DbTx.isErrorDuplicateKey(error)) throw error
+      return await Models.SelectorPermission.findExistingLog(selectorParams)
+    }
   },
 
   async selectorAllowed(parsedEvent: LogDescription, info: ILogInfo) {
@@ -75,18 +91,21 @@ export const ExecuteHandler = {
           }
         : {}
 
-      const selectorRecord = await Models.SelectorPermission.create({
-        blockNumber,
-        blockTimestamp,
-        pluginAddress: plugin.address,
-        daoAddress: plugin.daoAddress,
-        selector,
-        target: where,
-        chainId,
-        isAllowed: true,
-        ...selectorParams,
-        decoded,
-      })
+      const selectorRecord = await ExecuteHandler._createSelectorPermission(
+        {
+          blockNumber,
+          blockTimestamp,
+          pluginAddress: plugin.address,
+          daoAddress: plugin.daoAddress,
+          selector,
+          target: where,
+          chainId,
+          isAllowed: true,
+          ...selectorParams,
+          decoded,
+        },
+        selectorParams,
+      )
 
       logger.info(
         'Selector allowed',
@@ -211,25 +230,28 @@ export const ExecuteHandler = {
 
       const decoded = await ContractInfo.parseSignature(null, where, network)
 
-      const selectorRecord = await Models.SelectorPermission.create({
-        network,
-        transactionHash,
-        transactionIndex,
-        logIndex,
-        blockNumber,
-        blockTimestamp,
-        pluginAddress: plugin.address,
-        daoAddress: plugin.daoAddress,
-        conditionAddress: info.address,
-        selector: null,
-        target: where,
-        chainId,
-        isAllowed: true,
-        decoded: {
-          functionName: decoded.functionName,
-          contractName: decoded.contractName,
+      const selectorRecord = await ExecuteHandler._createSelectorPermission(
+        {
+          network,
+          transactionHash,
+          transactionIndex,
+          logIndex,
+          blockNumber,
+          blockTimestamp,
+          pluginAddress: plugin.address,
+          daoAddress: plugin.daoAddress,
+          conditionAddress: info.address,
+          selector: null,
+          target: where,
+          chainId,
+          isAllowed: true,
+          decoded: {
+            functionName: decoded.functionName,
+            contractName: decoded.contractName,
+          },
         },
-      })
+        selectorParams,
+      )
 
       logger.info(
         'Native transfers allowed',

--- a/src/migrations/20260819141224-dedupeSelectorPermissions.ts
+++ b/src/migrations/20260819141224-dedupeSelectorPermissions.ts
@@ -1,0 +1,75 @@
+import { Models } from '@dbModels'
+import logger from '@logger'
+import { type IMigration } from '@types'
+
+const llo = logger.logMeta.bind(null, { service: 'Migration: dedupeSelectorPermissions' })
+
+/**
+ * `SelectorPermission` was the only collection whose entity id had no unique index, so two workers
+ * handling the same log both passed the "does this log already exist" check and both wrote a row.
+ * The API then lists the same allowed selector twice, and revoking it only flips one of the copies
+ * because the disallow lookup reads a single document.
+ *
+ * Keep one row per id — the revoked copy when the group has one, otherwise the oldest — drop the
+ * rest, then build the unique index the model now declares. Safe to run again.
+ */
+export const dedupeSelectorPermissionsMigration: IMigration = {
+  start: async () => {
+    logger.info('Starting migration', llo({ migration: '20260819141224-dedupeSelectorPermissions' }))
+
+    try {
+      const duplicates = await Models.SelectorPermission.aggregate([
+        {
+          $group: {
+            _id: '$id',
+            count: { $sum: 1 },
+            docs: { $push: { _id: '$_id', isAllowed: '$isAllowed' } },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+      ]).allowDiskUse(true)
+
+      // A revoked copy carries the disallow that the racing writer never saw, so it wins over the
+      // older row. Otherwise the oldest wins — ObjectIds are time ordered, so string order is age.
+      const idsToDelete = duplicates.flatMap((group: any) =>
+        [...group.docs]
+          .sort((left, right) => {
+            if (left.isAllowed !== right.isAllowed) return left.isAllowed ? 1 : -1
+            return String(left._id).localeCompare(String(right._id))
+          })
+          .slice(1)
+          .map(doc => doc._id),
+      )
+
+      if (idsToDelete.length) {
+        await Models.SelectorPermission.deleteMany({ _id: { $in: idsToDelete } })
+      }
+
+      logger.verbose(
+        'Duplicate selector permissions removed',
+        llo({ duplicatedIds: duplicates.length, deleted: idsToDelete.length }),
+      )
+
+      await Models.SelectorPermission.syncIndexes()
+
+      const indexes = await Models.SelectorPermission.collection.indexes()
+
+      logger.info(
+        'Migration completed successfully',
+        llo({
+          migration: '20260819141224-dedupeSelectorPermissions',
+          duplicatedIds: duplicates.length,
+          deleted: idsToDelete.length,
+          indexes: indexes.map((index: any) => index.name),
+        }),
+      )
+    } catch (error) {
+      logger.error('Migration failed', llo({ migration: '20260819141224-dedupeSelectorPermissions', error }))
+      throw error
+    }
+  },
+
+  stop: async () => {},
+}
+
+export default dedupeSelectorPermissionsMigration

--- a/src/migrations/20260819141224-dedupeSelectorPermissions.ts
+++ b/src/migrations/20260819141224-dedupeSelectorPermissions.ts
@@ -1,8 +1,47 @@
 import { Models } from '@dbModels'
 import logger from '@logger'
+import DbTx from '@modules/dbTx'
 import { type IMigration } from '@types'
 
 const llo = logger.logMeta.bind(null, { service: 'Migration: dedupeSelectorPermissions' })
+
+const migration = '20260819141224-dedupeSelectorPermissions'
+
+// The build reads the whole collection, so one pass is enough unless a pod that still runs the old
+// code writes a duplicate while it is running. One extra pass covers that, and a second failure
+// means the old pods are still up, which the deploy has to solve.
+const MAX_ATTEMPTS = 2
+
+const removeDuplicates = async () => {
+  const duplicates = await Models.SelectorPermission.aggregate([
+    {
+      $group: {
+        _id: '$id',
+        count: { $sum: 1 },
+        docs: { $push: { _id: '$_id', isAllowed: '$isAllowed' } },
+      },
+    },
+    { $match: { count: { $gt: 1 } } },
+  ]).allowDiskUse(true)
+
+  // A revoked copy carries the disallow that the racing writer never saw, so it wins over the
+  // older row. Otherwise the oldest wins — ObjectIds are time ordered, so string order is age.
+  const idsToDelete = duplicates.flatMap((group: any) =>
+    [...group.docs]
+      .sort((left, right) => {
+        if (left.isAllowed !== right.isAllowed) return left.isAllowed ? 1 : -1
+        return String(left._id).localeCompare(String(right._id))
+      })
+      .slice(1)
+      .map(doc => doc._id),
+  )
+
+  if (idsToDelete.length) {
+    await Models.SelectorPermission.deleteMany({ _id: { $in: idsToDelete } })
+  }
+
+  return { duplicatedIds: duplicates.length, deleted: idsToDelete.length }
+}
 
 /**
  * `SelectorPermission` was the only collection whose entity id had no unique index, so two workers
@@ -15,56 +54,38 @@ const llo = logger.logMeta.bind(null, { service: 'Migration: dedupeSelectorPermi
  */
 export const dedupeSelectorPermissionsMigration: IMigration = {
   start: async () => {
-    logger.info('Starting migration', llo({ migration: '20260819141224-dedupeSelectorPermissions' }))
+    logger.info('Starting migration', llo({ migration }))
 
     try {
-      const duplicates = await Models.SelectorPermission.aggregate([
-        {
-          $group: {
-            _id: '$id',
-            count: { $sum: 1 },
-            docs: { $push: { _id: '$_id', isAllowed: '$isAllowed' } },
-          },
-        },
-        { $match: { count: { $gt: 1 } } },
-      ]).allowDiskUse(true)
+      let removed = { duplicatedIds: 0, deleted: 0 }
 
-      // A revoked copy carries the disallow that the racing writer never saw, so it wins over the
-      // older row. Otherwise the oldest wins — ObjectIds are time ordered, so string order is age.
-      const idsToDelete = duplicates.flatMap((group: any) =>
-        [...group.docs]
-          .sort((left, right) => {
-            if (left.isAllowed !== right.isAllowed) return left.isAllowed ? 1 : -1
-            return String(left._id).localeCompare(String(right._id))
-          })
-          .slice(1)
-          .map(doc => doc._id),
-      )
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        removed = await removeDuplicates()
 
-      if (idsToDelete.length) {
-        await Models.SelectorPermission.deleteMany({ _id: { $in: idsToDelete } })
+        logger.verbose('Duplicate selector permissions removed', llo({ ...removed, attempt }))
+
+        try {
+          await Models.SelectorPermission.syncIndexes()
+          break
+        } catch (error) {
+          if (!DbTx.isErrorDuplicateKey(error) || attempt === MAX_ATTEMPTS) throw error
+
+          logger.warn('Unique index rejected a duplicate written mid build, cleaning up again', llo({ attempt }))
+        }
       }
-
-      logger.verbose(
-        'Duplicate selector permissions removed',
-        llo({ duplicatedIds: duplicates.length, deleted: idsToDelete.length }),
-      )
-
-      await Models.SelectorPermission.syncIndexes()
 
       const indexes = await Models.SelectorPermission.collection.indexes()
 
       logger.info(
         'Migration completed successfully',
         llo({
-          migration: '20260819141224-dedupeSelectorPermissions',
-          duplicatedIds: duplicates.length,
-          deleted: idsToDelete.length,
+          migration,
+          ...removed,
           indexes: indexes.map((index: any) => index.name),
         }),
       )
     } catch (error) {
-      logger.error('Migration failed', llo({ migration: '20260819141224-dedupeSelectorPermissions', error }))
+      logger.error('Migration failed', llo({ migration, error }))
       throw error
     }
   },

--- a/src/models/schema/selectorPermission.ts
+++ b/src/models/schema/selectorPermission.ts
@@ -68,7 +68,7 @@ export class Disallowed {
 @index({ daoAddress: 1, network: 1, conditionAddress: 1, isAllowed: 1 })
 @index({ pluginAddress: 1, network: 1, chainId: 1, isAllowed: 1 })
 export default class SelectorPermission extends Model {
-  @prop({ type: () => String, required: true })
+  @prop({ type: () => String, required: true, unique: true })
   public id!: string
 
   @prop({ type: () => String, required: true })

--- a/test/unit/handlers/executeHandler.spec.ts
+++ b/test/unit/handlers/executeHandler.spec.ts
@@ -745,4 +745,49 @@ describe('ExecuteHandler', () => {
       expect(permissions.every(p => p.isAllowed)).to.be.true
     })
   })
+
+  describe('_createSelectorPermission', () => {
+    const selectorParams = () => ({
+      network: mockInfo.network,
+      transactionHash: mockInfo.transactionHash,
+      transactionIndex: mockInfo.transactionIndex,
+      logIndex: mockInfo.logIndex,
+      conditionAddress: mockInfo.address,
+    })
+
+    it('returns the row the other worker wrote when both handled the same log', async () => {
+      const params = selectorParams()
+      const winner = await Models.SelectorPermission.create({
+        ...params,
+        blockNumber: mockInfo.blockNumber,
+        blockTimestamp: 1620000000,
+        pluginAddress: mockPlugin.address,
+        daoAddress: mockPlugin.daoAddress,
+        selector: '0x12345678',
+        target: '0x3333333333333333333333333333333333333333',
+        chainId: 1,
+        isAllowed: true,
+      })
+
+      // What the unique index on the entity id throws at the worker that comes second.
+      const duplicateKey: any = new Error('E11000 duplicate key error collection')
+      duplicateKey.code = 11000
+      sandbox.stub(Models.SelectorPermission, 'create').rejects(duplicateKey)
+
+      const result = await ExecuteHandler._createSelectorPermission({ ...params }, params)
+
+      expect(result).to.exist
+      expect(result!.id).to.equal(winner.id)
+      expect(await Models.SelectorPermission.countDocuments({ id: winner.id })).to.equal(1)
+    })
+
+    it('rethrows anything that is not a duplicate', async () => {
+      sandbox.stub(Models.SelectorPermission, 'create').rejects(new Error('mongo is down'))
+
+      const error = await ExecuteHandler._createSelectorPermission({}, selectorParams()).catch((e: any) => e)
+
+      expect(error).to.be.an('error')
+      expect(error.message).to.equal('mongo is down')
+    })
+  })
 })

--- a/test/unit/handlers/executeHandler.spec.ts
+++ b/test/unit/handlers/executeHandler.spec.ts
@@ -770,11 +770,14 @@ describe('ExecuteHandler', () => {
       })
 
       // What the unique index on the entity id throws at the worker that comes second.
-      const duplicateKey: any = new Error('E11000 duplicate key error collection')
+      const duplicateKey: any = new Error(
+        `E11000 duplicate key error collection: ${Models.SelectorPermission.db.name}.${Models.SelectorPermission.collection.collectionName} index: id_1`,
+      )
       duplicateKey.code = 11000
+      duplicateKey.keyValue = { id: winner.id }
       sandbox.stub(Models.SelectorPermission, 'create').rejects(duplicateKey)
 
-      const result = await ExecuteHandler._createSelectorPermission({ ...params }, params)
+      const result = await ExecuteHandler._createSelectorPermission({ ...params })
 
       expect(result).to.exist
       expect(result!.id).to.equal(winner.id)
@@ -784,7 +787,7 @@ describe('ExecuteHandler', () => {
     it('rethrows anything that is not a duplicate', async () => {
       sandbox.stub(Models.SelectorPermission, 'create').rejects(new Error('mongo is down'))
 
-      const error = await ExecuteHandler._createSelectorPermission({}, selectorParams()).catch((e: any) => e)
+      const error = await ExecuteHandler._createSelectorPermission({}).catch((e: any) => e)
 
       expect(error).to.be.an('error')
       expect(error.message).to.equal('mongo is down')

--- a/test/unit/migrations/20260819141224-dedupeSelectorPermissions.spec.ts
+++ b/test/unit/migrations/20260819141224-dedupeSelectorPermissions.spec.ts
@@ -1,0 +1,119 @@
+import { Models } from '@dbModels'
+import dedupeSelectorPermissionsMigration from '@src/migrations/20260819141224-dedupeSelectorPermissions'
+import { NetworksEnum } from '@types'
+import { expect } from 'chai'
+
+const DAO_ADDRESS = '0x32d627b081e0f4fF28474820f20128049DA55360'
+const PLUGIN_ADDRESS = '0xC3611e534d37eC6cAE251CECc06b25CCfA088e7c'
+const CONDITION_ADDRESS = '0xDC6f14D31A1f01784F0954eb90b675a4332D80A6'
+const TARGET_ADDRESS = '0x0c4ad337B1b4aD6D7130185fb9ebDD6c58a0f95F'
+const TRANSACTION_HASH = '0xb07380e446629624458fb3a6a9ae781352b0f2b764056b1e7d7839bef5a4f89e'
+
+const selectorPermission = (overrides: Record<string, any> = {}) => {
+  const logIndex = overrides.logIndex ?? 397
+  return {
+    id: `${NetworksEnum.baseMainnet}-${TRANSACTION_HASH}-49-${logIndex}-${CONDITION_ADDRESS}`,
+    transactionHash: TRANSACTION_HASH,
+    transactionIndex: 49,
+    logIndex,
+    blockNumber: 34567890,
+    blockTimestamp: 1755000000,
+    network: NetworksEnum.baseMainnet,
+    chainId: 8453,
+    pluginAddress: PLUGIN_ADDRESS,
+    daoAddress: DAO_ADDRESS,
+    conditionAddress: CONDITION_ADDRESS,
+    selector: '0x3628731c',
+    target: TARGET_ADDRESS,
+    isAllowed: true,
+    ...overrides,
+  }
+}
+
+// Raw driver: the whole point is to seed rows that the unique index would now reject.
+const seed = async (rows: Record<string, any>[]) => {
+  await Models.SelectorPermission.collection.insertMany(rows as any)
+}
+
+describe('migration: dedupe selector permissions', () => {
+  beforeEach(async () => {
+    await Models.SelectorPermission.collection.dropIndexes().catch(() => undefined)
+  })
+
+  it('keeps one row per log when two workers wrote the same one', async () => {
+    await seed([selectorPermission(), selectorPermission()])
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const rows = await Models.SelectorPermission.find({ daoAddress: DAO_ADDRESS })
+    expect(rows).to.have.lengthOf(1)
+    expect(rows[0].selector).to.equal('0x3628731c')
+  })
+
+  it('keeps the revoked copy, so a disallowed selector does not come back as allowed', async () => {
+    await seed([
+      selectorPermission(),
+      selectorPermission({
+        isAllowed: false,
+        disallowed: {
+          status: true,
+          transactionHash: TRANSACTION_HASH,
+          blockNumber: 34567999,
+          blockTimestamp: 1755009999,
+        },
+      }),
+    ])
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const rows = await Models.SelectorPermission.find({ daoAddress: DAO_ADDRESS })
+    expect(rows).to.have.lengthOf(1)
+    expect(rows[0].isAllowed).to.equal(false)
+    expect(rows[0].disallowed.status).to.equal(true)
+  })
+
+  it('leaves the other logs alone', async () => {
+    await seed([
+      selectorPermission(),
+      selectorPermission(),
+      selectorPermission({ logIndex: 398, selector: '0xa84eb999' }),
+      selectorPermission({ logIndex: 399, selector: '0x303f4336' }),
+    ])
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const rows = await Models.SelectorPermission.find({ daoAddress: DAO_ADDRESS })
+    expect(rows).to.have.lengthOf(3)
+    expect(rows.map(row => row.selector).sort()).to.deep.equal(['0x303f4336', '0x3628731c', '0xa84eb999'])
+  })
+
+  it('builds the unique index that stops the race from writing twice again', async () => {
+    await seed([selectorPermission(), selectorPermission()])
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const indexes = await Models.SelectorPermission.collection.indexes()
+    const idIndex = indexes.find((index: any) => index.key?.id === 1) as any
+
+    expect(idIndex, 'no index on id').to.exist
+    expect(idIndex.unique).to.equal(true)
+
+    const secondWrite = await seed([selectorPermission()]).catch((error: any) => error)
+    expect(secondWrite?.code).to.equal(11000)
+  })
+
+  it('completes cleanly when there is nothing to migrate', async () => {
+    await seed([selectorPermission()])
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const rows = await Models.SelectorPermission.find({})
+    expect(rows).to.have.lengthOf(1)
+  })
+
+  describe('stop', () => {
+    it('does nothing', async () => {
+      await dedupeSelectorPermissionsMigration.stop()
+    })
+  })
+})

--- a/test/unit/migrations/20260819141224-dedupeSelectorPermissions.spec.ts
+++ b/test/unit/migrations/20260819141224-dedupeSelectorPermissions.spec.ts
@@ -2,6 +2,7 @@ import { Models } from '@dbModels'
 import dedupeSelectorPermissionsMigration from '@src/migrations/20260819141224-dedupeSelectorPermissions'
 import { NetworksEnum } from '@types'
 import { expect } from 'chai'
+import sinon, { type SinonSandbox } from 'sinon'
 
 const DAO_ADDRESS = '0x32d627b081e0f4fF28474820f20128049DA55360'
 const PLUGIN_ADDRESS = '0xC3611e534d37eC6cAE251CECc06b25CCfA088e7c'
@@ -36,8 +37,15 @@ const seed = async (rows: Record<string, any>[]) => {
 }
 
 describe('migration: dedupe selector permissions', () => {
+  let sandbox: SinonSandbox
+
   beforeEach(async () => {
+    sandbox = sinon.createSandbox()
     await Models.SelectorPermission.collection.dropIndexes().catch(() => undefined)
+  })
+
+  afterEach(() => {
+    sandbox?.restore()
   })
 
   it('keeps one row per log when two workers wrote the same one', async () => {
@@ -100,6 +108,45 @@ describe('migration: dedupe selector permissions', () => {
 
     const secondWrite = await seed([selectorPermission()]).catch((error: any) => error)
     expect(secondWrite?.code).to.equal(11000)
+  })
+
+  it('cleans up again when an old pod writes a duplicate while the index is building', async () => {
+    await seed([selectorPermission(), selectorPermission()])
+
+    const syncIndexes = sandbox.stub(Models.SelectorPermission, 'syncIndexes')
+    // First build fails the way it would if a pod on the old code wrote a row mid build.
+    syncIndexes.onFirstCall().callsFake(async () => {
+      await seed([selectorPermission()])
+      const duplicateKey: any = new Error('E11000 duplicate key error collection')
+      duplicateKey.code = 11000
+      throw duplicateKey
+    })
+    syncIndexes.onSecondCall().callsFake(async () => {
+      syncIndexes.restore()
+      return await Models.SelectorPermission.syncIndexes()
+    })
+
+    await dedupeSelectorPermissionsMigration.start()
+
+    const rows = await Models.SelectorPermission.find({ daoAddress: DAO_ADDRESS })
+    expect(rows).to.have.lengthOf(1)
+
+    const indexes = await Models.SelectorPermission.collection.indexes()
+    const idIndex = indexes.find((index: any) => index.key?.id === 1) as any
+    expect(idIndex?.unique, 'unique index was never built').to.equal(true)
+  })
+
+  it('gives up when the duplicates keep coming back, so the deploy has to stop the old pods', async () => {
+    await seed([selectorPermission(), selectorPermission()])
+
+    const duplicateKey: any = new Error('E11000 duplicate key error collection')
+    duplicateKey.code = 11000
+    sandbox.stub(Models.SelectorPermission, 'syncIndexes').rejects(duplicateKey)
+
+    const error = await dedupeSelectorPermissionsMigration.start().catch((e: any) => e)
+
+    expect(error).to.be.an('error')
+    expect(error.code).to.equal(11000)
   })
 
   it('completes cleanly when there is nothing to migrate', async () => {


### PR DESCRIPTION
_5 changes since v0.36.0_

**Fixes**
- fix(execute-handler): improve error handling and simplify selector permission creation
- fix(release): update release and hotfix branch handling in workflows
- fix(selector-permission): enhance deduplication migration to handle duplicate writes
- fix(selector-permission): keep one row per allowed selector log

**Other Changes**
- test(selector-permission): cover the duplicate write race


<!-- slack_ts: 1787145482.682019 -->
